### PR TITLE
Add options to enable EIP reusage

### DIFF
--- a/aviatrix/resource_gateway.go
+++ b/aviatrix/resource_gateway.go
@@ -164,6 +164,14 @@ func resourceAviatrixGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"allocate_new_eip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"eip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -203,6 +211,8 @@ func resourceAviatrixGatewayCreate(d *schema.ResourceData, meta interface{}) err
 		PeeringHASubnet:    d.Get("public_subnet").(string),
 		NewZone:            d.Get("zone").(string),
 		SingleAZ:           d.Get("single_az_ha").(string),
+		AllocateNewEip:     d.Get("allocate_new_eip").(string),
+		Eip:                d.Get("eip").(string),
 	}
 
 	log.Printf("[INFO] Creating Aviatrix gateway: %#v", gateway)

--- a/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/gateway.go
+++ b/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/gateway.go
@@ -13,6 +13,7 @@ type Gateway struct {
 	Action                  string `form:"action,omitempty"`
 	AdditionalCidrs         string `form:"additional_cidrs,omitempty"`
 	AuthMethod              string `form:"auth_method,omitempty" json:"auth_method,omitempty"`
+	AllocateNewEip          string `form:"allocate_new_eip,omitempty" json:"allocate_new_eip,omitempty"`
 	BkupGatewayZone         string `form:"bkup_gateway_zone,omitempty" json:"bkup_gateway_zone,omitempty"`
 	BkupPrivateIP           string `form:"bkup_private_ip,omitempty" json:"bkup_private_ip,omitempty"`
 	CID                     string `form:"CID,omitempty"`
@@ -30,6 +31,7 @@ type Gateway struct {
 	DuoIntegrationKey       string `form:"duo_integration_key,omitempty"`
 	DuoPushMode             string `form:"duo_push_mode,omitempty"`
 	DuoSecretKey            string `form:"duo_secret_key,omitempty"`
+	Eip                     string `form:"eip,omitempty" json:"eip,omitempty"`
 	ElbDNSName              string `form:"elb_dns_name,omitempty" json:"elb_dns_name,omitempty"`
 	ElbName                 string `form:"elb_name,omitempty"`
 	ElbState                string `form:"elb_state,omitempty" json:"elb_state,omitempty"`


### PR DESCRIPTION
This PR will add the possibility to reuse preexisting EIP's allocated in your AWS Account.

Our use case for this is that we are switching from NAT instances to Aviatrix GW's. As the IP's are often used for whitelisting we need to reuse those IP's.