### PR TITLE
6223: terraform: support datacenter extension gateway destroy

### DIFF
--- a/aviatrix/resource_dc_extn.go
+++ b/aviatrix/resource_dc_extn.go
@@ -85,9 +85,38 @@ func resourceDCExtnRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceDCExtnUpdate(d *schema.ResourceData, meta interface{}) error {
-	return resourceAviatrixGatewayUpdate(d, meta)
+	client := meta.(*goaviatrix.Client)
+	dc_extn := &goaviatrix.DCExtn{}
+	log.Printf("[INFO] Update available public subnet CIDR: %#v", dc_extn)
+	err := client.UpdateDCExtn(dc_extn)
+	if err != nil {
+		return fmt.Errorf("No available public CIDR or fully exhausted: %s", err)
+	}
+
+	return nil
+	//return resourceAviatrixGatewayUpdate(d, meta)
 }
 
 func resourceDCExtnDelete(d *schema.ResourceData, meta interface{}) error {
-	return resourceAviatrixGatewayDelete(d, meta)
+	client := meta.(*goaviatrix.Client)
+	dc_extn := &goaviatrix.DCExtn{
+		CloudType: d.Get("cloud_type").(int),
+		GwName:    d.Get("gw_name").(string),
+	}
+	//If HA is enabled, delete HA GW first.
+	//if ha_subnet := d.Get("ha_subnet").(string); ha_subnet != "" {
+	//Delete HA Gw first
+	//        log.Printf("[INFO] Deleting Aviatrix HA gateway: %#v", gateway)
+	//        err := client.DisableHaGateway(gateway)
+	//        if err != nil {
+	//                return fmt.Errorf("Failed to delete Aviatrix HA gateway: %s", err)
+	//        }
+	//}
+	log.Printf("[INFO] Deleting Aviatrix datacenter extension gateway: %#v", dc_extn)
+	err := client.DeleteDCExtn(dc_extn)
+	if err != nil {
+		return fmt.Errorf("Failed to delete Aviatrix Gateway: %s", err)
+	}
+	d.SetId(dc_extn.GwName)
+	return nil
 }

--- a/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/dc_extn.go
+++ b/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/dc_extn.go
@@ -3,11 +3,12 @@ package goaviatrix
 import (
 	"encoding/json"
 	"errors"
+        "fmt"
 	//"log"
 	//"github.com/davecgh/go-spew/spew"
 )
 
-// DCExtn simple struct to hold transitive peering details
+// DCExtn simple struct
 
 type DCExtn struct {
 	CID           	string `form:"CID,omitempty"`
@@ -71,17 +72,13 @@ func (c *Client) GetDCExtn(dc_extn *DCExtn) (*DCExtn, error) {
 }
 
 func (c *Client) UpdateDCExtn(dc_extn *DCExtn) (error) {
-	return nil
-}
-
-func (c *Client) DeleteDCExtn(dc_extn *DCExtn) (error) {
 	dc_extn.CID=c.CID
-	dc_extn.Action="delete_extended_vpc_peer"
+	dc_extn.Action="list_cidr_of_available_vpcs"
 	resp,err := c.Post(c.baseURL, dc_extn)
 		if err != nil {
 		return err
 	}
-	var data APIResp
+	var data DCExtnListResp
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return err
 	}
@@ -89,4 +86,21 @@ func (c *Client) DeleteDCExtn(dc_extn *DCExtn) (error) {
 		return errors.New(data.Reason)
 	}
 	return nil
+}
+
+func (c *Client) DeleteDCExtn(dc_extn *DCExtn) (error) {
+        path := c.baseURL + fmt.Sprintf("?action=delete_container&CID=%s&cloud_type=%d&gw_name=%s", c.CID, dc_extn.CloudType, dc_extn.GwName)
+        resp,err := c.Get(path, nil)
+
+        if err != nil {
+               return err
+        }
+        var data APIResp
+        if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+               return err
+        }
+        if(!data.Return){
+               return errors.New(data.Reason)
+        }
+        return nil
 }


### PR DESCRIPTION
Added support to delete datacenter extension gateways from terraform resource "aviatrix_dc_extn".