### PR TITLE
(0014965) Implement support of IKE version in Terraform

### DIFF
--- a/aviatrix/resource_aviatrix_site2cloud.go
+++ b/aviatrix/resource_aviatrix_site2cloud.go
@@ -174,6 +174,13 @@ func resourceAviatrixSite2Cloud() *schema.Resource {
 				Description: "Phase two Encryption. Valid values: '3DES', 'AES-128-CBC', 'AES-192-CBC', " +
 					"'AES-256-CBC', 'AES-128-GCM-64', 'AES-128-GCM-96' and 'AES-128-GCM-128'.",
 			},
+			"enable_ikev2": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Switch to enable IKEv2 for policy based site2cloud.",
+			},
 			"private_route_encryption": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -327,6 +334,14 @@ func resourceAviatrixSite2CloudCreate(d *schema.ResourceData, meta interface{}) 
 		} else {
 			s2c.Phase2Encryption = goaviatrix.Phase2EncryptionDefault
 		}
+	}
+
+	enableIKEv2 := d.Get("enable_ikev2").(bool)
+	if enableIKEv2 {
+		if s2c.TunnelType == "route" {
+			return fmt.Errorf("'enable_ikev2' is only supported for policy based site2cloud creation")
+		}
+		s2c.EnableIKEv2 = "true"
 	}
 
 	privateRouteEncryption := d.Get("private_route_encryption").(bool)
@@ -492,6 +507,10 @@ func resourceAviatrixSite2CloudRead(d *schema.ResourceData, meta interface{}) er
 
 		d.Set("enable_dead_peer_detection", s2c.DeadPeerDetection)
 		d.Set("enable_active_active", s2c.EnableActiveActive)
+
+		if s2c.EnableIKEv2 == "true" {
+			d.Set("enable_ikev2", true)
+		}
 	}
 
 	log.Printf("[TRACE] Reading Aviatrix Site2Cloud %s: %#v", d.Get("connection_name").(string), site2cloud)

--- a/goaviatrix/site2cloud.go
+++ b/goaviatrix/site2cloud.go
@@ -52,6 +52,7 @@ type Site2Cloud struct {
 	Phase2Auth              string   `form:"phase2_auth,omitempty"`
 	Phase2DhGroups          string   `form:"phase2_dh_group,omitempty"`
 	Phase2Encryption        string   `form:"phase2_encryption,omitempty"`
+	EnableIKEv2             string   `form:"enable_ikev2,omitempty"`
 	PrivateRouteEncryption  string   `form:"private_route_encryption,omitempty"`
 	RemoteGwLatitude        float64  `form:"remote_gateway_latitude,omitempty"`
 	RemoteGwLongitude       float64  `form:"remote_gateway_longitude,omitempty"`
@@ -103,6 +104,7 @@ type EditSite2CloudConnDetail struct {
 	SslServerPool           []string      `json:"ssl_server_pool,omitempty"`
 	DeadPeerDetectionConfig string        `json:"dpd_config,omitempty"`
 	EnableActiveActive      string        `json:"active_active_ha,omitempty"`
+	EnableIKEv2             string        `json:"ike_ver,omitempty"`
 }
 
 type Site2CloudConnDetailResp struct {
@@ -160,6 +162,10 @@ func (c *Client) CreateSite2Cloud(site2cloud *Site2Cloud) error {
 
 	if site2cloud.TunnelType == "tcp" {
 		addSite2cloud.Add("ssl_server_pool", site2cloud.SslServerPool)
+	}
+
+	if site2cloud.EnableIKEv2 == "true" {
+		addSite2cloud.Add("enable_ikev2", "true")
 	}
 
 	if site2cloud.PrivateRouteEncryption == "true" {
@@ -341,6 +347,9 @@ func (c *Client) GetSite2CloudConnDetail(site2cloud *Site2Cloud) (*Site2Cloud, e
 			site2cloud.EnableActiveActive = false
 		}
 
+		if s2cConnDetail.EnableIKEv2 == "2" {
+			site2cloud.EnableIKEv2 = "true"
+		}
 		return site2cloud, nil
 	}
 

--- a/website/docs/r/aviatrix_site2cloud.html.markdown
+++ b/website/docs/r/aviatrix_site2cloud.html.markdown
@@ -71,6 +71,7 @@ The following arguments are supported:
 * `ssl_server_pool` - (Optional) Specify ssl_server_pool for tunnel_type "tcp". Default value: "192.168.44.0/24". **NOTE: Only supported for 'tcp' tunnel type. Please see notes [here](#ssl_server_pool-1) for more information.**
 * `enable_dead_peer_detection` - (Optional) Enable/disable Deed Peer Detection for an existing site2cloud connection. Default value: true. **NOTE: Please see notes [here](#enable_dead_peer_detection-1) in regards to any deltas found in your state with the addition of this argument in R1.9**
 * `enable_active_active` - (Optional) Enable/disable active active HA for an existing site2cloud connection. Valid values: true, false. Default value: false.
+* `enable_ikev2` - (Optional) Switch to enable IKEv2 for policy based site2cloud.
 
 ## Attribute Reference
 

--- a/website/docs/r/aviatrix_site2cloud.html.markdown
+++ b/website/docs/r/aviatrix_site2cloud.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 * `ssl_server_pool` - (Optional) Specify ssl_server_pool for tunnel_type "tcp". Default value: "192.168.44.0/24". **NOTE: Only supported for 'tcp' tunnel type. Please see notes [here](#ssl_server_pool-1) for more information.**
 * `enable_dead_peer_detection` - (Optional) Enable/disable Deed Peer Detection for an existing site2cloud connection. Default value: true. **NOTE: Please see notes [here](#enable_dead_peer_detection-1) in regards to any deltas found in your state with the addition of this argument in R1.9**
 * `enable_active_active` - (Optional) Enable/disable active active HA for an existing site2cloud connection. Valid values: true, false. Default value: false.
-* `enable_ikev2` - (Optional) Switch to enable IKEv2 for policy based site2cloud.
+* `enable_ikev2` - (Optional) Switch to enable IKEv2 for policy based site2cloud. Valid values: true, false. Default value: false.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Add a parameter called "enable_ikev2" to support IKE version 2.