### PR TITLE
(15989) Fix allocate_new_eip for GCP gateway data sources

### DIFF
--- a/aviatrix/data_source_aviatrix_gateway.go
+++ b/aviatrix/data_source_aviatrix_gateway.go
@@ -335,13 +335,13 @@ func dataSourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) err
 			d.Set("single_ip_snat", false)
 		}
 
-		if gw.CloudType == goaviatrix.AWS || gw.CloudType == goaviatrix.AWSGOV {
+		if gw.CloudType == goaviatrix.AWS || gw.CloudType == goaviatrix.AWSGOV || gw.CloudType == goaviatrix.GCP {
 			if gw.AllocateNewEipRead {
 				d.Set("allocate_new_eip", true)
 			} else {
 				d.Set("allocate_new_eip", false)
 			}
-		} else if gw.CloudType == goaviatrix.GCP || gw.CloudType == goaviatrix.AZURE || gw.CloudType == goaviatrix.OCI {
+		} else if gw.CloudType == goaviatrix.AZURE || gw.CloudType == goaviatrix.OCI {
 			d.Set("allocate_new_eip", true)
 		}
 

--- a/aviatrix/data_source_aviatrix_spoke_gateway.go
+++ b/aviatrix/data_source_aviatrix_spoke_gateway.go
@@ -216,7 +216,11 @@ func dataSourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}
 			d.Set("vpc_id", strings.Split(gw.VpcID, "~-~")[0])
 			d.Set("vpc_reg", gw.GatewayZone)
 
-			d.Set("allocate_new_eip", true)
+			if gw.AllocateNewEipRead {
+				d.Set("allocate_new_eip", true)
+			} else {
+				d.Set("allocate_new_eip", false)
+			}
 		} else if gw.CloudType == goaviatrix.AZURE || gw.CloudType == goaviatrix.OCI {
 			d.Set("vpc_id", gw.VpcID)
 			d.Set("vpc_reg", gw.VpcRegion)

--- a/aviatrix/data_source_aviatrix_transit_gateway.go
+++ b/aviatrix/data_source_aviatrix_transit_gateway.go
@@ -241,7 +241,11 @@ func dataSourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface
 		} else if gw.CloudType == goaviatrix.GCP {
 			d.Set("vpc_id", strings.Split(gw.VpcID, "~-~")[0])
 			d.Set("vpc_reg", gw.GatewayZone)
-			d.Set("allocate_new_eip", true)
+			if gw.AllocateNewEipRead {
+				d.Set("allocate_new_eip", true)
+			} else {
+				d.Set("allocate_new_eip", false)
+			}
 		} else if gw.CloudType == goaviatrix.AZURE || gw.CloudType == goaviatrix.OCI {
 			d.Set("vpc_id", gw.VpcID)
 			d.Set("vpc_reg", gw.VpcRegion)


### PR DESCRIPTION
Update GCP gateway data sources to properly set the value for allocate_new_eip attribute