### PR TITLE
(15994) support enable_vpc_dns_server for controller

### DIFF
--- a/aviatrix/resource_aviatrix_controller_config_test.go
+++ b/aviatrix/resource_aviatrix_controller_config_test.go
@@ -38,6 +38,7 @@ func TestAccAviatrixControllerConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "fqdn_exception_rule", "false"),
 					resource.TestCheckResourceAttr(resourceName, "http_access", "true"),
 					resource.TestCheckResourceAttr(resourceName, "security_group_management", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_vpc_dns_server", "true"),
 				),
 			},
 			{
@@ -63,6 +64,7 @@ resource "aviatrix_controller_config" "test_controller_config" {
 	fqdn_exception_rule 	  = false
 	http_access         	  = true
 	security_group_management = false
+	enable_vpc_dns_server     = true
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"))
 }

--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -150,18 +150,18 @@ var BasicCheck CheckAPIResponseFunc = func(action, reason string, ret bool) erro
 func (c *Client) PostAPI(action string, d interface{}, checkFunc CheckAPIResponseFunc) error {
 	resp, err := c.Post(c.baseURL, d)
 	if err != nil {
-		return fmt.Errorf("HTTP POST %s failed: %v", action, err)
+		return fmt.Errorf("HTTP POST %q failed: %v", action, err)
 	}
 
 	var data APIResp
 	var b bytes.Buffer
 	_, err = b.ReadFrom(resp.Body)
 	if err != nil {
-		return fmt.Errorf("reading response body %s failed: %v", action, err)
+		return fmt.Errorf("reading response body %q failed: %v", action, err)
 	}
 
 	if err = json.NewDecoder(&b).Decode(&data); err != nil {
-		return fmt.Errorf("json Decode %s failed: %v\n Body: %s", action, err, b.String())
+		return fmt.Errorf("json Decode %q failed: %v\n Body: %s", action, err, b.String())
 	}
 
 	return checkFunc(action, data.Reason, data.Return)

--- a/website/docs/r/aviatrix_controller_config.html.markdown
+++ b/website/docs/r/aviatrix_controller_config.html.markdown
@@ -59,6 +59,7 @@ The following arguments are supported:
 
 ### Misc.
 * `target_version` - (Optional) The release version number to which the controller will be upgraded to. If not specified, controller will not be upgraded. If set to "latest", controller will be upgraded to the latest release. Please see the [Controller upgrade guide](https://docs.aviatrix.com/HowTos/inline_upgrade.html) for more information.
+* `enable_vpc_dns_server` - (Optional) Enable VPC/VNET DNS Server for the controller. Valid values: true, false. Default value: false.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Add `enable_vpc_dns_server` to the controller config resource.