### PR TITLE
Fix parameter typo in website documentation

### DIFF
--- a/website/docs/r/aviatrix_account.html.markdown
+++ b/website/docs/r/aviatrix_account.html.markdown
@@ -21,7 +21,7 @@ resource "aviatrix_account" "tempacc" {
   cloud_type = 1
   aws_account_number = "123456789012"
   aws_iam = "true"
-  aws_role_arn = "arn:aws:iam::123456789012:role/aviatrix-role-app"
+  aws_role_app = "arn:aws:iam::123456789012:role/aviatrix-role-app"
   aws_role_ec2 = "arn:aws:iam::123456789012:role/aviatrix-role-ec2"
 }
 
@@ -49,5 +49,5 @@ The following arguments are supported:
 * `aws_iam` - (Optional) AWS IAM-role based flag, this option is for UserConnect.
 * `aws_access_key` - (Optional) AWS Access Key (Required when aws_iam is "false" and when creating an account for AWS)
 * `aws_secret_key` - (Optional) AWS Secret Key (Required when aws_iam is "false" and when creating an account for AWS)
-* `aws_role_arn` - (Optional) AWS role ARN, this option is for UserConnect (Required when aws_iam is "true" and when creating an account for AWS).
-* `aws_role_ec2` - (Optional) AWS role EC2, this option is for UserConnect (Required when aws_iam is "true" and when creating an account for AWS).
+* `aws_role_app` - (Optional) AWS App role ARN, this option is for UserConnect (Required when aws_iam is "true" and when creating an account for AWS).
+* `aws_role_ec2` - (Optional) AWS EC2 role ARN, this option is for UserConnect (Required when aws_iam is "true" and when creating an account for AWS).


### PR DESCRIPTION
This can be considered two different things.

1. A typo in the documentation that doesn't match the actual Provider expected parameter: https://github.com/AviatrixSystems/terraform-provider-aviatrix/blob/ba252174e4d4e573c134e4e7c6fee6a8ea5808ae/aviatrix/resource_account.go#L43
2. Or points to the actual provider parameter being inconsistent with its underlying Go API library (`aws_role_arn`): https://github.com/AviatrixSystems/go-aviatrix/blob/8973b3e188e61fae66691bc53671be96b5b987ee/goaviatrix/account.go#L21

Fixing 2 would likely be a breaking change for anyone using this Provider in its current form. I chose to go with the easy fix of just making the documentation consistent until this repo conforms to semver.