### PR TITLE
16302:Allow changing addional cidr servers individually on GeoVPN

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1413,25 +1413,6 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 				sTunnel.VpcID = gw1.VpcID
 			}
 
-			if vpnAccess && enableElb && geoVpnDnsName != "" {
-				//GeoVPN is Enabled
-				if d.HasChange("additional_cidrs") {
-					if d.HasChange("name_servers") || d.HasChange("search_domains") {
-						// Special case where two API calls are needed
-						sTunnel2 := sTunnel
-						oldCIDR, _ := d.GetChange("additional_cidrs")
-						sTunnel2.AdditionalCidrs = oldCIDR.(string)
-						// Only change name_servers and search domain first
-						err := client.ModifySplitTunnel(sTunnel2)
-						if err != nil {
-							return fmt.Errorf("failed to modify split tunnel: %s", err)
-						}
-					}
-					//Change additional CIDR with GeoVPN name
-					sTunnel.ElbName = geoVpnDnsName
-					sTunnel.Dns = "true"
-				}
-			}
 			err := client.ModifySplitTunnel(sTunnel)
 			if err != nil {
 				return fmt.Errorf("failed to modify split tunnel: %s", err)


### PR DESCRIPTION
- Controller will additional CIDR changes as well per LB to prevent modifying name servers for a different LB
- This would prevent the need for multiple applies in GeoVPN