### PR TITLE
(15672) Add 4 new transit gateway advanced config options

### DIFF
--- a/aviatrix/resource_aviatrix_aws_tgw.go
+++ b/aviatrix/resource_aviatrix_aws_tgw.go
@@ -39,29 +39,10 @@ func resourceAviatrixAWSTgw() *schema.Resource {
 				Description: "Region of cloud provider.",
 			},
 			"aws_side_as_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "BGP Local ASN (Autonomous System Number), Integer between 1-4294967294.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if len(v) > 10 {
-						errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-					} else {
-						sum := int64(0)
-						for _, r := range v {
-							num := int64(r - '0')
-							if num < 0 || num > 9 {
-								errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-								return
-							}
-							sum = sum*10 + num
-						}
-						if sum == 0 || sum > 4294967294 {
-							errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-						}
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "BGP Local ASN (Autonomous System Number), Integer between 1-4294967294.",
+				ValidateFunc: goaviatrix.ValidateASN,
 			},
 			"security_domains": {
 				Type:        schema.TypeList,

--- a/aviatrix/resource_aviatrix_aws_tgw_vpn_conn.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpn_conn.go
@@ -57,30 +57,11 @@ func resourceAviatrixAwsTgwVpnConn() *schema.Resource {
 					"connection; 'static' stands for a static VPN connection. Default value: 'dynamic'.",
 			},
 			"remote_as_number": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "AWS side as a number. Integer between 1-4294967294. Example: '12'. Required for a dynamic VPN connection.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if len(v) > 10 {
-						errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-					} else {
-						sum := int64(0)
-						for _, r := range v {
-							num := int64(r - '0')
-							if num < 0 || num > 9 {
-								errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-								return
-							}
-							sum = sum*10 + num
-						}
-						if sum == 0 || sum > 4294967294 {
-							errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-						}
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "AWS side as a number. Integer between 1-4294967294. Example: '12'. Required for a dynamic VPN connection.",
+				ValidateFunc: goaviatrix.ValidateASN,
 			},
 			"remote_cidr": {
 				Type:        schema.TypeString,

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -59,56 +59,18 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				},
 			},
 			"bgp_local_as_num": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "BGP local ASN (Autonomous System Number). Integer between 1-4294967294.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if len(v) > 10 {
-						errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-					} else {
-						sum := int64(0)
-						for _, r := range v {
-							num := int64(r - '0')
-							if num < 0 || num > 9 {
-								errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-								return
-							}
-							sum = sum*10 + num
-						}
-						if sum == 0 || sum > 4294967294 {
-							errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-						}
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "BGP local ASN (Autonomous System Number). Integer between 1-4294967294.",
+				ValidateFunc: goaviatrix.ValidateASN,
 			},
 			"bgp_remote_as_num": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "BGP remote ASN (Autonomous System Number). Integer between 1-4294967294.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if len(v) > 10 {
-						errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-					} else {
-						sum := int64(0)
-						for _, r := range v {
-							num := int64(r - '0')
-							if num < 0 || num > 9 {
-								errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-								return
-							}
-							sum = sum*10 + num
-						}
-						if sum == 0 || sum > 4294967294 {
-							errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-						}
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "BGP remote ASN (Autonomous System Number). Integer between 1-4294967294.",
+				ValidateFunc: goaviatrix.ValidateASN,
 			},
 			"remote_subnet": {
 				Type:        schema.TypeString,
@@ -205,31 +167,12 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Description: "Backup remote gateway IP.",
 			},
 			"backup_bgp_remote_as_num": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				ForceNew:    true,
-				Description: "Backup BGP remote ASN (Autonomous System Number). Integer between 1-4294967294.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if len(v) > 10 {
-						errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-					} else {
-						sum := int64(0)
-						for _, r := range v {
-							num := int64(r - '0')
-							if num < 0 || num > 9 {
-								errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-								return
-							}
-							sum = sum*10 + num
-						}
-						if sum == 0 || sum > 4294967294 {
-							errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-						}
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "",
+				ForceNew:     true,
+				Description:  "Backup BGP remote ASN (Autonomous System Number). Integer between 1-4294967294.",
+				ValidateFunc: goaviatrix.ValidateASN,
 			},
 			"backup_pre_shared_key": {
 				Type:        schema.TypeString,

--- a/aviatrix/resource_aviatrix_vgw_conn.go
+++ b/aviatrix/resource_aviatrix_vgw_conn.go
@@ -59,30 +59,11 @@ func resourceAviatrixVGWConn() *schema.Resource {
 				Description: "Region of AWS's VGW that is used for this connection.",
 			},
 			"bgp_local_as_num": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "BGP local ASN (Autonomous System Number). Integer between 1-4294967294.",
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if len(v) > 10 {
-						errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-					} else {
-						sum := int64(0)
-						for _, r := range v {
-							num := int64(r - '0')
-							if num < 0 || num > 9 {
-								errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-								return
-							}
-							sum = sum*10 + num
-						}
-						if sum == 0 || sum > 4294967294 {
-							errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
-						}
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "BGP local ASN (Autonomous System Number). Integer between 1-4294967294.",
+				ValidateFunc: goaviatrix.ValidateASN,
 			},
 		},
 	}

--- a/goaviatrix/utils.go
+++ b/goaviatrix/utils.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -191,4 +192,21 @@ func CompareMapOfInterface(map1 map[string]interface{}, map2 map[string]interfac
 		return false
 	}
 	return true
+}
+
+func ValidateASN(val interface{}, key string) (warns []string, errs []error) {
+	v, ok := val.(string)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be of type string", key))
+		return
+	}
+
+	asNum, err := strconv.ParseInt(v, 10, 64)
+
+	if err != nil || asNum < int64(1) || asNum > int64(4294967294) {
+		errs = append(errs, fmt.Errorf("%q must be an integer in 1-4294967294, got: %s", key, val))
+		return
+	}
+
+	return warns, errs
 }

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -1,0 +1,50 @@
+package goaviatrix
+
+import "testing"
+
+func TestValidateASN(t *testing.T) {
+	tt := []struct {
+		Name        string
+		Input       interface{}
+		ExpectedErr string
+	}{
+		{
+			"too small",
+			"0",
+			`"test" must be an integer in 1-4294967294, got: 0`,
+		},
+		{
+			"too large",
+			"4294967295",
+			`"test" must be an integer in 1-4294967294, got: 4294967295`,
+		},
+		{
+			"wrong type",
+			65001,
+			`"test" must be of type string`,
+		},
+		{
+			"passing",
+			"4294967294",
+			"",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, errs := ValidateASN(tc.Input, "test")
+			if tc.ExpectedErr != "" {
+				if len(errs) < 1 {
+					t.Fatalf("test case %q expected an error: %q, got: none", tc.Name, tc.ExpectedErr)
+				}
+				if errs[0].Error() != tc.ExpectedErr {
+					t.Fatalf("test case %q expected an error: %q, got: %q", tc.Name, tc.ExpectedErr, errs[0].Error())
+				}
+			} else {
+				if len(errs) > 0 {
+					t.Fatalf("test case %q expected no error, got %q", tc.Name, errs[0].Error())
+				}
+			}
+		})
+	}
+}

--- a/website/docs/r/aviatrix_transit_gateway.html.markdown
+++ b/website/docs/r/aviatrix_transit_gateway.html.markdown
@@ -117,6 +117,10 @@ The following arguments are supported:
 -> **NOTE:** Enabling FireNet will automatically enable hybrid connection. If `enable_firenet` is set to true, please set `enable_hybrid_connection` to true in the respective **aviatrix_transit_gateway** as well.
 
 * `enable_transit_firenet` - (Optional) Sign of readiness for [Transit FireNet](https://docs.aviatrix.com/HowTos/transit_firenet_faq.html) connection. Valid values: true, false. Default value: false.
+* `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: "50".
+* `prepend_as_path` - (Optional) List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
+* `local_as_number` - (Optional) Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations.
+* `bgp_ecmp` - (Optional) Enable Equal Cost Multi Path (ECMP) routing for the next hop. Default value: false.
 
 ### Encryption
 * `enable_encrypt_volume` - (Optional) Enable EBS volume encryption for Gateway. Only supports AWS. Valid values: true, false. Default value: false.


### PR DESCRIPTION
4 new advanced config options for the transit_gateway resource
 - bgp_polling_time
 - prepend_as_path
 - local_as_number
 - bgp_ecmp

NOTE: `local_as_number` is one the edge cases where an attribute can be set, but never unset. So if you were to have the value set in your config, then remove it and apply, in reality the value is still set. Thus if you were to them remove the resource from state and import, the `local_as_number` value would still be imported.