### PR TITLE
(14155) Fix gateway ha_subnet deletion issue

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -236,7 +236,6 @@ func resourceAviatrixGateway() *schema.Resource {
 			"peering_ha_subnet": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 				Description: "Public Subnet Information while creating Peering HA Gateway, only subnet is accepted. " +
 					"Required to create peering ha gateway if cloud_type = 1 or 8 (AWS or AZURE). Optional if cloud_type = 4 (GCP)",
 			},

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -84,7 +84,6 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 			"ha_subnet": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 				Description: "HA Subnet. Required if enabling HA for AWS/AZURE. Optional if enabling HA for GCP.",
 			},
 			"ha_zone": {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -81,7 +81,6 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 			"ha_subnet": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 				Description: "HA Subnet. Required for enabling HA for AWS/AZURE gateway. " +
 					"Optional for enabling HA for GCP gateway.",
 			},

--- a/website/docs/r/aviatrix_gateway.html.markdown
+++ b/website/docs/r/aviatrix_gateway.html.markdown
@@ -267,3 +267,6 @@ If you are using/upgraded to Aviatrix Terraform Provider R2.10+, and a gateway w
 
 ### dnat_policy
 If you are using/upgraded to Aviatrix Terraform Provider R2.10+, and a gateway with `dnat_policy` was originally created with a provider version <R2.10, you must do a ‘terraform refresh’ to remove attribute’s value from the state. In addition, you must transfer its corresponding values to the **aviatrix_gateway_dnat** resource in your `.tf` file and perform a 'terraform import' to rectify the state file.
+
+### peering_ha_subnet
+If you are using Aviatrix Terraform Provider R2.15+, and import a Google Cloud gateway with HA enabled then you must set a value for `peering_ha_subnet` in your Terraform config.

--- a/website/docs/r/aviatrix_spoke_gateway.html.markdown
+++ b/website/docs/r/aviatrix_spoke_gateway.html.markdown
@@ -176,3 +176,6 @@ If you are using/upgraded to Aviatrix Terraform Provider R2.10+, and a spoke gat
 
 ### dnat_policy
 If you are using/upgraded to Aviatrix Terraform Provider R2.10+, and a spoke gateway with `dnat_policy` was originally created with a provider version <R2.10, you must do a ‘terraform refresh’ to remove attribute’s value from the state. In addition, you must its value to its corresponding **aviatrix_gateway_dnat** resource in your `.tf` file and perform a 'terraform import' to rectify the state file.
+
+### ha_subnet
+If you are using Aviatrix Terraform Provider R2.15+, and import a Google Cloud spoke gateway with HA enabled then you must set a value for `ha_subnet` in your Terraform config.

--- a/website/docs/r/aviatrix_transit_gateway.html.markdown
+++ b/website/docs/r/aviatrix_transit_gateway.html.markdown
@@ -170,3 +170,6 @@ If `insane_mode` is enabled, you must specify a valid /26 CIDR segment of the VP
 
 ### enable_snat
 If you are using/upgraded to Aviatrix Terraform Provider R2.10+, and a transit gateway with `enable_snat` set to true was originally created with a provider version <R2.10, you must do a ‘terraform refresh’ to update and apply the attribute’s value into the state. In addition, you must also change this attribute to `single_ip_snat` in your `.tf` file.
+
+### ha_subnet
+If you are using Aviatrix Terraform Provider R2.15+, and import a Google Cloud transit gateway with HA enabled then you must set a value for `ha_subnet` in your Terraform config.


### PR DESCRIPTION
- Remove Computed from ha_subnet attributes, this caused an issue where we could not remove the ha_subnet value from the state when we wanted to delete the HA gw
- Update docs to tell users about the import issue, where we will always set the ha_subnet value when importing since we have no way to tell if the gateway was created with an ha_subnet or not.