### PR TITLE
(14155) Add ha_subnet to spoke gw GCP

### DIFF
--- a/website/docs/r/aviatrix_spoke_gateway.html.markdown
+++ b/website/docs/r/aviatrix_spoke_gateway.html.markdown
@@ -21,7 +21,6 @@ resource "aviatrix_spoke_gateway" "test_spoke_gateway_aws" {
   vpc_reg      = "us-west-1"
   gw_size      = "t2.micro"
   subnet       = "10.11.0.0/24"
-  enable_snat  = false
   tag_list     = [
     "k1:v1",
     "k2:v2",
@@ -38,7 +37,6 @@ resource "aviatrix_spoke_gateway" "test_spoke_gateway_gcp" {
   vpc_reg      = "us-west1-b"
   gw_size      = "n1-standard-1"
   subnet       = "10.12.0.0/24"
-  enable_snat  = false
 }
 ```
 ```hcl
@@ -51,7 +49,6 @@ resource "aviatrix_spoke_gateway" "test_spoke_gateway_azure" {
   vpc_reg      = "West US"
   gw_size      = "Standard_B1s"
   subnet       = "10.13.0.0/24"
-  enable_snat  = false
 }
 ```
 ```hcl
@@ -82,7 +79,7 @@ The following arguments are supported:
 
 ### HA
 * `single_az_ha` (Optional) Set to true if this [feature](https://docs.aviatrix.com/Solutions/gateway_ha.html#single-az-gateway) is desired. Valid values: true, false.
-* `ha_subnet` - (Optional) HA Subnet. Required only if enabling HA for AWS/Azure gateway. Setting to empty/unsetting will disable HA. Setting to a valid subnet CIDR will create an HA gateway on the subnet. Example: "10.12.0.0/24"
+* `ha_subnet` - (Optional) HA Subnet. Required if enabling HA for AWS/Azure gateway. Optional for GCP. Setting to empty/unsetting will disable HA. Setting to a valid subnet CIDR will create an HA gateway on the subnet. Example: "10.12.0.0/24"
 * `ha_zone` - (Optional) HA Zone. Required only if enabling HA for GCP gateway. Setting to empty/unsetting will disable HA. Setting to a valid zone will create an HA gateway in the zone. Example: "us-west1-c".
 * `ha_insane_mode_az` (Optional) AZ of subnet being created for Insane Mode Spoke HA Gateway. Required for AWS if `insane_mode` is enabled and `ha_subnet` is set. Example: AWS: "us-west-1a".
 * `ha_eip` - (Optional) Public IP address that you want to assign to the HA peering instance. If no value is given, a new EIP will automatically be allocated. Only available for AWS.


### PR DESCRIPTION
- Allow ha_subnet option when creating GCP spoke gw
  - This required targeting a new API action create_peering_ha_gateway instead of what we had previously enable_spoke_ha
- Update docs