### PR TITLE
Add EIP for peering ha gateways

### DIFF
--- a/aviatrix/resource_gateway.go
+++ b/aviatrix/resource_gateway.go
@@ -198,6 +198,7 @@ func resourceAviatrixGateway() *schema.Resource {
 			"peering_ha_eip": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"zone": {
 				Type:     schema.TypeString,
@@ -627,6 +628,9 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 	if d.HasChange("vpn_access") {
 		return fmt.Errorf("updating vpn_access is not allowed")
+	}
+	if d.HasChange("peering_ha_eip") {
+		return fmt.Errorf("updating peering_ha_eip is not allowed")
 	}
 	if d.HasChange("enable_elb") {
 		return fmt.Errorf("updating enable_elb is not allowed")

--- a/aviatrix/resource_gateway.go
+++ b/aviatrix/resource_gateway.go
@@ -195,6 +195,10 @@ func resourceAviatrixGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"peering_ha_eip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"zone": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -335,6 +339,7 @@ func resourceAviatrixGatewayCreate(d *schema.ResourceData, meta interface{}) err
 	// peering_ha_subnet is for Peering HA Gateway. https://docs.aviatrix.com/HowTos/gateway.html#high-availability
 	if peeringHaSubnet := d.Get("peering_ha_subnet").(string); peeringHaSubnet != "" {
 		peeringHaGateway := &goaviatrix.Gateway{
+			Eip:             d.Get("peering_ha_eip").(string),
 			GwName:          d.Get("gw_name").(string),
 			PeeringHASubnet: d.Get("peering_ha_subnet").(string),
 			NewZone:         d.Get("zone").(string),
@@ -546,16 +551,19 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 				d.Set("cloudn_bkup_gateway_inst_id", gwHaGw.CloudnGatewayInstID)
 				d.Set("backup_public_ip", gwHaGw.PublicIP)
 				d.Set("peering_ha_subnet", gwHaGw.VpcNet)
+				d.Set("peering_ha_eip", gwHaGw.Eip)
 			} else {
 				d.Set("cloudn_bkup_gateway_inst_id", "")
 				d.Set("backup_public_ip", "")
 				d.Set("peering_ha_subnet", "")
+				d.Set("peering_ha_eip", "")
 			}
 			log.Printf("[TRACE] reading peering HA gateway %s: %#v", d.Get("gw_name").(string), gwHaGw)
 		} else {
 			d.Set("cloudn_bkup_gateway_inst_id", "")
 			d.Set("backup_public_ip", "")
 			d.Set("peering_ha_subnet", "")
+			d.Set("peering_ha_eip", "")
 		}
 
 		tags := &goaviatrix.Tags{

--- a/website/docs/r/aviatrix_gateway.html.markdown
+++ b/website/docs/r/aviatrix_gateway.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `vpn_access` - (Optional) Enable user access through VPN to this container. (Supported values: "yes", "no")
 * `vpn_cidr` - (Optional) VPN CIDR block for the container (Required if vpn_access is "yes", Example: "192.168.43.0/24")
 * `enable_elb` - (Optional) Specify whether to enable ELB or not. (Required: Yes when cloud_type is "1", "4", "256" or "1024", supported values "yes" and "no")
-* `elb_name` - (Optional) A name for the ELB that is created. If it is not specified a name is generated automatically 
+* `elb_name` - (Optional) A name for the ELB that is created. If it is not specified a name is generated automatically
 * `split_tunnel` - (Optional) Specify split tunnel mode. (Supported values: "yes", "no")
 * `name_servers` - (Optional) A list of DNS servers used to resolve domain names by a connected VPN user when Split Tunnel Mode is enabled.
 * `search_domains` - (Optional) A list of domain names that will use the NameServer when a specific name is not in the destination when Split Tunnel Mode is enabled.
@@ -64,6 +64,7 @@ The following arguments are supported:
 * `ldap_username_attribute` - (Optional) LDAP user attribute (Required: Yes if enable_ldap is "yes")
 * `ha_subnet` - (Optional) This is for Gateway HA. Deprecated. https://docs.aviatrix.com/HowTos/gateway.html#high-availability
 * `peering_ha_subnet` - Public Subnet Information while creating Peering HA Gateway. Example: AWS: "10.0.0.0/16\~\~ZONE\~\~SubnetName"
+* `peering_ha_eip` - (Optional) Public IP address that you want assigned to the HA peering instance
 * `zone` - (Optional) A GCE zone where this gateway will be launched. (Required when cloud_type is 4)
 * `single_az_ha` (Optional) Set to "enabled" if this feature is desired
 * `allocate_new_eip` - (Optional) When value is off, reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway. Available in 2.7 or later release. (Supported values : "on", "off") (Default: "on")


### PR DESCRIPTION
To assign own EIP in terraform, adding "peering_ha_eip" option to aviatrix_gateway resource. We are needing this because we update security groups based on this EIP.