### PR TITLE
Enable more linters, but only for last commit

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,3 +58,4 @@ jobs:
         uses: golangci/golangci-lint-action@v1
         with:
           version: v1.26
+          only-new-issues: true

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -7,4 +7,12 @@
   enable = [
     "gofmt",
     "goimports",
+    "deadcode",
+    "gosimple",
+    "govet",
+    "ineffassign",
+    "structcheck",
+    "unconvert",
+    "unused",
+    "varcheck",
   ]


### PR DESCRIPTION
This will enable a few more good linters:
- govet - Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
- deadcode - Finds unused code
- gosimple - Linter for Go source code that specializes in simplifying a code
- ineffassign - Detects when assignments to existing variables are not used
- structcheck - Finds unused struct fields
- unconvert - Remove unnecessary type conversions
- unused - Checks Go code for unused constants, variables, functions and types
- varcheck - Finds unused global variables and constants

Though because this would raise a bunch of errors, I set `only-new-issues: true` which means the linter will only run on the changes made in the PR