### PR TITLE
(14697) Fix gateway_snat error

### DIFF
--- a/aviatrix/resource_aviatrix_gateway_snat.go
+++ b/aviatrix/resource_aviatrix_gateway_snat.go
@@ -150,7 +150,7 @@ func resourceAviatrixGatewaySNatCreate(d *schema.ResourceData, meta interface{})
 			gateway.SnatPolicy = append(gateway.SnatPolicy, *customPolicy)
 		}
 	}
-	err := client.EnableSNat(gateway)
+	err := client.EnableCustomSNat(gateway)
 	if err != nil {
 		return fmt.Errorf("failed to configure policies for 'customized_snat' mode due to: %s", err)
 	}
@@ -259,7 +259,7 @@ func resourceAviatrixGatewaySNatUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
-		err := client.EnableSNat(gateway)
+		err := client.EnableCustomSNat(gateway)
 		if err != nil {
 			return fmt.Errorf("failed to enable SNAT of 'customized_snat': %s", err)
 		}
@@ -276,7 +276,7 @@ func resourceAviatrixGatewaySNatDelete(d *schema.ResourceData, meta interface{})
 		GatewayName: d.Get("gw_name").(string),
 	}
 
-	err := client.DisableSNat(gateway)
+	err := client.DisableCustomSNat(gateway)
 	if err != nil {
 		return fmt.Errorf("failed to disable SNAT for Aviatrix gateway(name: %s) due to: %s", gateway.GatewayName, err)
 	}

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -424,6 +424,54 @@ func (c *Client) DeleteGateway(gateway *Gateway) error {
 	return nil
 }
 
+func (c *Client) EnableCustomSNat(gateway *Gateway) error {
+	gateway.CID = c.CID
+	gateway.Action = "edit_gw_customized_snat_config"
+	args, err := json.Marshal(gateway.SnatPolicy)
+	if err != nil {
+		return err
+	}
+	gateway.PolicyList = string(args)
+	resp, err := c.Post(c.baseURL, gateway)
+	if err != nil {
+		return errors.New("HTTP POST edit_gw_customized_snat_config failed: " + err.Error())
+	}
+	var data APIResp
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	bodyString := buf.String()
+	bodyIoCopy := strings.NewReader(bodyString)
+	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
+		return errors.New("Json Decode edit_gw_customized_snat_config failed: " + err.Error() + "\n Body: " + bodyString)
+	}
+	if !data.Return {
+		return errors.New("Rest API edit_gw_customized_snat_config POST failed: " + data.Reason)
+	}
+	return nil
+}
+
+func (c *Client) DisableCustomSNat(gateway *Gateway) error {
+	gateway.CID = c.CID
+	gateway.Action = "edit_gw_customized_snat_config"
+	gateway.PolicyList = ""
+	resp, err := c.Post(c.baseURL, gateway)
+	if err != nil {
+		return errors.New("HTTP POST edit_gw_customized_snat_config failed: " + err.Error())
+	}
+	var data APIResp
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	bodyString := buf.String()
+	bodyIoCopy := strings.NewReader(bodyString)
+	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
+		return errors.New("Json Decode edit_gw_customized_snat_config failed: " + err.Error() + "\n Body: " + bodyString)
+	}
+	if !data.Return {
+		return errors.New("Rest API edit_gw_customized_snat_config POST failed: " + data.Reason)
+	}
+	return nil
+}
+
 func (c *Client) EnableSNat(gateway *Gateway) error {
 	gateway.CID = c.CID
 	gateway.Action = "enable_snat"


### PR DESCRIPTION
- Fix syntax error when creating an gateway snat policy
- Solution was to change the api endpoint for custom snat configs
  -  `enable_snat` => `edit_gw_customized_snat_config`
  - `disable_snat` => `edit_gw_customized_snat_config`