### PR TITLE
(14155) Fix ha subnet import for gcp gateways

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -236,7 +236,7 @@ func resourceAviatrixGateway() *schema.Resource {
 			"peering_ha_subnet": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "",
+				Computed: true,
 				Description: "Public Subnet Information while creating Peering HA Gateway, only subnet is accepted. " +
 					"Required to create peering ha gateway if cloud_type = 1 or 8 (AWS or AZURE). Optional if cloud_type = 4 (GCP)",
 			},
@@ -767,8 +767,10 @@ func resourceAviatrixGatewayReadIfRequired(d *schema.ResourceData, meta interfac
 func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 
+	var isImport bool
 	gwName := d.Get("gw_name").(string)
 	if gwName == "" {
+		isImport = true
 		id := d.Id()
 		log.Printf("[DEBUG] Looks like an import, no gateway name received. Import Id is %s", id)
 		d.Set("gw_name", id)
@@ -1016,7 +1018,7 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 				} else if gwHaGw.CloudType == goaviatrix.GCP {
 					d.Set("peering_ha_zone", gwHaGw.GatewayZone)
 					// only set peering_ha_subnet if the user has explicitly set it.
-					if peeringHaSubnet != "" {
+					if peeringHaSubnet != "" || isImport {
 						d.Set("peering_ha_subnet", gwHaGw.VpcNet)
 					}
 				}

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -84,7 +84,7 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 			"ha_subnet": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
+				Computed:    true,
 				Description: "HA Subnet. Required if enabling HA for AWS/AZURE. Optional if enabling HA for GCP.",
 			},
 			"ha_zone": {
@@ -545,8 +545,10 @@ func resourceAviatrixSpokeGatewayReadIfRequired(d *schema.ResourceData, meta int
 func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 
+	var isImport bool
 	gwName := d.Get("gw_name").(string)
 	if gwName == "" {
+		isImport = true
 		id := d.Id()
 		log.Printf("[DEBUG] Looks like an import, no gateway name received. Import Id is %s", id)
 		d.Set("gw_name", id)
@@ -742,7 +744,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 			d.Set("ha_zone", "")
 		} else if haGw.CloudType == goaviatrix.GCP {
 			d.Set("ha_zone", haGw.GatewayZone)
-			if d.Get("ha_subnet") != "" {
+			if d.Get("ha_subnet") != "" || isImport {
 				d.Set("ha_subnet", haGw.VpcNet)
 			} else {
 				d.Set("ha_subnet", "")

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -81,7 +81,7 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 			"ha_subnet": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "",
+				Computed: true,
 				Description: "HA Subnet. Required for enabling HA for AWS/AZURE gateway. " +
 					"Optional for enabling HA for GCP gateway.",
 			},
@@ -674,8 +674,10 @@ func resourceAviatrixTransitGatewayReadIfRequired(d *schema.ResourceData, meta i
 func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 
+	var isImport bool
 	gwName := d.Get("gw_name").(string)
 	if gwName == "" {
+		isImport = true
 		id := d.Id()
 		log.Printf("[DEBUG] Looks like an import, no gateway name received. Import Id is %s", id)
 		d.Set("gw_name", id)
@@ -914,7 +916,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 			d.Set("ha_zone", "")
 		} else if haGw.CloudType == goaviatrix.GCP {
 			d.Set("ha_zone", haGw.GatewayZone)
-			if d.Get("ha_subnet") != "" {
+			if d.Get("ha_subnet") != "" || isImport {
 				d.Set("ha_subnet", haGw.VpcNet)
 			}
 		}


### PR DESCRIPTION
- Changed ha subnet attributes to be `Computed`, this meant removing the previous `Default` values, however, since the previous `Default` values were all empty string this doesn't actually change the behavior since any string attribute that is unset automatically is set to the empty string anyway.
- When the resource is being read for an import we will set the ha_subnet value