### PR TITLE
(13388) Remove 'commit' option from branch_router_tag resource

### DIFF
--- a/aviatrix/resource_aviatrix_branch_router_tag.go
+++ b/aviatrix/resource_aviatrix_branch_router_tag.go
@@ -45,11 +45,6 @@ func resourceAviatrixBranchRouterTag() *schema.Resource {
 				},
 				Description: "List of branch names to attach to this tag.",
 			},
-			"commit": {
-				Type:        schema.TypeBool,
-				Required:    true,
-				Description: "Whether to commit the config to the branches.",
-			},
 		},
 	}
 }
@@ -58,7 +53,6 @@ func marshalBranchRouterTagInput(d *schema.ResourceData) *goaviatrix.BranchRoute
 	brt := &goaviatrix.BranchRouterTag{
 		Name:   d.Get("name").(string),
 		Config: d.Get("config").(string),
-		Commit: d.Get("commit").(bool),
 	}
 
 	var brs []string
@@ -134,11 +128,9 @@ func resourceAviatrixBranchRouterTagUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	// User had changed 'commit' to true, commit the tag
-	if d.HasChange("commit") && d.Get("commit").(bool) {
-		if err := client.CommitBranchRouterTag(brt); err != nil {
-			return err
-		}
+	// Commit any changes
+	if err := client.CommitBranchRouterTag(brt); err != nil {
+		return err
 	}
 
 	return nil

--- a/aviatrix/resource_aviatrix_branch_router_tag_test.go
+++ b/aviatrix/resource_aviatrix_branch_router_tag_test.go
@@ -22,6 +22,7 @@ func TestAccAviatrixBranchRouterTag_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccAviatrixBranchRouterTagtPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBranchRouterTagDestroy,
@@ -33,10 +34,9 @@ func TestAccAviatrixBranchRouterTag_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"commit"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -44,35 +44,14 @@ func TestAccAviatrixBranchRouterTag_basic(t *testing.T) {
 
 func testAccBranchRouterTagBasic(rName string) string {
 	return fmt.Sprintf(`
-resource "aviatrix_branch_router" "test_branch_router_a" {
-	name                            = "branchrouter-A%[1]s"
-	public_ip                       = "18.144.102.14"
-	username                        = "ec2-user"
-	password                        = "testing"
-	wan_primary_interface           = "GigabitEthernet1"
-    wan_primary_interface_public_ip = "18.144.102.14"
-	zip_code                        = "19232"
-}
-
-resource "aviatrix_branch_router" "test_branch_router_b" {
-	name                            = "branchrouter-B%[1]s"
-	public_ip                       = "18.144.102.14"
-	username                        = "ec2-user"
-	password                        = "testing"
-	wan_primary_interface           = "GigabitEthernet1"
-    wan_primary_interface_public_ip = "18.144.102.14"
-	zip_code                        = "19232"
-}
-
 resource "aviatrix_branch_router_tag" "test_branch_router_tag" {
-	name                = "branchroutertag-%[1]s"
+	name                = "branchroutertag-%s"
 	config              = <<EOD
 hostname myrouter
 EOD
-	branch_router_names = [aviatrix_branch_router.test_branch_router_a.name, aviatrix_branch_router.test_branch_router_b.name]
-	commit              = false
+	branch_router_names = ["%s"]
 }
-`, rName)
+`, rName, os.Getenv("BRANCH_ROUTER_NAME"))
 }
 
 func testAccCheckBranchRouterTagExists(n string) resource.TestCheckFunc {
@@ -120,4 +99,10 @@ func testAccCheckBranchRouterTagDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAviatrixBranchRouterTagtPreCheck(t *testing.T) {
+	if os.Getenv("BRANCH_ROUTER_NAME") == "" {
+		t.Fatal("BRANCH_ROUTER_NAME must be set for aviatrix_branch_router_tag acceptance test.")
+	}
 }

--- a/goaviatrix/branch_router_tag.go
+++ b/goaviatrix/branch_router_tag.go
@@ -12,7 +12,6 @@ type BranchRouterTag struct {
 	Config         string `form:"custom_cfg,omitempty"`
 	Branches       []string
 	BranchesString string `form:"include_branch_list,omitempty"`
-	Commit         bool
 	CID            string `form:"CID"`
 	Action         string `form:"action"`
 }
@@ -56,10 +55,7 @@ func (c *Client) CreateBranchRouterTag(brt *BranchRouterTag) error {
 		return err
 	}
 
-	// Commit the tag config to the branches if 'commit' == true
-	if !brt.Commit {
-		return nil
-	}
+	// Commit the tag config to the branches
 	if err := c.CommitBranchRouterTag(brt); err != nil {
 		return err
 	}

--- a/website/docs/r/aviatrix_branch_router_tag.html.markdown
+++ b/website/docs/r/aviatrix_branch_router_tag.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 The **aviatrix_branch_router_tag** resource allows the creation and management of branch router config tags.
 
+~> **NOTE:** Creating this resource will automatically commit the config to the specified branch routers.
+
 ## Example Usage
 
 ```hcl
@@ -19,7 +21,6 @@ resource "aviatrix_branch_router_tag" "test_branch_router_tag" {
 hostname myrouter
 EOT
   branch_router_names = [aviatrix_branch_router.test_branch_router.name]
-  commit              = true
 }
 ```
 
@@ -31,7 +32,6 @@ The following arguments are supported:
 * `name` - (Required) Name of the tag.
 * `config` - (Required) Config to apply to branches that are attached to the tag.
 * `branch_router_names` - (Required) List of branch names to attach to this tag.
-* `commit` - (Required) Whether to commit the config to the attached branches. Valid values are `true` or `false`.
 
 ## Import
 


### PR DESCRIPTION
- Remove 'commit' option for branch_router_tag resource. Instead we will always commit configs to branch routers