### PR TITLE
(12521) Implement updating customized_routes in aws_tgw_vpc_attachment resource

### DIFF
--- a/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
@@ -49,7 +49,6 @@ func resourceAviatrixAwsTgwVpcAttachment() *schema.Resource {
 			"customized_routes": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Default:     "",
 				Description: "Advanced option. Customized Spoke VPC Routes. It allows the admin to enter non-RFC1918 routes in the VPC route table targeting the TGW.",
 			},
@@ -208,6 +207,8 @@ func resourceAviatrixAwsTgwVpcAttachmentRead(d *schema.ResourceData, meta interf
 }
 
 func resourceAviatrixAwsTgwVpcAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+
 	d.Partial(true)
 	if d.HasChange("tgw_name") {
 		return fmt.Errorf("updating tgw_name is not allowed")
@@ -220,6 +221,17 @@ func resourceAviatrixAwsTgwVpcAttachmentUpdate(d *schema.ResourceData, meta inte
 	}
 	if d.HasChange("vpc_id") {
 		return fmt.Errorf("updating vpc_id is not allowed")
+	}
+	if d.HasChange("customized_routes") {
+		awsTgwVpcAttachment := &goaviatrix.AwsTgwVpcAttachment{
+			TgwName:          d.Get("tgw_name").(string),
+			VpcID:            d.Get("vpc_id").(string),
+			CustomizedRoutes: d.Get("customized_routes").(string),
+		}
+		err := client.EditTgwSpokeVpcCustomizedRoutes(awsTgwVpcAttachment)
+		if err != nil {
+			return fmt.Errorf("failed to update spoke vpc customized routes: %s", err)
+		}
 	}
 
 	d.Partial(false)

--- a/goaviatrix/aws_tgw_vpc_attachment.go
+++ b/goaviatrix/aws_tgw_vpc_attachment.go
@@ -321,3 +321,33 @@ func (c *Client) GetVPCAttachmentRouteTableDetails(awsTgwVpcAttachment *AwsTgwVp
 	}
 	return nil, ErrNotFound
 }
+
+func (c *Client) EditTgwSpokeVpcCustomizedRoutes(awsTgwVpcAttachment *AwsTgwVpcAttachment) error {
+	Url, err := url.Parse(c.baseURL)
+	if err != nil {
+		return errors.New(("url Parsing failed for edit_tgw_spoke_vpc_customized_routes: ") + err.Error())
+	}
+	editTgwSpokeVpcCustomizedRoutes := url.Values{}
+	editTgwSpokeVpcCustomizedRoutes.Add("CID", c.CID)
+	editTgwSpokeVpcCustomizedRoutes.Add("action", "edit_tgw_spoke_vpc_customized_routes")
+	editTgwSpokeVpcCustomizedRoutes.Add("tgw_name", awsTgwVpcAttachment.TgwName)
+	editTgwSpokeVpcCustomizedRoutes.Add("vpc_id", awsTgwVpcAttachment.VpcID)
+	editTgwSpokeVpcCustomizedRoutes.Add("route_list", awsTgwVpcAttachment.CustomizedRoutes)
+	Url.RawQuery = editTgwSpokeVpcCustomizedRoutes.Encode()
+	resp, err := c.Get(Url.String(), nil)
+	if err != nil {
+		return errors.New("HTTP Get 'edit_tgw_spoke_vpc_customized_routes' failed: " + err.Error())
+	}
+	var data APIResp
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	bodyString := buf.String()
+	bodyIoCopy := strings.NewReader(bodyString)
+	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
+		return errors.New("Json Decode 'edit_tgw_spoke_vpc_customized_routes' failed: " + err.Error() + "\n Body: " + bodyString)
+	}
+	if !data.Return {
+		return errors.New("Rest API 'edit_tgw_spoke_vpc_customized_routes' Get failed: " + data.Reason)
+	}
+	return nil
+}


### PR DESCRIPTION
Remove customized_routes's characteristic of "ForceNew", and add functionality of updating of customized_routes. It will not impact existing customers.