### PR TITLE
Added import to gateway resource

### DIFF
--- a/aviatrix/resource_gateway.go
+++ b/aviatrix/resource_gateway.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/AviatrixSystems/go-aviatrix/goaviatrix"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -18,11 +17,6 @@ func resourceAviatrixGateway() *schema.Resource {
 		Delete: resourceAviatrixGatewayDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
-		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(15 * time.Minute),
-			Update: schema.DefaultTimeout(15 * time.Minute),
-			Delete: schema.DefaultTimeout(25 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Added an import function to the gateway resource. Besides generally useful, this is needed as long as gateway resources do not have a non default timeout enough to prevent Terraform for failing after 60 seconds of waiting for the instance to be created.
Tested on 3.5 but should work on 4.0 too.

Correction: The 60 second timeout was an issue due to accessing controller with DNS name instead of IP. The feature is anyway useful to terraformize existing infrastructure