### PR TITLE
(11363) Add support for option to manage attachment on either vpn_profile/vpn_user

### DIFF
--- a/aviatrix/data_source_aviatrix_firewall.go
+++ b/aviatrix/data_source_aviatrix_firewall.go
@@ -2,6 +2,7 @@ package aviatrix
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )

--- a/aviatrix/resource_aviatrix_vpn_profile.go
+++ b/aviatrix/resource_aviatrix_vpn_profile.go
@@ -27,7 +27,7 @@ func resourceAviatrixProfile() *schema.Resource {
 			"base_rule": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Base policy rule of  the profile to be added. Enter 'allow_all' or 'deny_all'.",
+				Description: "Base policy rule of the profile to be added. Enter 'allow_all' or 'deny_all'.",
 			},
 			"users": {
 				Type:        schema.TypeList,
@@ -64,6 +64,11 @@ func resourceAviatrixProfile() *schema.Resource {
 					},
 				},
 			},
+			"manage_user_attachment": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -81,8 +86,16 @@ func resourceAviatrixProfileCreate(d *schema.ResourceData, meta interface{}) err
 	if profile.Name == "" {
 		return fmt.Errorf("profile name can't be empty string")
 	}
-	for _, user := range d.Get("users").([]interface{}) {
-		profile.UserList = append(profile.UserList, user.(string))
+
+	manageUserAttachment := d.Get("manage_user_attachment").(bool)
+	if manageUserAttachment {
+		for _, user := range d.Get("users").([]interface{}) {
+			profile.UserList = append(profile.UserList, user.(string))
+		}
+	} else {
+		if len(d.Get("users").([]interface{})) != 0 {
+			return fmt.Errorf("'manage_user_attachment' is set false. Please empty 'users' and manage user attachment in other resource")
+		}
 	}
 
 	log.Printf("[INFO] Creating Aviatrix Profile with users: %v", profile.UserList)
@@ -124,6 +137,7 @@ func resourceAviatrixProfileRead(d *schema.ResourceData, meta interface{}) error
 		id := d.Id()
 		log.Printf("[DEBUG] Looks like an import, no profile name received. Import Id is %s", id)
 		d.Set("name", id)
+		d.Set("manage_user_attachment", true)
 		d.SetId(id)
 	}
 
@@ -150,18 +164,20 @@ func resourceAviatrixProfileRead(d *schema.ResourceData, meta interface{}) error
 	}
 	d.Set("name", profile.Name)
 	log.Printf("[TRACE] Profile policy %v", profile.Policy)
-	log.Printf("[TRACE] Profile users %v", d.Get("users"))
 
-	var users []string
-	for _, user := range d.Get("users").([]interface{}) {
-		users = append(users, user.(string))
-	}
-	if len(goaviatrix.Difference(users, profile.UserList)) == 0 &&
-		len(goaviatrix.Difference(profile.UserList, users)) == 0 {
-		d.Set("users", users)
-	} else {
-		d.Set("users", profile.UserList)
-		log.Printf("[TRACE] Profile userlistnew %v", profile.UserList)
+	manageUserAttachment := d.Get("manage_user_attachment").(bool)
+	if manageUserAttachment {
+		var users []string
+		for _, user := range d.Get("users").([]interface{}) {
+			users = append(users, user.(string))
+		}
+		if len(goaviatrix.Difference(users, profile.UserList)) == 0 &&
+			len(goaviatrix.Difference(profile.UserList, users)) == 0 {
+			d.Set("users", users)
+		} else {
+			d.Set("users", profile.UserList)
+			log.Printf("[TRACE] Profile userlistnew %v", profile.UserList)
+		}
 	}
 	log.Printf("[TRACE] Profile policy %v", profile.Policy)
 
@@ -194,10 +210,22 @@ func resourceAviatrixProfileUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 	d.Partial(true)
 
-	for _, user := range d.Get("users").([]interface{}) {
-		profile.UserList = append(profile.UserList, user.(string))
+	manageUserAttachment := d.Get("manage_user_attachment").(bool)
+	if d.HasChange("manage_user_attachment") {
+		_, nMUA := d.GetChange("manage_user_attachment")
+		newManageUserAttachment := nMUA.(bool)
+		if newManageUserAttachment {
+			d.Set("manage_user_attachment", true)
+		} else {
+			d.Set("manage_user_attachment", false)
+		}
 	}
-	log.Printf("[INFO] Creating Aviatrix Profile with users: %v", profile.UserList)
+	if manageUserAttachment {
+		for _, user := range d.Get("users").([]interface{}) {
+			profile.UserList = append(profile.UserList, user.(string))
+		}
+		log.Printf("[INFO] Creating Aviatrix Profile with users: %v", profile.UserList)
+	}
 	names := d.Get("policy").([]interface{})
 	for _, domain := range names {
 		dn := domain.(map[string]interface{})
@@ -222,50 +250,52 @@ func resourceAviatrixProfileUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("base_rule") {
 		return fmt.Errorf("cannot change base rule of a profile")
 	}
-	if d.HasChange("users") {
+	if manageUserAttachment {
+		if d.HasChange("users") {
+			oldU, newU := d.GetChange("users")
+			log.Printf("[INFO] Users to be attached : %#v %#v ", oldU, newU)
 
-		oldU, newU := d.GetChange("users")
-		log.Printf("[INFO] Users to be attached : %#v %#v ", oldU, newU)
-
-		if oldU == nil {
-			oldU = new([]interface{})
+			if oldU == nil {
+				oldU = new([]interface{})
+			}
+			if newU == nil {
+				newU = new([]interface{})
+			}
+			oldString := oldU.([]interface{})
+			newString := newU.([]interface{})
+			oldUserList := goaviatrix.ExpandStringList(oldString)
+			newUserList := goaviatrix.ExpandStringList(newString)
+			//Attach all the newly added Users
+			toAddUsers := goaviatrix.Difference(newUserList, oldUserList)
+			log.Printf("[INFO] Users to be attached : %#v", toAddUsers)
+			profile.UserList = toAddUsers
+			err := client.AttachUsers(profile)
+			if err != nil {
+				return fmt.Errorf("failed to attach User : %s", err)
+			}
+			//Detach all the removed Users
+			toDelGws := goaviatrix.Difference(oldUserList, newUserList)
+			log.Printf("[INFO] Users to be detached : %#v", toDelGws)
+			profile.UserList = toDelGws
+			err = client.DetachUsers(profile)
+			if err != nil {
+				return fmt.Errorf("failed to detach user : %s", err)
+			}
+			d.SetPartial("users")
 		}
-		if newU == nil {
-			newU = new([]interface{})
+	} else {
+		if len(d.Get("users").([]interface{})) != 0 {
+			return fmt.Errorf("'manage_user_attachment' is set false. Please empty 'users' and manage user attachment in other resource")
 		}
-		oldString := oldU.([]interface{})
-		newString := newU.([]interface{})
-		oldUserList := goaviatrix.ExpandStringList(oldString)
-		newUserList := goaviatrix.ExpandStringList(newString)
-		//Attach all the newly added Users
-		toAddUsers := goaviatrix.Difference(newUserList, oldUserList)
-		log.Printf("[INFO] Users to be attached : %#v", toAddUsers)
-		profile.UserList = toAddUsers
-		err := client.AttachUsers(profile)
-		if err != nil {
-			return fmt.Errorf("failed to attach User : %s", err)
-		}
-		//Detach all the removed Users
-		toDelGws := goaviatrix.Difference(oldUserList, newUserList)
-		log.Printf("[INFO] Users to be detached : %#v", toDelGws)
-		profile.UserList = toDelGws
-		err = client.DetachUsers(profile)
-		if err != nil {
-			return fmt.Errorf("failed to detach user : %s", err)
-		}
-		d.SetPartial("users")
-
 	}
+
 	log.Printf("[INFO] Checking for policy changes")
-
 	if d.HasChange("policy") {
-
 		err := client.UpdateProfilePolicy(profile)
 		if err != nil {
 			return fmt.Errorf("failed to create Aviatrix Profile: %s", err)
 		}
 		d.SetPartial("policy")
-
 	}
 
 	d.Partial(false)
@@ -283,7 +313,6 @@ func resourceAviatrixProfileDelete(d *schema.ResourceData, meta interface{}) err
 		log.Printf("[INFO] Found users: %#v", d.Get("users"))
 
 		profile.UserList = goaviatrix.ExpandStringList(d.Get("users").([]interface{}))
-
 		err := client.DetachUsers(profile)
 		if err != nil {
 			return fmt.Errorf("failed to detach Users: %s", err)

--- a/aviatrix/resource_aviatrix_vpn_user.go
+++ b/aviatrix/resource_aviatrix_vpn_user.go
@@ -3,6 +3,7 @@ package aviatrix
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
@@ -12,6 +13,7 @@ func resourceAviatrixVPNUser() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAviatrixVPNUserCreate,
 		Read:   resourceAviatrixVPNUserRead,
+		Update: resourceAviatrixVPNUserUpdate,
 		Delete: resourceAviatrixVPNUserDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -50,6 +52,17 @@ func resourceAviatrixVPNUser() *schema.Resource {
 				ForceNew:    true,
 				Description: "This is the name of the SAML endpoint to which the user is to be associated.",
 			},
+			"profiles": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "List of profiles for user to attach to.",
+			},
+			"manage_user_attachment": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -71,15 +84,45 @@ func resourceAviatrixVPNUserCreate(d *schema.ResourceData, meta interface{}) err
 	if vpnUser.GwName == "" {
 		return fmt.Errorf("invalid choice: gw_name can't be empty")
 	}
+
+	manageUserAttachment := d.Get("manage_user_attachment").(bool)
+	if !manageUserAttachment && len(d.Get("profiles").([]interface{})) != 0 {
+		return fmt.Errorf("'manage_user_attachment' is set false. Please empty 'profiles' and manage user attachment in other resource")
+	}
+
 	log.Printf("[INFO] Creating Aviatrix VPN User: %#v", vpnUser)
 
 	err := client.CreateVPNUser(vpnUser)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix VPNUser: %s", err)
 	}
-
 	d.SetId(vpnUser.UserName)
-	return resourceAviatrixVPNUserRead(d, meta)
+
+	flag := false
+	defer resourceAviatrixVPNUserReadIfRequired(d, meta, &flag)
+
+	if manageUserAttachment && len(d.Get("profiles").([]interface{})) != 0 {
+		for _, profileName := range d.Get("profiles").([]interface{}) {
+			profile := &goaviatrix.Profile{
+				Name: profileName.(string),
+			}
+			profile.UserList = append(profile.UserList, vpnUser.UserName)
+			err := client.AttachUsers(profile)
+			if err != nil {
+				return fmt.Errorf("failed to attach User(%s) to Profile(%s) due to: %s", vpnUser.UserName, profile.Name, err)
+			}
+		}
+	}
+
+	return resourceAviatrixVPNUserReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixVPNUserReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixVPNUserRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixVPNUserRead(d *schema.ResourceData, meta interface{}) error {
@@ -89,11 +132,13 @@ func resourceAviatrixVPNUserRead(d *schema.ResourceData, meta interface{}) error
 	if userName == "" {
 		id := d.Id()
 		log.Printf("[DEBUG] Looks like an import, user_name is empty. Id is %s", id)
-		userName = id
+		d.Set("user_name", id)
+		d.Set("manage_user_attachment", true)
+		d.SetId(id)
 	}
 
 	vpnUser := &goaviatrix.VPNUser{
-		UserName: userName,
+		UserName: d.Get("user_name").(string),
 	}
 	vu, err := client.GetVPNUser(vpnUser)
 	if err != nil {
@@ -116,7 +161,101 @@ func resourceAviatrixVPNUserRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("saml_endpoint", vu.SamlEndpoint)
 	}
 
+	manageUserAttachment := d.Get("manage_user_attachment").(bool)
+	if manageUserAttachment {
+		var profiles []string
+		for _, profile := range d.Get("profiles").([]interface{}) {
+			profiles = append(profiles, profile.(string))
+		}
+		profileListRead, err := client.GetProfileForUser(vpnUser)
+		if err != nil {
+			return fmt.Errorf("couldn't get profile information for vpn user: %s due to: %s", vpnUser.UserName, err)
+		}
+		profileList := strings.Split(profileListRead, ",")
+		if len(profileList) != 0 {
+			for i := range profileList {
+				profileList[i] = strings.TrimSpace(profileList[i])
+			}
+		}
+		if len(goaviatrix.Difference(profiles, profileList)) == 0 && len(goaviatrix.Difference(profileList, profiles)) == 0 {
+			err := d.Set("profiles", profiles)
+			if err != nil {
+				return fmt.Errorf("couldn't set 'profiles' for vpn user: %s", vpnUser.UserName)
+			}
+		} else {
+			err := d.Set("profiles", profileList)
+			if err != nil {
+				return fmt.Errorf("couldn't set 'profiles' for vpn user: %s", vpnUser.UserName)
+			}
+		}
+	}
+
 	return nil
+}
+
+func resourceAviatrixVPNUserUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+
+	vpnUser := &goaviatrix.VPNUser{
+		UserName: d.Get("user_name").(string),
+	}
+	d.Partial(true)
+
+	manageUserAttachment := d.Get("manage_user_attachment").(bool)
+	if d.HasChange("manage_user_attachment") {
+		_, nMUA := d.GetChange("manage_user_attachment")
+		newManageUserAttachment := nMUA.(bool)
+		if newManageUserAttachment {
+			d.Set("manage_user_attachment", true)
+		} else {
+			d.Set("manage_user_attachment", false)
+		}
+	}
+	if manageUserAttachment {
+		if d.HasChange("profiles") {
+			oldU, newU := d.GetChange("profiles")
+			if oldU == nil {
+				oldU = new([]interface{})
+			}
+			if newU == nil {
+				newU = new([]interface{})
+			}
+			oldString := oldU.([]interface{})
+			newString := newU.([]interface{})
+			oldProfileList := goaviatrix.ExpandStringList(oldString)
+			newProfileList := goaviatrix.ExpandStringList(newString)
+			toAddProfiles := goaviatrix.Difference(newProfileList, oldProfileList)
+			for _, profileName := range toAddProfiles {
+				profile := &goaviatrix.Profile{
+					Name: profileName,
+				}
+				profile.UserList = []string{vpnUser.UserName}
+				err := client.AttachUsers(profile)
+				if err != nil {
+					return fmt.Errorf("failed to attach User: %s", err)
+				}
+			}
+			toDelProfiles := goaviatrix.Difference(oldProfileList, newProfileList)
+			for _, profileName := range toDelProfiles {
+				profile := &goaviatrix.Profile{
+					Name: profileName,
+				}
+				profile.UserList = []string{vpnUser.UserName}
+				err := client.DetachUsers(profile)
+				if err != nil {
+					return fmt.Errorf("failed to detach User: %s", err)
+				}
+			}
+			d.SetPartial("profiles")
+		}
+	} else {
+		if len(d.Get("profiles").([]interface{})) != 0 {
+			return fmt.Errorf("'manage_user_attachment' is set false. Please empty 'profiles' and manage user attachment in other resource")
+		}
+	}
+
+	d.Partial(false)
+	return resourceAviatrixVPNUserRead(d, meta)
 }
 
 func resourceAviatrixVPNUserDelete(d *schema.ResourceData, meta interface{}) error {
@@ -128,6 +267,20 @@ func resourceAviatrixVPNUserDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	log.Printf("[INFO] Deleting Aviatrix VPNUser: %#v", vpnUser)
+
+	if _, ok := d.GetOk("profiles"); ok {
+		log.Printf("[INFO] Found profiles: %#v", d.Get("profiles"))
+		for _, profileName := range d.Get("profiles").([]interface{}) {
+			profile := &goaviatrix.Profile{
+				Name: profileName.(string),
+			}
+			profile.UserList = append(profile.UserList, vpnUser.UserName)
+			err := client.DetachUsers(profile)
+			if err != nil {
+				return fmt.Errorf("failed to attach User(%s) to Profile(%s) due to: %s", vpnUser.UserName, profile.Name, err)
+			}
+		}
+	}
 
 	err := client.DeleteVPNUser(vpnUser)
 	if err != nil {

--- a/aviatrix/resource_aviatrix_vpn_user.go
+++ b/aviatrix/resource_aviatrix_vpn_user.go
@@ -258,20 +258,6 @@ func resourceAviatrixVPNUserDelete(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Deleting Aviatrix VPNUser: %#v", vpnUser)
 
-	if _, ok := d.GetOk("profiles"); ok {
-		log.Printf("[INFO] Found profiles: %#v", d.Get("profiles"))
-		for _, profileName := range d.Get("profiles").([]interface{}) {
-			profile := &goaviatrix.Profile{
-				Name: profileName.(string),
-			}
-			profile.UserList = append(profile.UserList, vpnUser.UserName)
-			err := client.DetachUsers(profile)
-			if err != nil {
-				return fmt.Errorf("failed to attach User(%s) to Profile(%s) due to: %s", vpnUser.UserName, profile.Name, err)
-			}
-		}
-	}
-
 	err := client.DeleteVPNUser(vpnUser)
 	if err != nil {
 		return fmt.Errorf("failed to delete Aviatrix VPNUser: %s", err)

--- a/goaviatrix/vpn_user.go
+++ b/goaviatrix/vpn_user.go
@@ -21,12 +21,6 @@ type VPNUser struct {
 	Profiles     []string `json:"profiles,omitempty"`
 }
 
-type VPNUserListResp struct {
-	Return  bool      `json:"return"`
-	Results []VPNUser `json:"results"`
-	Reason  string    `json:"reason"`
-}
-
 type VPNUserResp struct {
 	Return  bool        `json:"return"`
 	Results VPNUserInfo `json:"results"`
@@ -35,17 +29,6 @@ type VPNUserResp struct {
 
 type VPNUserInfo struct {
 	VpnUser VPNUser `json:"vpn_user"`
-}
-
-type GetVpnUsersResp struct {
-	Return  bool    `json:"return"`
-	Results VPNUser `json:"results"`
-	Reason  string  `json:"reason"`
-}
-
-type EditVPNUser struct {
-	UserName string `json:"_id"`
-	Profile  string `json:"profile"`
 }
 
 func (c *Client) CreateVPNUser(vpnUser *VPNUser) error {

--- a/goaviatrix/vpn_user.go
+++ b/goaviatrix/vpn_user.go
@@ -11,13 +11,14 @@ import (
 
 // VPNUser simple struct to hold vpn_user details
 type VPNUser struct {
-	Action       string `form:"action,omitempty" json:"action,omitempty"`
-	CID          string `form:"CID,omitempty" json:"CID,omitempty"`
-	SamlEndpoint string `form:"saml_endpoint,omitempty" json:"saml_endpoint,omitempty"`
-	VpcID        string `form:"vpc_id,omitempty" json:"vpc_id,omitempty"`
-	GwName       string `form:"lb_name,omitempty" json:"lb_name,omitempty"`
-	UserName     string `form:"username" json:"_id,omitempty"`
-	UserEmail    string `form:"user_email,omitempty" json:"email,omitempty"`
+	Action       string   `form:"action,omitempty" json:"action,omitempty"`
+	CID          string   `form:"CID,omitempty" json:"CID,omitempty"`
+	SamlEndpoint string   `form:"saml_endpoint,omitempty" json:"saml_endpoint,omitempty"`
+	VpcID        string   `form:"vpc_id,omitempty" json:"vpc_id,omitempty"`
+	GwName       string   `form:"lb_name,omitempty" json:"lb_name,omitempty"`
+	UserName     string   `form:"username" json:"_id,omitempty"`
+	UserEmail    string   `form:"user_email,omitempty" json:"email,omitempty"`
+	Profiles     []string `json:"profiles,omitempty"`
 }
 
 type VPNUserListResp struct {
@@ -36,10 +37,10 @@ type VPNUserInfo struct {
 	VpnUser VPNUser `json:"vpn_user"`
 }
 
-type ListVpnUsersResp struct {
-	Return  bool          `json:"return"`
-	Results []EditVPNUser `json:"results"`
-	Reason  string        `json:"reason"`
+type GetVpnUsersResp struct {
+	Return  bool    `json:"return"`
+	Results VPNUser `json:"results"`
+	Reason  string  `json:"reason"`
 }
 
 type EditVPNUser struct {
@@ -50,7 +51,7 @@ type EditVPNUser struct {
 func (c *Client) CreateVPNUser(vpnUser *VPNUser) error {
 	Url, err := url.Parse(c.baseURL)
 	if err != nil {
-		return errors.New(("url Parsing failed for add_vpn_user") + err.Error())
+		return errors.New(("url Parsing failed for 'add_vpn_user': ") + err.Error())
 	}
 	addVpnUser := url.Values{}
 	addVpnUser.Add("CID", c.CID)
@@ -63,7 +64,7 @@ func (c *Client) CreateVPNUser(vpnUser *VPNUser) error {
 	Url.RawQuery = addVpnUser.Encode()
 	resp, err := c.Get(Url.String(), nil)
 	if err != nil {
-		return errors.New("HTTP Get add_vpn_user failed: " + err.Error())
+		return errors.New("HTTP Get 'add_vpn_user' failed: " + err.Error())
 	}
 	var data APIResp
 	buf := new(bytes.Buffer)
@@ -71,13 +72,13 @@ func (c *Client) CreateVPNUser(vpnUser *VPNUser) error {
 	bodyString := buf.String()
 	bodyIoCopy := strings.NewReader(bodyString)
 	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
-		return errors.New("Json Decode add_vpn_user failed: " + err.Error() + "\n Body: " + bodyString)
+		return errors.New("Json Decode 'add_vpn_user' failed: " + err.Error() + "\n Body: " + bodyString)
 	}
 	if !data.Return {
 		if strings.Contains(data.Reason, "Sending VPN certificates to email") {
 			return nil
 		}
-		return errors.New("Rest API add_vpn_user Get failed: " + data.Reason)
+		return errors.New("Rest API 'add_vpn_user' Get failed: " + data.Reason)
 	}
 	return nil
 }
@@ -85,7 +86,7 @@ func (c *Client) CreateVPNUser(vpnUser *VPNUser) error {
 func (c *Client) GetVPNUser(vpnUser *VPNUser) (*VPNUser, error) {
 	Url, err := url.Parse(c.baseURL)
 	if err != nil {
-		return nil, errors.New(("url Parsing failed for get_vpn_user_by_name") + err.Error())
+		return nil, errors.New(("url Parsing failed for 'get_vpn_user_by_name': ") + err.Error())
 	}
 	getVpnUserByName := url.Values{}
 	getVpnUserByName.Add("CID", c.CID)
@@ -96,7 +97,7 @@ func (c *Client) GetVPNUser(vpnUser *VPNUser) (*VPNUser, error) {
 	resp, err := c.Get(Url.String(), nil)
 
 	if err != nil {
-		return nil, errors.New("HTTP Get get_vpn_user_by_name failed: " + err.Error())
+		return nil, errors.New("HTTP Get 'get_vpn_user_by_name' failed: " + err.Error())
 	}
 	var data VPNUserResp
 	buf := new(bytes.Buffer)
@@ -104,13 +105,13 @@ func (c *Client) GetVPNUser(vpnUser *VPNUser) (*VPNUser, error) {
 	bodyString := buf.String()
 	bodyIoCopy := strings.NewReader(bodyString)
 	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
-		return nil, errors.New("Json Decode get_vpn_user_by_name failed: " + err.Error() + "\n Body: " + bodyString)
+		return nil, errors.New("Json Decode 'get_vpn_user_by_name' failed: " + err.Error() + "\n Body: " + bodyString)
 	}
 	if !data.Return {
 		if strings.Contains(data.Reason, "Invalid VPN username") {
 			return nil, ErrNotFound
 		}
-		return nil, errors.New("Rest API get_vpn_user_by_name Get failed: " + data.Reason)
+		return nil, errors.New("Rest API 'get_vpn_user_by_name' Get failed: " + data.Reason)
 	}
 
 	if data.Results.VpnUser.UserName != "" {
@@ -130,7 +131,7 @@ func (c *Client) DeleteVPNUser(vpnUser *VPNUser) error {
 		vpnUser.VpcID, vpnUser.UserName)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
-		return errors.New("HTTP Get delete_vpn_user failed: " + err.Error())
+		return errors.New("HTTP Get 'delete_vpn_user' failed: " + err.Error())
 	}
 	var data APIResp
 	buf := new(bytes.Buffer)
@@ -138,43 +139,10 @@ func (c *Client) DeleteVPNUser(vpnUser *VPNUser) error {
 	bodyString := buf.String()
 	bodyIoCopy := strings.NewReader(bodyString)
 	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
-		return errors.New("Json Decode delete_vpn_user failed: " + err.Error() + "\n Body: " + bodyString)
+		return errors.New("Json Decode 'delete_vpn_user' failed: " + err.Error() + "\n Body: " + bodyString)
 	}
 	if !data.Return {
-		return errors.New("Rest API delete_vpn_user Get failed: " + data.Reason)
+		return errors.New("Rest API 'delete_vpn_user' Get failed: " + data.Reason)
 	}
 	return nil
-}
-
-func (c *Client) GetProfileForUser(vpnUser *VPNUser) (string, error) {
-	Url, err := url.Parse(c.baseURL)
-	if err != nil {
-		return "", errors.New(("url Parsing failed for 'list_vpn_users': ") + err.Error())
-	}
-	listVpnUsers := url.Values{}
-	listVpnUsers.Add("CID", c.CID)
-	listVpnUsers.Add("action", "list_vpn_users")
-	Url.RawQuery = listVpnUsers.Encode()
-	resp, err := c.Get(Url.String(), nil)
-	if err != nil {
-		return "", errors.New("HTTP Get 'list_vpn_users' failed: " + err.Error())
-	}
-	var data ListVpnUsersResp
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
-	bodyString := buf.String()
-	bodyIoCopy := strings.NewReader(bodyString)
-	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
-		return "", errors.New("Json Decode 'list_vpn_users' failed: " + err.Error() + "\n Body: " + bodyString)
-	}
-	if !data.Return {
-		return "", errors.New("Rest API 'list_vpn_users' Get failed: " + data.Reason)
-	}
-	vpnUserList := data.Results
-	for i := range vpnUserList {
-		if vpnUserList[i].UserName == vpnUser.UserName {
-			return vpnUserList[i].Profile, nil
-		}
-	}
-	return "", nil
 }


### PR DESCRIPTION
Solution:
 - Add a flag called "manage_user_attachment" into aviatrix_vpn_profile;
 - Add a flag called "manage_user_attachment" into aviatrix_vpn_user;
 - Add a parameter called "profiles" (list of profile name) into aviatrix_vpn_user;