### PR TITLE
(14894) Add excluded network CIDRs and tgw connections to tgw peering

### DIFF
--- a/website/docs/r/aviatrix_transit_gateway_peering.html.markdown
+++ b/website/docs/r/aviatrix_transit_gateway_peering.html.markdown
@@ -14,8 +14,12 @@ The **aviatrix_transit_gateway_peering** resource allows the creation and manage
 ```hcl
 # Create an Aviatrix Transit Gateway Peering
 resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering" {
-  transit_gateway_name1 = "transit-Gw1"
-  transit_gateway_name2 = "transit-Gw2"
+  transit_gateway_name1             = "transit-Gw1"
+  transit_gateway_name2             = "transit-Gw2"
+  gateway1_excluded_network_cidrs   = ["10.0.0.48/28"] // Optional
+  gateway2_excluded_network_cidrs   = ["10.0.0.48/28"] // Optional
+  gateway1_excluded_tgw_connections = ["vpn_connection_a"] // Optional
+  gateway2_excluded_tgw_connections = ["vpn_connection_b"] // Optional
 }
 ```
 
@@ -26,6 +30,12 @@ The following arguments are supported:
 ### Required
 * `transit_gateway_name1` - (Required) The first transit gateway name to make a peer pair.
 * `transit_gateway_name2` - (Required) The second transit gateway name to make a peer pair.
+
+### Optional
+* `gateway1_excluded_network_cidrs` - (Optional) List of excluded network CIDRs for the first transit gateway.
+* `gateway2_excluded_network_cidrs` - (Optional) List of excluded network CIDRs for the second transit gateway.
+* `gateway1_excluded_tgw_connections` - (Optional) List of excluded TGW connections for the first transit gateway.
+* `gateway2_excluded_tgw_connections` - (Optional) List of excluded TGW connections for the second transit gateway.
 
 ## Import
 


### PR DESCRIPTION
- Add 4 new optional attributes to `aviatrix_transit_gateway_peering` resource
  - `gateway1_excluded_network_cidrs`
  - `gateway2_excluded_network_cidrs`
  - `gateway1_excluded_tgw_connections`
  - `gateway2_excluded_tgw_connections`
- Updated documentation