### PR TITLE
(16544) Use TypeSet instead of TypeList for snat policies

### DIFF
--- a/aviatrix/resource_aviatrix_gateway_snat.go
+++ b/aviatrix/resource_aviatrix_gateway_snat.go
@@ -36,7 +36,7 @@ func resourceAviatrixGatewaySNat() *schema.Resource {
 				Description:  "Nat mode. Currently only supports 'customized_snat'.",
 			},
 			"snat_policy": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Default:     nil,
 				Description: "Policy rules applied for 'snat_mode'' of 'customized_snat'.'",
@@ -131,14 +131,14 @@ func resourceAviatrixGatewaySNatCreate(d *schema.ResourceData, meta interface{})
 		GatewayName: d.Get("gw_name").(string),
 	}
 
-	if len(d.Get("snat_policy").([]interface{})) == 0 {
+	if len(d.Get("snat_policy").(*schema.Set).List()) == 0 {
 		return fmt.Errorf("please specify 'snat_policy' for 'snat_mode' of 'customized_snat'")
 	}
 	gateway.EnableNat = "yes"
 	gateway.SnatMode = "custom"
 	gateway.SyncSNATToHA = strconv.FormatBool(d.Get("sync_to_ha").(bool))
 	if _, ok := d.GetOk("snat_policy"); ok {
-		policies := d.Get("snat_policy").([]interface{})
+		policies := d.Get("snat_policy").(*schema.Set).List()
 		for _, policy := range policies {
 			pl := policy.(map[string]interface{})
 			customPolicy := &goaviatrix.PolicyRule{
@@ -244,13 +244,13 @@ func resourceAviatrixGatewaySNatUpdate(d *schema.ResourceData, meta interface{})
 	gateway.SyncSNATToHA = strconv.FormatBool(d.Get("sync_to_ha").(bool))
 
 	if d.HasChange("snat_policy") || d.HasChange("sync_to_ha") {
-		if len(d.Get("snat_policy").([]interface{})) == 0 {
+		if len(d.Get("snat_policy").(*schema.Set).List()) == 0 {
 			return fmt.Errorf("please specify 'snat_policy' for 'snat_mode' of 'customized_snat'")
 		}
 
 		gateway.SnatMode = "custom"
 		if _, ok := d.GetOk("snat_policy"); ok {
-			policies := d.Get("snat_policy").([]interface{})
+			policies := d.Get("snat_policy").(*schema.Set).List()
 			for _, policy := range policies {
 				pl := policy.(map[string]interface{})
 				customPolicy := &goaviatrix.PolicyRule{


### PR DESCRIPTION
In certain test cases the backend will send back duplicate SNAT policies for a gateway, for example, tf config sets two policies [policy.A, policy.B] the backend could send back three policies [policy.A, policy.A, policy.B]. This would then cause a diff. To avoid this we can use a TypeSet instead of TypeList for SNAT policies, this will guarantee we do not write duplicate policies to state. Thus even if the backend sends a duplicate there will be no diff. 