### PR TITLE
(13388) Remove branch router HA on transit gateway attachment

### DIFF
--- a/aviatrix/resource_aviatrix_branch_router_transit_gateway_attachment.go
+++ b/aviatrix/resource_aviatrix_branch_router_transit_gateway_attachment.go
@@ -98,13 +98,6 @@ func resourceAviatrixBranchRouterTransitGatewayAttachment() *schema.Resource {
 				Default:     false,
 				Description: "Enable AWS Global Accelerator",
 			},
-			"enable_branch_router_ha": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     false,
-				Description: "Enable Branch Router HA",
-			},
 			"pre_shared_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -124,25 +117,6 @@ func resourceAviatrixBranchRouterTransitGatewayAttachment() *schema.Resource {
 				ForceNew:    true,
 				Description: "Remote tunnel IP",
 			},
-			"backup_pre_shared_key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				ForceNew:    true,
-				Description: "Backup pre-shared Key.",
-			},
-			"backup_local_tunnel_ip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Backup local tunnel IP",
-			},
-			"backup_remote_tunnel_ip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Backup remote tunnel IP",
-			},
 		},
 	}
 }
@@ -161,14 +135,10 @@ func marshalBranchRouterTransitGatewayAttachmentInput(d *schema.ResourceData) *g
 		Phase2Authentication:    d.Get("phase2_authentication").(string),
 		Phase2DHGroups:          strconv.Itoa(d.Get("phase2_dh_groups").(int)),
 		Phase2Encryption:        d.Get("phase2_encryption").(string),
-		EnableBranchRouterHA:    strconv.FormatBool(d.Get("enable_branch_router_ha").(bool)),
 		EnableGlobalAccelerator: strconv.FormatBool(d.Get("enable_global_accelerator").(bool)),
 		PreSharedKey:            d.Get("pre_shared_key").(string),
 		LocalTunnelIP:           d.Get("local_tunnel_ip").(string),
 		RemoteTunnelIP:          d.Get("remote_tunnel_ip").(string),
-		BackupPreSharedKey:      d.Get("backup_pre_shared_key").(string),
-		BackupLocalTunnelIP:     d.Get("backup_local_tunnel_ip").(string),
-		BackupRemoteTunnelIP:    d.Get("backup_remote_tunnel_ip").(string),
 	}
 
 	return brata
@@ -254,23 +224,11 @@ func resourceAviatrixBranchRouterTransitGatewayAttachmentRead(d *schema.Resource
 	}
 	d.Set("enable_global_accelerator", enableGlobalAccelerator)
 
-	enableBranchRouterHA := false
-	if brata.EnableBranchRouterHA == "enabled" {
-		enableBranchRouterHA = true
-	}
-	d.Set("enable_branch_router_ha", enableBranchRouterHA)
-
 	if isImport || d.Get("local_tunnel_ip") != "" {
 		d.Set("local_tunnel_ip", brata.LocalTunnelIP)
 	}
 	if isImport || d.Get("remote_tunnel_ip") != "" {
 		d.Set("remote_tunnel_ip", brata.RemoteTunnelIP)
-	}
-	if isImport || d.Get("backup_local_tunnel_ip") != "" {
-		d.Set("backup_local_tunnel_ip", brata.BackupLocalTunnelIP)
-	}
-	if isImport || d.Get("backup_remote_tunnel_ip") != "" {
-		d.Set("backup_remote_tunnel_ip", brata.BackupRemoteTunnelIP)
 	}
 
 	d.SetId(brata.ConnectionName)

--- a/goaviatrix/branch_router_transit_gateway_attachment.go
+++ b/goaviatrix/branch_router_transit_gateway_attachment.go
@@ -23,13 +23,9 @@ type BranchRouterTransitGatewayAttachment struct {
 	Phase2DHGroups          string `form:"phase2_dh_groups,omitempty"`
 	Phase2Encryption        string `form:"phase2_encryption,omitempty"`
 	EnableGlobalAccelerator string `form:"enable_global_accelerator,omitempty"`
-	EnableBranchRouterHA    string `form:"enable_ha,omitempty"`
 	PreSharedKey            string `form:"pre_shared_key,omitempty"`
 	LocalTunnelIP           string `form:"local_tunnel_ip,omitempty"`
 	RemoteTunnelIP          string `form:"remote_tunnel_ip,omitempty"`
-	BackupPreSharedKey      string `form:"backup_pre_shared_key,omitempty"`
-	BackupLocalTunnelIP     string `form:"backup_local_tunnel_ip,omitempty"`
-	BackupRemoteTunnelIP    string `form:"backup_remote_tunnel_ip,omitempty"`
 	Action                  string `form:"action"`
 	CID                     string `form:"CID"`
 }
@@ -121,11 +117,8 @@ func (c *Client) GetBranchRouterTransitGatewayAttachment(brata *BranchRouterTran
 		Phase2DHGroups:          data.Results.Connections.Algorithm.Phase2DhGroups[0],
 		Phase2Encryption:        data.Results.Connections.Algorithm.Phase2Encrption[0],
 		EnableGlobalAccelerator: strconv.FormatBool(data.Results.Connections.EnableGlobalAccelerator),
-		EnableBranchRouterHA:    data.Results.Connections.HAEnabled,
 		LocalTunnelIP:           data.Results.Connections.BgpLocalIP,
 		RemoteTunnelIP:          data.Results.Connections.BgpRemoteIP,
-		BackupLocalTunnelIP:     data.Results.Connections.BgpBackupLocalIP,
-		BackupRemoteTunnelIP:    data.Results.Connections.BgpBackupRemoteIP,
 	}, nil
 }
 

--- a/website/docs/r/aviatrix_branch_router_transit_gateway_attachment.html.markdown
+++ b/website/docs/r/aviatrix_branch_router_transit_gateway_attachment.html.markdown
@@ -45,13 +45,9 @@ The following arguments are supported:
 * `phase2_dh_groups` - Number of phase 2 Diffie-Hellman groups. Default "14".
 * `phase2_encryption` - Phase 2 encryption algorithm. Default "AES-256-CBC".
 * `enable_global_accelerator` - Boolean enable AWS Global Accelerator. Default "false".
-* `enable_branch_router_ha` - Boolean enable Branch Router HA. Default "false".
 * `pre_shared_key` - Pre-shared Key.
 * `local_tunnel_ip` - Local tunnel IP.
 * `remote_tunnel_ip` - Remote tunnel IP.
-* `backup_pre_shared_key` - Pre-shared Key (Backup).
-* `backup_local_tunnel_ip` - Local tunnel IP (Backup).
-* `backup_remote_tunnel_ip` - Remote tunnel IP (Backup).
 
 ## Import
 


### PR DESCRIPTION
Backend is removing the capability for branch router HA, so removing any HA related attributes from our resources