### PR TITLE
(13061) Update logic of enable_transit_firenet to cover arm provider

### DIFF
--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -40,6 +40,7 @@ type TransitVpc struct {
 	Zone                         string `form:"zone,omitempty" json:"zone,omitempty"`
 	EnableAdvertiseTransitCidr   bool
 	BgpManualSpokeAdvertiseCidrs string `form:"bgp_manual_spoke,omitempty"`
+	EnableTransitFireNet         string `form:"enable_transit_firenet,omitempty"`
 }
 
 type TransitGwFireNetInterfaces struct {


### PR DESCRIPTION
For arm provider, enable_transit_firenet can only be enabled in creating transit gateway, and disabled in destroying transit gateway. Does not support editing.