### PR TITLE
(13388) Separate interface configuration from branch router resource

### DIFF
--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -53,6 +53,7 @@ func Provider() terraform.ResourceProvider {
 			"aviatrix_branch_router":                        resourceAviatrixBranchRouter(),
 			"aviatrix_branch_router_aws_tgw_attachment":     resourceAviatrixBranchRouterAwsTgwAttachment(),
 			"aviatrix_branch_router_avx_tgw_attachment":     resourceAviatrixBranchRouterAvxTgwAttachment(),
+			"aviatrix_branch_router_interface_config":       resourceAviatrixBranchRouterInterfaceConfig(),
 			"aviatrix_branch_router_tag":                    resourceAviatrixBranchRouterTag(),
 			"aviatrix_branch_router_virtual_wan_attachment": resourceAviatrixBranchRouterVirtualWanAttachment(),
 			"aviatrix_controller_config":                    resourceAviatrixControllerConfig(),

--- a/aviatrix/resource_aviatrix_branch_router.go
+++ b/aviatrix/resource_aviatrix_branch_router.go
@@ -54,28 +54,6 @@ func resourceAviatrixBranchRouter() *schema.Resource {
 					"This attribute can also be set via environment variable 'AVIATRIX_BRANCH_ROUTER_PASSWORD'. " +
 					"If both are set the value in the config file will be used.",
 			},
-			"wan_primary_interface": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Primary WAN interface of the branch router. For example, 'GigabitEthernet1'.",
-			},
-			"wan_primary_interface_public_ip": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.IsIPAddress,
-				Description:  "Primary WAN interface public IP address.",
-			},
-			"wan_backup_interface": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Backup WAN interface of the branch router. For example, 'GigabitEthernet2'.",
-			},
-			"wan_backup_interface_public_ip": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.IsIPAddress,
-				Description:  "Backup WAN interface public IP address.",
-			},
 			"host_os": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -132,25 +110,21 @@ func resourceAviatrixBranchRouter() *schema.Resource {
 // marshalBranchRouterInput marshals the ResourceData into a BranchRouter struct.
 func marshalBranchRouterInput(d *schema.ResourceData) *goaviatrix.BranchRouter {
 	return &goaviatrix.BranchRouter{
-		Name:               d.Get("name").(string),
-		PublicIP:           d.Get("public_ip").(string),
-		Username:           d.Get("username").(string),
-		KeyFile:            d.Get("key_file").(string),
-		Password:           d.Get("password").(string),
-		PrimaryInterface:   d.Get("wan_primary_interface").(string),
-		PrimaryInterfaceIP: d.Get("wan_primary_interface_public_ip").(string),
-		BackupInterface:    d.Get("wan_backup_interface").(string),
-		BackupInterfaceIP:  d.Get("wan_backup_interface_public_ip").(string),
-		HostOS:             d.Get("host_os").(string),
-		SshPort:            d.Get("ssh_port").(int),
-		SshPortStr:         strconv.Itoa(d.Get("ssh_port").(int)),
-		Address1:           d.Get("address_1").(string),
-		Address2:           d.Get("address_2").(string),
-		City:               d.Get("city").(string),
-		State:              d.Get("state").(string),
-		Country:            d.Get("country").(string),
-		ZipCode:            d.Get("zip_code").(string),
-		Description:        d.Get("description").(string),
+		Name:        d.Get("name").(string),
+		PublicIP:    d.Get("public_ip").(string),
+		Username:    d.Get("username").(string),
+		KeyFile:     d.Get("key_file").(string),
+		Password:    d.Get("password").(string),
+		HostOS:      d.Get("host_os").(string),
+		SshPort:     d.Get("ssh_port").(int),
+		SshPortStr:  strconv.Itoa(d.Get("ssh_port").(int)),
+		Address1:    d.Get("address_1").(string),
+		Address2:    d.Get("address_2").(string),
+		City:        d.Get("city").(string),
+		State:       d.Get("state").(string),
+		Country:     d.Get("country").(string),
+		ZipCode:     d.Get("zip_code").(string),
+		Description: d.Get("description").(string),
 	}
 }
 
@@ -160,10 +134,6 @@ func resourceAviatrixBranchRouterCreate(d *schema.ResourceData, meta interface{}
 	br := marshalBranchRouterInput(d)
 
 	if err := client.CreateBranchRouter(br); err != nil {
-		return err
-	}
-
-	if err := client.ConfigureBranchRouterInterfaces(br); err != nil {
 		return err
 	}
 
@@ -198,10 +168,6 @@ func resourceAviatrixBranchRouterRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("name", br.Name)
 	d.Set("public_ip", br.PublicIP)
 	d.Set("username", br.Username)
-	d.Set("wan_primary_interface", br.PrimaryInterface)
-	d.Set("wan_primary_interface_public_ip", br.PrimaryInterfaceIP)
-	d.Set("wan_backup_interface", br.BackupInterface)
-	d.Set("wan_backup_interface_public_ip", br.BackupInterfaceIP)
 	d.Set("host_os", br.HostOS)
 	d.Set("ssh_port", br.SshPort)
 	d.Set("address_1", br.Address1)
@@ -223,14 +189,6 @@ func resourceAviatrixBranchRouterUpdate(d *schema.ResourceData, meta interface{}
 
 	if err := client.UpdateBranchRouter(br); err != nil {
 		return err
-	}
-
-	primaryInterfaceChanged := d.HasChange("wan_primary_interface") || d.HasChange("wan_primary_interface_public_ip")
-	backupInterfaceChanged := d.HasChange("wan_backup_interface") || d.HasChange("wan_backup_interface_public_ip")
-	if primaryInterfaceChanged || backupInterfaceChanged {
-		if err := client.ConfigureBranchRouterInterfaces(br); err != nil {
-			return err
-		}
 	}
 
 	d.SetId(br.Name)

--- a/aviatrix/resource_aviatrix_branch_router_interface_config.go
+++ b/aviatrix/resource_aviatrix_branch_router_interface_config.go
@@ -1,0 +1,111 @@
+package aviatrix
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
+)
+
+func resourceAviatrixBranchRouterInterfaceConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAviatrixBranchRouterInterfaceConfigCreate,
+		Read:   resourceAviatrixBranchRouterInterfaceConfigRead,
+		Update: resourceAviatrixBranchRouterInterfaceConfigUpdate,
+		Delete: resourceAviatrixBranchRouterInterfaceConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"branch_router_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of branch router.",
+			},
+			"wan_primary_interface": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Primary WAN interface of the branch router. For example, 'GigabitEthernet1'.",
+			},
+			"wan_primary_interface_public_ip": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsIPAddress,
+				Description:  "Primary WAN interface public IP address.",
+			},
+		},
+	}
+}
+
+func marshalBranchRouterInterfaceConfigInput(d *schema.ResourceData) *goaviatrix.BranchRouterInterfaceConfig {
+	return &goaviatrix.BranchRouterInterfaceConfig{
+		BranchName:         d.Get("branch_router_name").(string),
+		PrimaryInterface:   d.Get("wan_primary_interface").(string),
+		PrimaryInterfaceIP: d.Get("wan_primary_interface_public_ip").(string),
+	}
+}
+
+func resourceAviatrixBranchRouterInterfaceConfigCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+
+	config := marshalBranchRouterInterfaceConfigInput(d)
+
+	if err := client.ConfigureBranchRouterInterfaces(config); err != nil {
+		return err
+	}
+
+	d.SetId(config.BranchName)
+	return nil
+}
+
+func resourceAviatrixBranchRouterInterfaceConfigRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+
+	name := d.Get("branch_router_name").(string)
+	if name == "" {
+		id := d.Id()
+		log.Printf("[DEBUG] Looks like an import, no branch_router_interface_config branch_router_name received. Import Id is %s", id)
+		d.SetId(id)
+		name = id
+	}
+
+	br, err := client.GetBranchRouter(&goaviatrix.BranchRouter{Name: name})
+	if err == goaviatrix.ErrNotFound {
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("could not find branch_router_interface_config %s: %v", name, err)
+	}
+
+	d.Set("branch_router_name", name)
+	d.Set("wan_primary_interface", br.PrimaryInterface)
+	d.Set("wan_primary_interface_public_ip", br.PrimaryInterfaceIP)
+
+	d.SetId(name)
+	return nil
+}
+
+func resourceAviatrixBranchRouterInterfaceConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+
+	config := marshalBranchRouterInterfaceConfigInput(d)
+
+	if err := client.ConfigureBranchRouterInterfaces(config); err != nil {
+		return err
+	}
+
+	d.SetId(config.BranchName)
+	return nil
+}
+
+func resourceAviatrixBranchRouterInterfaceConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	// This is intentionally left empty.
+	// There is no way to unconfigure/delete the WAN interface of a branch router.
+	// Due to backend design the ability to unconfigure/delete can not be added.
+	return nil
+}

--- a/aviatrix/resource_aviatrix_branch_router_interface_config_test.go
+++ b/aviatrix/resource_aviatrix_branch_router_interface_config_test.go
@@ -1,0 +1,104 @@
+package aviatrix
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
+)
+
+func TestAccAviatrixBranchRouterInterfaceConfig_basic(t *testing.T) {
+	if os.Getenv("SKIP_BRANCH_ROUTER_INTERFACE_CONFIG") == "yes" {
+		t.Skip("Skipping Branch Router test as SKIP_BRANCH_ROUTER_INTERFACE_CONFIG is set")
+	}
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_branch_router_interface_config.test_branch_router_interface_config"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			branchRouterPreCheck(t)
+			branchRouterInterfaceConfigPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBranchRouterInterfaceConfigBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBranchRouterInterfaceConfigExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccBranchRouterInterfaceConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_branch_router" "test_branch_router" {
+	name        = "branchrouter-%s"
+	public_ip   = "%[2]s"
+	username    = "ec2-user"
+	key_file    = "%[3]s"
+	host_os     = "ios"
+	ssh_port    = 22
+	address_1   = "2901 Tasman Dr"
+	address_2   = "Suite #104"
+	city        = "Santa Clara"
+	state       = "CA"
+	zip_code    = "12323"
+	description = "Test branch router."
+}
+
+resource "aviatrix_branch_router_interface_config" "test_branch_router_interface_config" {
+	branch_router_name              = aviatrix_branch_router.test_branch_router.name
+	wan_primary_interface           = "%[4]s"
+	wan_primary_interface_public_ip = "%[2]s"
+}
+`, rName, os.Getenv("BRANCH_ROUTER_PUBLIC_IP"), os.Getenv("BRANCH_ROUTER_KEY_FILE_PATH"), os.Getenv("BRANCH_ROUTER_PRIMARY_INTERFACE"))
+}
+
+func testAccCheckBranchRouterInterfaceConfigExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("branch_router_interface_config Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no branch_router_interface_config ID is set")
+		}
+
+		client := testAccProvider.Meta().(*goaviatrix.Client)
+
+		br := &goaviatrix.BranchRouter{Name: rs.Primary.Attributes["branch_router_name"]}
+
+		br, err := client.GetBranchRouter(br)
+		if err != nil {
+			return err
+		}
+
+		if br.Name != rs.Primary.ID ||
+			br.PrimaryInterface != rs.Primary.Attributes["wan_primary_interface"] ||
+			br.PrimaryInterfaceIP != rs.Primary.Attributes["wan_primary_interface_public_ip"] {
+			return fmt.Errorf("branch_router_interface_config not found")
+		}
+
+		return nil
+	}
+}
+
+func branchRouterInterfaceConfigPreCheck(t *testing.T) {
+	if os.Getenv("BRANCH_ROUTER_PRIMARY_INTERFACE") == "" {
+		t.Fatal("environment variable BRANCH_ROUTER_PRIMARY_INTERFACE must be set for " +
+			"branch_router_interface_config acceptance test")
+	}
+}

--- a/aviatrix/resource_aviatrix_branch_router_test.go
+++ b/aviatrix/resource_aviatrix_branch_router_test.go
@@ -22,6 +22,7 @@ func TestAccAviatrixBranchRouter_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			branchRouterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBranchRouterDestroy,
@@ -45,22 +46,20 @@ func TestAccAviatrixBranchRouter_basic(t *testing.T) {
 func testAccBranchRouterBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "aviatrix_branch_router" "test_branch_router" {
-	name                            = "branchrouter-%s"
-	public_ip                       = "18.144.102.14"
-	username                        = "ec2-user"
-	password                        = "testing"
-	host_os                         = "ios"
-	wan_primary_interface           = "GigabitEthernet1"
-    wan_primary_interface_public_ip = "18.144.102.14"
-	ssh_port                        = 22
-	address_1                       = "2901 Tasman Dr"
-	address_2                       = "Suite #104"
-	city                            = "Santa Clara"
-	state                           = "CA"
-	zip_code                        = "12323"
-	description                     = "Test branch router."
+	name        = "branchrouter-%s"
+	public_ip   = "%s"
+	username    = "ec2-user"
+	key_file    = "%s"
+	host_os     = "ios"
+	ssh_port    = 22
+	address_1   = "2901 Tasman Dr"
+	address_2   = "Suite #104"
+	city        = "Santa Clara"
+	state       = "CA"
+	zip_code    = "12323"
+	description = "Test branch router."
 }
-`, rName)
+`, rName, os.Getenv("BRANCH_ROUTER_PUBLIC_IP"), os.Getenv("BRANCH_ROUTER_KEY_FILE_PATH"))
 }
 
 func testAccCheckBranchRouterExists(n string) resource.TestCheckFunc {
@@ -108,4 +107,15 @@ func testAccCheckBranchRouterDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func branchRouterPreCheck(t *testing.T) {
+	if os.Getenv("BRANCH_ROUTER_PUBLIC_IP") == "" {
+		t.Fatal("environment variable BRANCH_ROUTER_PUBLIC_IP must be set for branch_router acceptance test")
+	}
+
+	if os.Getenv("BRANCH_ROUTER_KEY_FILE_PATH") == "" {
+		t.Fatal("environment variable BRANCH_ROUTER_KEY_FILE_PATH must be set for " +
+			"branch_router_interface_config acceptance test")
+	}
 }

--- a/test-infra/README_accep_test.md
+++ b/test-infra/README_accep_test.md
@@ -35,7 +35,8 @@ Passing an environment value of "yes" to the skip parameter allows you to skip t
 | aviatrix_azure_peer                  | SKIP_AZURE_PEER                    | aviatrix_account + AZURE_VNET_ID, AZURE_VNET_ID2, AZURE_REGION, AZURE_REGION2  |
 | aviatrix_azure_spoke_native_peering  | SKIP_AZURE_SPOKE_NATIVE_PEERING    | aviatrix_account + AZURE_VNET_ID, AZURE_VNET_ID2, AZURE_REGION, AZURE_REGION2  |
 | aviatrix_aws_tgw_vpn_conn            | SKIP_AWS_TGW_VPN_CONN              | aviatrix_aws_tgw                                                               |
-| aviatrix_branch_router               | SKIP_BRANCH_ROUTER                 | aviatrix_account                                                               |
+| aviatrix_branch_router               | SKIP_BRANCH_ROUTER                 | BRANCH_ROUTER_PUBLIC_IP, BRANCH_ROUTER_KEY_FILE_PATH                           |
+| aviatrix_branch_router_interface_config | SKIP_BRANCH_ROUTER_INTERFACE_CONFIG | aviatrix_branch_router, BRANCH_ROUTER_PRIMARY_INTERFACE                    |
 | aviatrix_branch_router_avx_tgw_attachment | SKIP_BRANCH_ROUTER_AVX_TGW_ATTACHMENT | BRANCH_ROUTER_NAME, TRANSIT_GATEWAY_NAME                               |
 | aviatrix_branch_router_aws_tgw_attachment | SKIP_BRANCH_ROUTER_AWS_TGW_ATTACHMENT | BRANCH_ROUTER_NAME, AWS_TGW_NAME                                       |
 | aviatrix_branch_router_tag           | SKIP_BRANCH_ROUTER_TAG             | aviatrix_account                                                               |

--- a/website/docs/r/aviatrix_branch_router.html.markdown
+++ b/website/docs/r/aviatrix_branch_router.html.markdown
@@ -9,29 +9,27 @@ description: |-
 
 The **aviatrix_branch_router** resource allows the creation and management of branch router entries for CloudWAN.
 
+~> **NOTE:** Before this branch router can be attached to any Aviatrix Transit Gateway, AWS TGW or Azure Virtual WAN you must configure its WAN interface and IP via the `aviatrix_branch_router_interface_config` resource.
+
 ## Example Usage
 
 ```hcl
 # Create an Aviatrix Branch Router entry with private key authentication
 resource "aviatrix_branch_router" "test_branch_router" {
-  name                            = "test-branch-router"
-  public_ip                       = "58.151.114.231"
-  username                        = "ec2-user"
-  key_file                        = "/path/to/key_file.pem"
-  wan_primary_interface           = "GigabitEthernet1"
-  wan_primary_interface_public_ip = "58.151.114.231"
+  name      = "test-branch-router"
+  public_ip = "58.151.114.231"
+  username  = "ec2-user"
+  key_file  = "/path/to/key_file.pem"
 }
 ```
 
 ```hcl
 # Create an Aviatrix Branch Router entry with password authentication
 resource "aviatrix_branch_router" "test_branch_router" {
-  name                            = "test-branch-router"
-  public_ip                       = "58.151.114.231"
-  username                        = "ec2-user"
-  password                        = "secret"
-  wan_primary_interface           = "GigabitEthernet1"
-  wan_primary_interface_public_ip = "58.151.114.231"
+  name      = "test-branch-router"
+  public_ip = "58.151.114.231"
+  username  = "ec2-user"
+  password  = "secret"
 }
 ```
 
@@ -45,12 +43,8 @@ The following arguments are supported:
 * `username` - (Required) Username for SSH into the router.
 * `key_file` - (Optional) Path to private key file for SSH into the router. Either `key_file` or `password` must be set to create a branch router successfully.
 * `password` - (Optional) Password for SSH into the router. Either `key_file` or `password` must be set to create a branch router successfully. This attribute can also be set via environment variable 'AVIATRIX_BRANCH_ROUTER_PASSWORD'. If both are set, the value in the config file will be used.
-* `wan_primary_interface` - (Required) Primary WAN interface of the branch router. For example, 'GigabitEthernet1'.
-* `wan_primary_interface_public_ip` - (Required) Primary WAN interface public IP address.
 
 ### Optional
-* `wan_backup_interface` - (Optional) Backup WAN interface of the branch router. For example, 'GigabitEthernet2'.
-* `wan_backup_interface_public_ip` - (Optional) Backup WAN interface public IP address.
 * `host_os` - (Optional) Router host OS.  Default value is 'ios'. Only valid value is 'ios'.
 * `ssh_port` - (Optional) SSH port for connecting to the router. Default value is 22.
 * `address_1` - (Optional) Address line 1.

--- a/website/docs/r/aviatrix_branch_router_avx_tgw_attachment.html.markdown
+++ b/website/docs/r/aviatrix_branch_router_avx_tgw_attachment.html.markdown
@@ -9,16 +9,20 @@ description: |-
 
 The **aviatrix_branch_router_avx_tgw_attachment** resource allows the creation and management of a branch router and Aviatrix Transit Gateway attachment
 
+~> **NOTE:** Before creating this attachment the branch router must have its WAN interface and IP configured via the `aviatrix_branch_router_interface_config` resource. To avoid attempting to create the attachment before the interface and IP are configured use a `depends_on` meta-argument so that the `aviatrix_branch_router_interface_config` resource is created before the attachment.  
+
 ## Example Usage
 
 ```hcl
 # Create an Aviatrix Branch Router and Transit Gateway attachment
 resource "aviatrix_branch_router_avx_tgw_attachment" "test_branch_router_avx_tgw_attachment" {
-	branch_name               = "branch-router"
-	transit_gateway_name      = "transit-gw"
-	connection_name           = "test-conn"
-	transit_gateway_bgp_asn   = 65000
-	branch_router_bgp_asn     = 65001
+  branch_name             = "branch-router"
+  transit_gateway_name    = "transit-gw"
+  connection_name         = "test-conn"
+  transit_gateway_bgp_asn = 65000
+  branch_router_bgp_asn   = 65001
+
+  depends_on = [aviatrix_branch_router_interface_config.test_branch_router_interface_config]
 }
 ```
 

--- a/website/docs/r/aviatrix_branch_router_aws_tgw_attachment.html.markdown
+++ b/website/docs/r/aviatrix_branch_router_aws_tgw_attachment.html.markdown
@@ -9,16 +9,20 @@ description: |-
 
 The **aviatrix_branch_router_aws_tgw_attachment** resource allows the creation and management of a branch router and AWS TGW attachment
 
+~> **NOTE:** Before creating this attachment the branch router must have its WAN interface and IP configured via the `aviatrix_branch_router_interface_config` resource. To avoid attempting to create the attachment before the interface and IP are configured use a `depends_on` meta-argument so that the `aviatrix_branch_router_interface_config` resource is created before the attachment.
+
 ## Example Usage
 
 ```hcl
 # Create an Aviatrix Branch Router and AWS TGW attachment
 resource "aviatrix_branch_router_aws_tgw_attachment" "test_branch_router_aws_tgw_attachment" {
-	connection_name           = "test-conn"
-	branch_name               = "branch-router"
-	aws_tgw_name              = "tgw-test"
-	branch_router_bgp_asn     = 65001
-	security_domain_name      = "Default_Domain"
+  connection_name       = "test-conn"
+  branch_name           = "branch-router"
+  aws_tgw_name          = "tgw-test"
+  branch_router_bgp_asn = 65001
+  security_domain_name  = "Default_Domain"
+
+  depends_on = [aviatrix_branch_router_interface_config.test_branch_router_interface_config]
 }
 ```
 

--- a/website/docs/r/aviatrix_branch_router_interface_config.html.markdown
+++ b/website/docs/r/aviatrix_branch_router_interface_config.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "aviatrix"
+page_title: "Aviatrix: aviatrix_branch_router_interface_config"
+description: |-
+  Configures primary WAN interface and IP for a branch router.
+---
+
+# aviatrix_branch_router_interface_config
+
+The **aviatrix_branch_router_interface_config** resource allows the configuration of the primary WAN interface and IP for a branch router.
+
+## Example Usage
+
+```hcl
+# Configure the primary WAN interface and IP for a branch router.
+resource "aviatrix_branch_router_interface_config" "test_branch_router_interface_config" {
+  branch_router_name              = "router-name"
+  wan_primary_interface           = "GigabitEthernet1"
+  wan_primary_interface_public_ip = "181.12.43.21"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `branch_router_name` - (Required) Name of the branch router.
+* `wan_primary_interface` - (Required) Name of the WAN Primary Interface.
+* `wan_primary_interface_public_ip` - (Required) IP of the WAN Primary IP.
+
+## Import
+
+**branch_router_interface_config** can be imported using the `branch_router_name`, e.g.
+
+```
+$ terraform import aviatrix_branch_router_interface_config.test branch_router_name
+```

--- a/website/docs/r/aviatrix_branch_router_virtual_wan_attachment.html.markdown
+++ b/website/docs/r/aviatrix_branch_router_virtual_wan_attachment.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 The **aviatrix_branch_router_virtual_wan_attachment** resource allows the creation and management of a branch router and Azure Virtual WAN attachment
 
+~> **NOTE:** Before creating this attachment the branch router must have its WAN interface and IP configured via the `aviatrix_branch_router_interface_config` resource. To avoid attempting to create the attachment before the interface and IP are configured use a `depends_on` meta-argument so that the `aviatrix_branch_router_interface_config` resource is created before the attachment.
+
 ## Example Usage
 
 ```hcl
@@ -20,6 +22,8 @@ resource "aviatrix_branch_router_virtual_wan_attachment" "test_branch_router_vir
   resource_group        = "aviatrix-rg"
   hub_name              = "aviatrix-hub"
   branch_router_bgp_asn = 65001
+
+  depends_on = [aviatrix_branch_router_interface_config.test_branch_router_interface_config]
 }
 ```
 


### PR DESCRIPTION
- Create a new resource `aviatrix_branch_router_interface_config`
- Updated docs to let users know that to use the attachments they must use the interface config resource