### PR TITLE
(14155) Add ha_subnet option to GCP transit gw

### DIFF
--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -24,6 +24,7 @@ type TransitVpc struct {
 	Subnet                       string `form:"public_subnet,omitempty" json:"vpc_net,omitempty"`
 	HASubnet                     string `form:"ha_subnet,omitempty"`
 	HAZone                       string `form:"new_zone,omitempty"`
+	HASubnetGCP                  string `form:"new_subnet,omitempty"`
 	PeeringHASubnet              string `json:"public_subnet,omitempty"`
 	VpcRegion                    string `form:"region,omitempty" json:"vpc_region,omitempty"`
 	VpcSize                      string `form:"gw_size,omitempty" json:"gw_size,omitempty"`
@@ -76,6 +77,27 @@ func (c *Client) LaunchTransitVpc(gateway *TransitVpc) error {
 	}
 	if !data.Return {
 		return errors.New("Rest API create_transit_gw Post failed: " + data.Reason)
+	}
+	return nil
+}
+
+func (c *Client) EnableHaTransitGateway(gateway *TransitVpc) error {
+	gateway.CID = c.CID
+	gateway.Action = "create_peering_ha_gateway"
+	resp, err := c.Post(c.baseURL, gateway)
+	if err != nil {
+		return errors.New("HTTP Post create_peering_ha_gateway failed: " + err.Error())
+	}
+	var data APIResp
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	bodyString := buf.String()
+	bodyIoCopy := strings.NewReader(bodyString)
+	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
+		return errors.New("Json Decode create_peering_ha_gateway failed: " + err.Error() + "\n Body: " + bodyString)
+	}
+	if !data.Return {
+		return errors.New("Rest API create_peering_ha_gateway Post failed: " + data.Reason)
 	}
 	return nil
 }

--- a/website/docs/r/aviatrix_transit_gateway.html.markdown
+++ b/website/docs/r/aviatrix_transit_gateway.html.markdown
@@ -43,6 +43,7 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_gcp" {
   gw_size      = "n1-standard-1"
   subnet       = "10.8.0.0/16"
   ha_zone      = "us-west2-b"
+  ha_subnet    = "10.8.0.0/16" // Optional
   ha_gw_size   = "n1-standard-1"
 }
 ```
@@ -89,7 +90,7 @@ The following arguments are supported:
 
 ### HA
 * `single_az_ha` (Optional) Set to true if this [feature](https://docs.aviatrix.com/Solutions/gateway_ha.html#single-az-gateway) is desired. Valid values: true, false.
-* `ha_subnet` - (Optional) HA Subnet CIDR. Required only if enabling HA for AWS/Azure gateway. Setting to empty/unsetting will disable HA. Setting to a valid subnet CIDR will create an HA gateway on the subnet. Example: "10.12.0.0/24".
+* `ha_subnet` - (Optional) HA Subnet CIDR. Required only if enabling HA for AWS/Azure gateway. Optional for GCP. Setting to empty/unsetting will disable HA. Setting to a valid subnet CIDR will create an HA gateway on the subnet. Example: "10.12.0.0/24".
 * `ha_zone` - (Optional) HA Zone. Required only if enabling HA for GCP gateway. Setting to empty/unsetting will disable HA. Setting to a valid zone will create an HA gateway in the zone. Example: "us-west1-c".
 * `ha_insane_mode_az` - (Optional) AZ of subnet being created for Insane Mode Transit HA Gateway. Required for AWS if `insane_mode` is enabled and `ha_subnet` is set. Example: AWS: "us-west-1a".
 * `ha_eip` - (Optional) Public IP address that you want to assign to the HA peering instance. If no value is given, a new EIP will automatically be allocated. Only available for AWS.


### PR DESCRIPTION
- Allow ha_subnet option when creating GCP transit gw
  - This required targeting a new API action `create_peering_ha_gateway` instead of what we had previously `enable_transit_ha`
- Update docs