### PR TITLE
Add support for saml auth on vpn users

### DIFF
--- a/aviatrix/resource_vpn_user.go
+++ b/aviatrix/resource_vpn_user.go
@@ -2,9 +2,10 @@ package aviatrix
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/AviatrixSystems/go-aviatrix/goaviatrix"
 	"github.com/hashicorp/terraform/helper/schema"
-	"log"
 )
 
 func resourceAviatrixVPNUser() *schema.Resource {
@@ -31,6 +32,10 @@ func resourceAviatrixVPNUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"saml_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -38,10 +43,11 @@ func resourceAviatrixVPNUser() *schema.Resource {
 func resourceAviatrixVPNUserCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 	vpn_user := &goaviatrix.VPNUser{
-		VpcID:     d.Get("vpc_id").(string),
-		GwName:    d.Get("gw_name").(string),
-		UserName:  d.Get("user_name").(string),
-		UserEmail: d.Get("user_email").(string),
+		VpcID:        d.Get("vpc_id").(string),
+		GwName:       d.Get("gw_name").(string),
+		UserName:     d.Get("user_name").(string),
+		UserEmail:    d.Get("user_email").(string),
+		SamlEndpoint: d.Get("saml_endpoint").(string),
 	}
 
 	log.Printf("[INFO] Creating Aviatrix VPN User: %#v", vpn_user)

--- a/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/vpn_user.go
+++ b/vendor/github.com/AviatrixSystems/go-aviatrix/goaviatrix/vpn_user.go
@@ -1,41 +1,42 @@
 package goaviatrix
 
 import (
-	"fmt"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 )
 
 // VPNUser simple struct to hold vpn_user details
 type VPNUser struct {
-	Action                  string `form:"action,omitempty" json:"action,omitempty"`
-	CID                     string `form:"CID,omitempty" json:"CID,omitempty"`
-	VpcID                   string `form:"vpc_id,omitempty" json:"vpc_id,omitempty"`
-	GwName                  string `form:"lb_name,omitempty" json:"lb_name,omitempty"`
-	UserName                string `form:"username" json:"_id,omitempty"`
-	UserEmail               string `form:"user_email,omitempty" json:"email,omitempty"`
+	Action       string `form:"action,omitempty" json:"action,omitempty"`
+	CID          string `form:"CID,omitempty" json:"CID,omitempty"`
+	SamlEndpoint string `form:"saml_endpoint,omitempty" json:"saml_endpoint,omitempty"`
+	VpcID        string `form:"vpc_id,omitempty" json:"vpc_id,omitempty"`
+	GwName       string `form:"lb_name,omitempty" json:"lb_name,omitempty"`
+	UserName     string `form:"username" json:"_id,omitempty"`
+	UserEmail    string `form:"user_email,omitempty" json:"email,omitempty"`
 }
 
 type VPNUserListResp struct {
-	Return  bool   `json:"return"`
+	Return  bool      `json:"return"`
 	Results []VPNUser `json:"results"`
-	Reason  string `json:"reason"`
+	Reason  string    `json:"reason"`
 }
 
-func (c *Client) CreateVPNUser(vpn_user *VPNUser) (error) {
-	vpn_user.Action="add_vpn_user"
-	path := c.baseURL + fmt.Sprintf("?CID=%s&action=%s&vpc_id=%s&username=%s&user_email=%s&lb_name=%s", c.CID, vpn_user.Action, vpn_user.VpcID, vpn_user.UserName, vpn_user.UserEmail, vpn_user.GwName)
+func (c *Client) CreateVPNUser(vpn_user *VPNUser) error {
+	vpn_user.Action = "add_vpn_user"
+	path := c.baseURL + fmt.Sprintf("?CID=%s&action=%s&vpc_id=%s&username=%s&user_email=%s&lb_name=%s&saml_endpoint=%s", c.CID, vpn_user.Action, vpn_user.VpcID, vpn_user.UserName, vpn_user.UserEmail, vpn_user.GwName, vpn_user.SamlEndpoint)
 
-	resp,err := c.Get(path, nil)
-		if err != nil {
+	resp, err := c.Get(path, nil)
+	if err != nil {
 		return err
 	}
 	var data APIResp
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return err
 	}
-	if(!data.Return){
+	if !data.Return {
 		return errors.New(data.Reason)
 	}
 	return nil
@@ -44,7 +45,7 @@ func (c *Client) CreateVPNUser(vpn_user *VPNUser) (error) {
 func (c *Client) GetVPNUser(vpn_user *VPNUser) (*VPNUser, error) {
 	vpn_user.Action = "list_vpn_users"
 	path := c.baseURL + fmt.Sprintf("?CID=%s&action=%s", c.CID, vpn_user.Action)
-	resp,err := c.Get(path, nil)
+	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -52,10 +53,10 @@ func (c *Client) GetVPNUser(vpn_user *VPNUser) (*VPNUser, error) {
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return nil, err
 	}
-	if(!data.Return){
+	if !data.Return {
 		return nil, errors.New(data.Reason)
 	}
-	vulist:= data.Results
+	vulist := data.Results
 	for i := range vulist {
 		if vulist[i].UserName == vpn_user.UserName {
 			return &vulist[i], nil
@@ -65,11 +66,10 @@ func (c *Client) GetVPNUser(vpn_user *VPNUser) (*VPNUser, error) {
 	return nil, ErrNotFound
 }
 
-
-func (c *Client) DeleteVPNUser(vpn_user *VPNUser) (error) {
+func (c *Client) DeleteVPNUser(vpn_user *VPNUser) error {
 	vpn_user.Action = "delete_vpn_user"
 	path := c.baseURL + fmt.Sprintf("?CID=%s&action=%s&vpc_id=%s&username=%s", c.CID, vpn_user.Action, vpn_user.VpcID, vpn_user.UserName)
-	resp,err := c.Delete(path, nil)
+	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (c *Client) DeleteVPNUser(vpn_user *VPNUser) (error) {
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return err
 	}
-	if(!data.Return){
+	if !data.Return {
 		return errors.New(data.Reason)
 	}
 	return nil


### PR DESCRIPTION
Happy to answer any questions about this or sign a cla if required.

## What is this: 

This adds support for saml auth on vpn users by adding a saml_endpoint field to the vpn_user resource

## Why:

This is important for our ability to provision vpn environments for our users in a semi automated way

## Caveats:

This required changing the vendored `aviatrix-go` because the version on github is way behind the vendored version.

Fixes #70