### PR TITLE
(14138) Add route_tables and route_tables_filter to data_source_vpc

### DIFF
--- a/aviatrix/data_source_aviatrix_vpc.go
+++ b/aviatrix/data_source_aviatrix_vpc.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
@@ -126,6 +128,21 @@ func dataSourceAviatrixVpc() *schema.Resource {
 					},
 				},
 			},
+			"route_tables": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of AWS route table ids associated with this VPC. Only populated for AWS vpc.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"route_tables_filter": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"private", "public"}, false),
+				Description: "Filters the route_tables list to contain only public or private route tables. " +
+					"Valid values are 'private' or 'public'. If not set then route_tables are not filtered.",
+			},
 		},
 	}
 }
@@ -189,6 +206,55 @@ func dataSourceAviatrixVpcRead(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[WARN] Error setting private subnets for (%s): %s", d.Id(), err)
 	}
 
+	if vC.CloudType == goaviatrix.AWS {
+		vpc.PublicRoutesOnly = true
+		publicRtbs, err := client.GetVpcRouteTableIDs(vpc)
+		if err != nil {
+			return fmt.Errorf("could not get public vpc route table ids: %v", err)
+		}
+
+		vpc.PublicRoutesOnly = false
+		allRtbs, err := client.GetVpcRouteTableIDs(vpc)
+		if err != nil {
+			return fmt.Errorf("could not get all vpc route table ids: %v", err)
+		}
+
+		var rtbs []string
+		routeTableFilter := d.Get("route_tables_filter")
+		if routeTableFilter == "private" {
+			rtbs = getPrivateRouteTables(allRtbs, publicRtbs)
+		} else if routeTableFilter == "public" {
+			rtbs = publicRtbs
+		} else {
+			rtbs = allRtbs
+		}
+
+		if err := d.Set("route_tables", rtbs); err != nil {
+			log.Printf("[WARN] Error setting route tables for (%s): %s", d.Id(), err)
+		}
+	}
+
 	d.SetId(vC.Name)
 	return nil
+}
+
+// To find all the private route tables we will remove the public route tables
+// from the list of all route tables.
+func getPrivateRouteTables(all, public []string) []string {
+	var rtbs []string
+	for _, rtb := range all {
+		if !sliceContains(public, rtb) {
+			rtbs = append(rtbs, rtb)
+		}
+	}
+	return rtbs
+}
+
+func sliceContains(sl []string, s string) bool {
+	for _, v := range sl {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/goaviatrix/vpc.go
+++ b/goaviatrix/vpc.go
@@ -23,6 +23,7 @@ type Vpc struct {
 	Subnets            []SubnetInfo `form:"subnet_list,omitempty" json:"subnets,omitempty"`
 	PublicSubnets      []SubnetInfo
 	PrivateSubnets     []SubnetInfo
+	PublicRoutesOnly   bool
 }
 
 type VpcEdit struct {
@@ -152,6 +153,57 @@ func (c *Client) GetVpc(vpc *Vpc) (*Vpc, error) {
 	}
 	log.Error("VPC not found")
 	return nil, ErrNotFound
+}
+
+func (c *Client) GetVpcRouteTableIDs(vpc *Vpc) ([]string, error) {
+	Url, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, errors.New(("url Parsing failed for list_vpc_route_tables ") + err.Error())
+	}
+	listRouteTables := url.Values{}
+	listRouteTables.Add("CID", c.CID)
+	listRouteTables.Add("action", "list_vpc_route_tables")
+	listRouteTables.Add("vpc_id", vpc.VpcID)
+	listRouteTables.Add("account_name", vpc.AccountName)
+	listRouteTables.Add("vpc_region", vpc.Region)
+	if vpc.PublicRoutesOnly {
+		listRouteTables.Add("public_only", "yes")
+	}
+
+	Url.RawQuery = listRouteTables.Encode()
+	resp, err := c.Get(Url.String(), nil)
+
+	if err != nil {
+		return nil, errors.New("HTTP Get list_vpc_route_tables failed: " + err.Error())
+	}
+
+	type RespResults struct {
+		RouteTables []string `json:"vpc_rtbs_list"`
+	}
+	type Resp struct {
+		Return  bool        `json:"return"`
+		Results RespResults `json:"results"`
+		Reason  string      `json:"reason"`
+	}
+	var data Resp
+
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(resp.Body)
+	bodyString := buf.String()
+	bodyIoCopy := strings.NewReader(bodyString)
+	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
+		return nil, errors.New("Json Decode list_vpc_route_tables failed: " + err.Error() + "\n Body: " + bodyString)
+	}
+	if !data.Return {
+		return nil, errors.New("Rest API list_vpc_route_tables Get failed: " + data.Reason)
+	}
+
+	var rtbs []string
+	for _, id := range data.Results.RouteTables {
+		rtbs = append(rtbs, strings.Split(id, "~~")[0])
+	}
+
+	return rtbs, nil
 }
 
 func (c *Client) UpdateVpc(vpc *Vpc) error {

--- a/website/docs/d/aviatrix_vpc.html.markdown
+++ b/website/docs/d/aviatrix_vpc.html.markdown
@@ -25,6 +25,7 @@ data "aviatrix_vpc" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the Aviatrix VPC.
+* `route_tables_filter` - (Optional) Filters the `route_tables` list to contain only public or private route tables. Valid values are 'private' or 'public'. If not set `route_tables` is not filtered.
 
 ## Attribute Reference
 
@@ -38,6 +39,7 @@ In addition to all arguments above, the following attributes are exported:
 * `aviatrix_transit_vpc` - Switch if the VPC created is an Aviatrix Transit VPC or not.
 * `aviatrix_firenet_vpc` - Switch if the VPC created is an Aviatrix FireNet VPC or not.
 * `vpc_id` - ID of the VPC created.
+* `route_tables` - List of AWS route table ids associated with this VPC. Only populated for AWS vpc.
 * `subnets` - List of subnet of the VPC created.
   * `cidr` - Subnet CIDR.
   * `name` - Subnet name.


### PR DESCRIPTION
- Add 2 new attributes to data source vpc
  - `route_tables` List of AWS route table ids associated with this VPC. Only populated for AWS vpc.
  - `route_tables_filter` Filters the route_tables list to contain only public or private route tables. Valid values are 'private' or 'public'. If not set then route_tables are not filtered.
- Updated docs