### PR TITLE
(14155) Add ha_peering_subnet option for GCP gateway

### DIFF
--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -61,6 +61,7 @@ type Gateway struct {
 	GwSubnetID                  string `form:"gw_subnet_id,omitempty" json:"gw_subnet_id,omitempty"`
 	PeeringHASubnet             string `form:"public_subnet,omitempty"`
 	NewZone                     string `form:"new_zone,omitempty"`
+	NewSubnet                   string `form:"new_subnet,omitempty"`
 	InsaneMode                  string `form:"insane_mode,omitempty" json:"high_perf,omitempty"`
 	InstState                   string `form:"inst_state,omitempty" json:"inst_state,omitempty"`
 	IntraVMRoute                string `form:"intra_vm_route,omitempty" json:"intra_vm_route,omitempty"`

--- a/website/docs/r/aviatrix_gateway.html.markdown
+++ b/website/docs/r/aviatrix_gateway.html.markdown
@@ -79,6 +79,7 @@ resource "aviatrix_gateway" "test_gateway_gcp" {
   gw_size            = "n1-standard-1"
   subnet             = "10.12.0.0/24"
   peering_ha_zone    = "us-west1-c"
+  peering_ha_subnet  = "10.12.0.0/24" // Optional
   peering_ha_gw_size = "n1-standard-1"
 }
 ```
@@ -138,7 +139,7 @@ The following arguments are supported:
 
 ### HA
 * `single_az_ha` (Optional) If enabled, Controller monitors the health of the gateway and restarts the gateway if it becomes unreachable. Valid values: true, false. Default value: false.
-* `peering_ha_subnet` - (Optional) Public subnet CIDR to create Peering HA Gateway in. Required only if enabling Peering HA for AWS/AZURE. Example: AWS: "10.0.0.0/16".
+* `peering_ha_subnet` - (Optional) Public subnet CIDR to create Peering HA Gateway in. Required if enabling Peering HA for AWS/AZURE. Optional if enabling Peering HA for GCP. Example: AWS: "10.0.0.0/16".
 * `peering_ha_zone` - (Optional) Zone to create Peering HA Gateway in. Required only if enabling Peering HA for GCP. Example: GCP: "us-west1-c".
 * `peering_ha_insane_mode_az` - (Optional) Region + Availability Zone of subnet being created for Insane Mode-enabled Peering HA Gateway. Required for AWS only if `insane_mode` is set and `peering_ha_subnet` is set. Example: AWS: "us-west-1a".
 * `peering_ha_eip` - (Optional) Public IP address to be assigned to the the HA peering instance. Only available for AWS.


### PR DESCRIPTION
- Allow `peering_ha_subnet` attribute when creating a `aviatrix_gateway` resource on GCP. 
- Update documentation to reflect the change

Note: This change also needs to be made in `aviatrix_transit_gateway` and `aviatrix_spoke_gateway`. I will do those each in their own PRs.