### PR TITLE
M6567 FQDN extended domain filter [fqdn, protocol, port]

### DIFF
--- a/aviatrix/resource_fqdn.go
+++ b/aviatrix/resource_fqdn.go
@@ -123,6 +123,7 @@ func resourceAviatrixFQDNRead(d *schema.ResourceData, meta interface{}) error {
 		FQDNMode:   d.Get("fqdn_mode").(string),
 	}
 
+	log.Printf("[INFO] Reading Aviatrix FQDN: %#v", fqdn)
 	newfqdn, err := client.GetFQDNTag(fqdn)
 	if err != nil {
 		if err == goaviatrix.ErrNotFound {
@@ -250,7 +251,9 @@ func resourceAviatrixFQDNDelete(d *schema.ResourceData, meta interface{}) error 
 	fqdn := &goaviatrix.FQDN{
 		FQDNTag: d.Get("fqdn_tag").(string),
 	}
+	log.Printf("[INFO] Deleting Aviatrix FQDN: %#v", fqdn)
 	if _, ok := d.GetOk("gw_list"); ok {
+		log.Printf("[INFO] Found GWs: %#v", fqdn)
 		fqdn.GwList = goaviatrix.ExpandStringList(d.Get("gw_list").([]interface{}))
 		err := client.DetachGws(fqdn)
 		if err != nil {

--- a/aviatrix/resource_fqdn.go
+++ b/aviatrix/resource_fqdn.go
@@ -97,7 +97,7 @@ func resourceAviatrixFQDNCreate(d *schema.ResourceData, meta interface{}) error 
 		d.Set("gw_list", fqdn.GwList)
 	}
 	if fqdn_status := d.Get("fqdn_status").(string); fqdn_status == "enabled" {
-		log.Printf("[TRACE] FQDNCreate Enable FQDN tag status: %#v", fqdn)
+		log.Printf("[INOF] Enable FQDN tag status: %#v", fqdn)
 		err := client.UpdateFQDNStatus(fqdn)
 		if err != nil {
 			return fmt.Errorf("Failed to update FQDN status : %s", err)
@@ -105,7 +105,7 @@ func resourceAviatrixFQDNCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	// update fqdn_mode when set to non-default "blacklist" mode
 	if fqdn_mode := d.Get("fqdn_mode").(string); fqdn_mode == "black" {
-		log.Printf("[INFO] FQDNCreate Enable FQDN Mode: %#v", fqdn)
+		log.Printf("[INFO] Enable FQDN Mode: %#v", fqdn)
 		err := client.UpdateFQDNMode(fqdn)
 		if err != nil {
 			return fmt.Errorf("Failed to update FQDN mode : %s", err)
@@ -144,7 +144,7 @@ func resourceAviatrixFQDNRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Couldn't list FQDN domains: %s", err)
 	}
 	if newfqdn != nil {
-		// This is nothing of ListDomains return empty
+		// This is nothing IF ListDomains return empty
 		var filter []map[string]interface{}
 		for _, fqdnDomain := range newfqdn.DomainList {
 			dn := make(map[string]interface{})
@@ -250,10 +250,6 @@ func resourceAviatrixFQDNDelete(d *schema.ResourceData, meta interface{}) error 
 	fqdn := &goaviatrix.FQDN{
 		FQDNTag: d.Get("fqdn_tag").(string),
 	}
-	for i := range fqdn.GwList {
-		log.Printf("EDSEL ............................................ gw_name=%s", fqdn.GwList[i])
-	}
-
 	if _, ok := d.GetOk("gw_list"); ok {
 		fqdn.GwList = goaviatrix.ExpandStringList(d.Get("gw_list").([]interface{}))
 		err := client.DetachGws(fqdn)

--- a/aviatrix/resource_fqdn.go
+++ b/aviatrix/resource_fqdn.go
@@ -5,6 +5,7 @@ import (
 	"github.com/AviatrixSystems/go-aviatrix/goaviatrix"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
+	//"strings"
 )
 
 func resourceAviatrixFQDN() *schema.Resource {
@@ -32,10 +33,25 @@ func resourceAviatrixFQDN() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
-			"domain_list": &schema.Schema{
+			"domain_names": &schema.Schema{
 				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fqdn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"proto": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"port": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -53,22 +69,35 @@ func resourceAviatrixFQDNCreate(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return fmt.Errorf("Failed to create Aviatrix FQDN: %s", err)
 	}
-	if _, ok := d.GetOk("domain_list"); ok {
-		fqdn.DomainList = goaviatrix.ExpandStringList(d.Get("domain_list").([]interface{}))
+	if _, ok := d.GetOk("domain_names"); ok {
+		names := d.Get("domain_names").([]interface{})
+		for _, domain := range names {
+			dn := domain.(map[string]interface{})
+			fqdnFilter := &goaviatrix.Filters{
+				FQDN:     dn["fqdn"].(string),
+				Protocol: dn["proto"].(string),
+				Port:     dn["port"].(string),
+			}
+			fqdn.DomainList = append(fqdn.DomainList, fqdnFilter)
+		}
 		err = client.UpdateDomains(fqdn)
 		if err != nil {
 			return fmt.Errorf("Failed to add domain : %s", err)
 		}
+		d.Set("domain_names", fqdn.DomainList)
 	}
 	if _, ok := d.GetOk("gw_list"); ok {
-		fqdn.GwList = goaviatrix.ExpandStringList(d.Get("gw_list").([]interface{}))
+		tag_list := d.Get("gw_list").([]interface{})
+		tag_list_str := goaviatrix.ExpandStringList(tag_list)
+		fqdn.GwList = tag_list_str
 		err = client.AttachGws(fqdn)
 		if err != nil {
 			return fmt.Errorf("Failed to attach GWs: %s", err)
 		}
+		d.Set("gw_list", fqdn.GwList)
 	}
 	if fqdn_status := d.Get("fqdn_status").(string); fqdn_status == "enabled" {
-		log.Printf("[INFO] Enable FQDN tag status: %#v", fqdn)
+		log.Printf("[TRACE] FQDNCreate Enable FQDN tag status: %#v", fqdn)
 		err := client.UpdateFQDNStatus(fqdn)
 		if err != nil {
 			return fmt.Errorf("Failed to update FQDN status : %s", err)
@@ -76,7 +105,7 @@ func resourceAviatrixFQDNCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	// update fqdn_mode when set to non-default "blacklist" mode
 	if fqdn_mode := d.Get("fqdn_mode").(string); fqdn_mode == "black" {
-		log.Printf("[INFO] Enable FQDN Mode: %#v", fqdn)
+		log.Printf("[INFO] FQDNCreate Enable FQDN Mode: %#v", fqdn)
 		err := client.UpdateFQDNMode(fqdn)
 		if err != nil {
 			return fmt.Errorf("Failed to update FQDN mode : %s", err)
@@ -93,7 +122,7 @@ func resourceAviatrixFQDNRead(d *schema.ResourceData, meta interface{}) error {
 		FQDNStatus: d.Get("fqdn_status").(string),
 		FQDNMode:   d.Get("fqdn_mode").(string),
 	}
-	log.Printf("[INFO] Reading Aviatrix FQDN: %#v", fqdn)
+
 	newfqdn, err := client.GetFQDNTag(fqdn)
 	if err != nil {
 		if err == goaviatrix.ErrNotFound {
@@ -110,14 +139,25 @@ func resourceAviatrixFQDNRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("fqdn_mode", newfqdn.FQDNMode)
 		}
 	}
-
 	newfqdn, err = client.ListDomains(fqdn)
 	if err != nil {
 		return fmt.Errorf("Couldn't list FQDN domains: %s", err)
 	}
 	if newfqdn != nil {
-		d.Set("domain_list", newfqdn.DomainList)
+		// This is nothing of ListDomains return empty
+		var filter []map[string]interface{}
+		for _, fqdnDomain := range newfqdn.DomainList {
+			dn := make(map[string]interface{})
+			dn["fqdn"] = fqdnDomain.FQDN
+			dn["proto"] = fqdnDomain.Protocol
+			dn["port"] = fqdnDomain.Port
+			filter = append(filter, dn)
+		}
+		d.Set("domain_names", filter)
 	}
+	tag_list := d.Get("gw_list").([]interface{})
+	tag_list_str := goaviatrix.ExpandStringList(tag_list)
+	fqdn.GwList = tag_list_str
 	newfqdn, err = client.ListGws(fqdn)
 	if err != nil {
 		return fmt.Errorf("Couldn't list attached gateways: %s", err)
@@ -151,15 +191,24 @@ func resourceAviatrixFQDNUpdate(d *schema.ResourceData, meta interface{}) error 
 		d.SetPartial("fqdn_mode")
 	}
 	//Update Domain list
-	if d.HasChange("domain_list") {
-		if _, ok := d.GetOk("domain_list"); ok {
-			fqdn.DomainList = goaviatrix.ExpandStringList(d.Get("domain_list").([]interface{}))
+	if d.HasChange("domain_names") {
+		if _, ok := d.GetOk("domain_names"); ok {
+			names := d.Get("domain_names").([]interface{})
+			for _, domain := range names {
+				dn := domain.(map[string]interface{})
+				fqdnDomain := &goaviatrix.Filters{
+					FQDN:     dn["fqdn"].(string),
+					Protocol: dn["proto"].(string),
+					Port:     dn["port"].(string),
+				}
+				fqdn.DomainList = append(fqdn.DomainList, fqdnDomain)
+			}
 		}
 		err := client.UpdateDomains(fqdn)
 		if err != nil {
 			return fmt.Errorf("Failed to add domain : %s", err)
 		}
-		d.SetPartial("domain_list")
+		d.SetPartial("domain_names")
 	}
 	//Update attached GW list
 	if d.HasChange("gw_list") {
@@ -201,9 +250,11 @@ func resourceAviatrixFQDNDelete(d *schema.ResourceData, meta interface{}) error 
 	fqdn := &goaviatrix.FQDN{
 		FQDNTag: d.Get("fqdn_tag").(string),
 	}
-	log.Printf("[INFO] Deleting Aviatrix FQDN: %#v", fqdn)
+	for i := range fqdn.GwList {
+		log.Printf("EDSEL ............................................ gw_name=%s", fqdn.GwList[i])
+	}
+
 	if _, ok := d.GetOk("gw_list"); ok {
-		log.Printf("[INFO] Found GWs: %#v", fqdn)
 		fqdn.GwList = goaviatrix.ExpandStringList(d.Get("gw_list").([]interface{}))
 		err := client.DetachGws(fqdn)
 		if err != nil {
@@ -214,6 +265,5 @@ func resourceAviatrixFQDNDelete(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return fmt.Errorf("Failed to delete Aviatrix FQDN: %s", err)
 	}
-
 	return nil
 }

--- a/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/fqdn.go
+++ b/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/fqdn.go
@@ -26,29 +26,11 @@ type FQDN struct {
 	DomainList              []*Filters `form:"domain_names[],omitempty" json:"domain_names,omitempty"`
 }
 
-
-//type DomainResp struct {
-//	Return  bool   `json:"return"`
-//	Results []*Filters `json:"results"`
-//	Reason  string `json:"reason"`
-//}
 type ResultListResp struct {
 	Return  bool   `json:"return"`
 	Results []string `json:"results"`
 	Reason  string `json:"reason"`
 }
-//type Data struct {
-//	Return  bool   `json:"return"`
-//	Results []Template `json:"data"`
-//	Reason  string `json:"reason"`
-//}
-
-//type Template struct {
-//	FQDN     string   `json:"fqdn"`
-//	Protocol string   `json:"proto"`
-//	Port    string   `json:"port"`
-//
-//}
 
 func (c *Client) CreateFQDN(fqdn *FQDN) (error) {
 	path := c.baseURL + fmt.Sprintf("?CID=%s&action=add_fqdn_filter_tag&tag_name=%s", c.CID, fqdn.FQDNTag)

--- a/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/fqdn.go
+++ b/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/fqdn.go
@@ -5,7 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
+        "net/http"
 )
+
+type Filters struct {
+        FQDN        string `form:"fqdn,omitempty" json:"fqdn,omitempty"`
+        Protocol    string `form:"proto,omitempty" json:"proto,omitempty"`
+        Port        string `form:"port,omitempty" json:"port,omitempty"`
+}
 
 // Gateway simple struct to hold fqdn details
 type FQDN struct {
@@ -14,14 +22,32 @@ type FQDN struct {
 	CID                     string `form:"CID,omitempty"`
 	FQDNStatus              string `form:"status,omitempty" json:"status,omitempty"`
 	FQDNMode                string `form:"color,omitempty" json:"color,omitempty"`
-	GwList                  []string `form:"gw_name,omitempty" json:"members,omitempty"`
-	DomainList              []string `form:"domain_names[],omitempty"`
+	GwList                  []string `form:"gw_name,omitempty" json:"gw_name,omitempty"`
+	DomainList              []*Filters `form:"domain_names[],omitempty" json:"domain_names,omitempty"`
 }
 
+
+type DomainResp struct {
+	Return  bool   `json:"return"`
+	Results []*Filters `json:"results"`
+	Reason  string `json:"reason"`
+}
 type ResultListResp struct {
 	Return  bool   `json:"return"`
 	Results []string `json:"results"`
 	Reason  string `json:"reason"`
+}
+type Data struct {
+	Return  bool   `json:"return"`
+	Results []Template `json:"data"`
+	Reason  string `json:"reason"`
+}
+
+type Template struct {
+	FQDN     string   `json:"fqdn"`
+	Protocol string   `json:"proto"`
+	Port    string   `json:"port"`
+
 }
 
 func (c *Client) CreateFQDN(fqdn *FQDN) (error) {
@@ -93,21 +119,36 @@ func (c *Client) UpdateFQDNMode(fqdn *FQDN) (error) {
 func (c *Client) UpdateDomains(fqdn *FQDN) (error) {
 	fqdn.CID=c.CID
 	fqdn.Action="set_fqdn_filter_tag_domain_names"
-	resp,err := c.Post(c.baseURL, fqdn)
-		if err != nil {
-		return err
-	}
-	var data APIResp
-	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return err
-	}
-	if(!data.Return){
-		return errors.New(data.Reason)
-	}
-	return nil
+        log.Printf("[INFO] Update domains: %#v", fqdn)
+
+        verb := "POST"
+        body := fmt.Sprintf("CID=%s&action=%s&tag_name=%s", c.CID, fqdn.Action, fqdn.FQDNTag)
+        for i, dn := range fqdn.DomainList {
+                body = body + fmt.Sprintf("&domain_names[%d][fqdn]=%s&domain_names[%d][proto]=%s&domain_names[%d][port]=%s", i,dn.FQDN, i,dn.Protocol, i,dn.Port)
+        }
+        log.Printf("[TRACE] %s %s Body: %s", verb, c.baseURL, body)
+        req, err := http.NewRequest(verb, c.baseURL, strings.NewReader(body))
+        if err == nil {
+                req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+        } else {
+                return err
+        }
+        resp, err := c.HTTPClient.Do(req)
+        if err != nil {
+                return err
+        }
+        var data APIResp
+        if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+                return err
+        }
+        if(!data.Return){
+                return errors.New(data.Reason)
+        }
+        return nil
 }
 
 func (c *Client) AttachGws(fqdn *FQDN) (error) {
+        log.Printf("[TRACE] inside AttachGWs ------------------------------------------------%#v",fqdn)
 	path := c.baseURL + fmt.Sprintf("?CID=%s&action=attach_fqdn_filter_tag_to_gw&tag_name=%s", c.CID, fqdn.FQDNTag)
 	for i := range fqdn.GwList {
 		newPath := path + fmt.Sprintf("&gw_name=%s", fqdn.GwList[i])
@@ -177,24 +218,42 @@ func (c *Client) GetFQDNTag(fqdn *FQDN) (*FQDN, error) {
 }
 
 func (c *Client) ListDomains(fqdn *FQDN) (*FQDN, error) {
+	fqdn.CID=c.CID
+	fqdn.Action="list_fqdn_filter_tag_domain_names"
 	path := c.baseURL + fmt.Sprintf("?CID=%s&action=list_fqdn_filter_tag_domain_names&tag_name=%s", c.CID, fqdn.FQDNTag)
 	resp,err := c.Get(path, nil)
 		if err != nil {
 		return nil, err
 	}
-	var data ResultListResp
+	var data map[string]interface{}
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return nil, err
 	}
-	if(!data.Return){
-		return nil, errors.New(data.Reason)
+        dn := data
+	names := dn["results"].([]interface{})
+        for _, domain := range names {
+	    dn := domain.(map[string]interface{})
+	    //log.Printf("[TRACE] domain ------------------------->>>>>>>>>>>>: %#v", dn["fqdn"])
+	    //log.Printf("[TRACE] domain ------------------------->>>>>>>>>>>>: %#v", dn["protocol"])
+	    //log.Printf("[TRACE] domain ------------------------->>>>>>>>>>>>: %#v", dn["port"])
+	    fqdnFilter := Filters{
+                                FQDN:     dn["fqdn"].(string),
+                                Protocol: dn["proto"].(string),
+                                Port:     dn["port"].(string),
+            }
+	    log.Printf("[TRACE] DOMAIN key FOUND ------------------------>>>>>>>>>>>>: %#v",fqdnFilter)
+	    //fqdn.DomainList = append(fqdn.DomainList, fqdnFilter)
 	}
-	//domainList:= data.Results
-	fqdn.DomainList = data.Results
-
+	//value, ok := dn["results"].([]interface{})
+	//if ok {
+	//    log.Printf("[TRACE] ListDomains FOUND ------------------------------->>>>>>>>>>>>: %#v", value)
+	//} else {
+	//    log.Printf("[TRACE] ListDomains NOT_FOUND --------------------------->>>>>>>>>>>>: %#v", value)
+	//}
+	// error when passing value or when passing fqdnFilter
+	// TODO please return successfully the correct value of domain list
 	return fqdn, nil
 }
-
 func (c *Client) ListGws(fqdn *FQDN) (*FQDN, error) {
 	path := c.baseURL + fmt.Sprintf("?CID=%s&action=list_fqdn_filter_tag_attached_gws&tag_name=%s", c.CID, fqdn.FQDNTag)
 	resp,err := c.Get(path, nil)
@@ -206,6 +265,7 @@ func (c *Client) ListGws(fqdn *FQDN) (*FQDN, error) {
 		return nil, err
 	}
 	if(!data.Return){
+                log.Printf("[INFO] Couldn't find Aviatrix FQDN tag names: %s", fqdn.FQDNTag, data.Reason)
 		return nil, errors.New(data.Reason)
 	}
 	fqdn.GwList = data.Results

--- a/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/fqdn.go
+++ b/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/fqdn.go
@@ -27,28 +27,28 @@ type FQDN struct {
 }
 
 
-type DomainResp struct {
-	Return  bool   `json:"return"`
-	Results []*Filters `json:"results"`
-	Reason  string `json:"reason"`
-}
+//type DomainResp struct {
+//	Return  bool   `json:"return"`
+//	Results []*Filters `json:"results"`
+//	Reason  string `json:"reason"`
+//}
 type ResultListResp struct {
 	Return  bool   `json:"return"`
 	Results []string `json:"results"`
 	Reason  string `json:"reason"`
 }
-type Data struct {
-	Return  bool   `json:"return"`
-	Results []Template `json:"data"`
-	Reason  string `json:"reason"`
-}
+//type Data struct {
+//	Return  bool   `json:"return"`
+//	Results []Template `json:"data"`
+//	Reason  string `json:"reason"`
+//}
 
-type Template struct {
-	FQDN     string   `json:"fqdn"`
-	Protocol string   `json:"proto"`
-	Port    string   `json:"port"`
-
-}
+//type Template struct {
+//	FQDN     string   `json:"fqdn"`
+//	Protocol string   `json:"proto"`
+//	Port    string   `json:"port"`
+//
+//}
 
 func (c *Client) CreateFQDN(fqdn *FQDN) (error) {
 	path := c.baseURL + fmt.Sprintf("?CID=%s&action=add_fqdn_filter_tag&tag_name=%s", c.CID, fqdn.FQDNTag)


### PR DESCRIPTION
Starting release 3.4, FQDN domain filter is now based on the combination of FQDN, Protocol, and Port.
Sample:
resource "aviatrix_fqdn" "TAG1" {
                fqdn_tag = "sample_FQDN_tag"
           fqdn_status = "enabled"
            fqdn_mode = "white"
                   gw_list = ["fqdn-gw1","fqdn-gw2"]
     domain_names = [ 
                                     { 
                                        fqdn = "aviatrix.com"
                                        proto= "tcp"
                                        port = "443"
                                     },
                                     {
                                        fqdn = "google.com"
                                        proto= "udp"
                                        port = "480"
                                     }
                                  ]
}