### PR TITLE
Update supported controller versions to 5.2 only

### DIFF
--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var supportedVersions = []string{"5.1", "5.2"}
+var supportedVersions = []string{"5.2"}
 
 // Provider returns a schema.Provider for Aviatrix.
 func Provider() terraform.ResourceProvider {


### PR DESCRIPTION
Since aviatrix_geo_vpn is not supported on 5.1.