### PR TITLE
(16585) Prevent updating eip attributes on transit and spoke gw

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -811,6 +811,18 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChange("insane_mode_az") {
 		return fmt.Errorf("updating insane_mode_az is not allowed")
 	}
+	if d.HasChange("allocate_new_eip") {
+		return fmt.Errorf("updating allocate_new_eip is not allowed")
+	}
+	if d.HasChange("eip") {
+		return fmt.Errorf("updating eip is not allowed")
+	}
+	if d.HasChange("ha_eip") {
+		o, n := d.GetChange("ha_eip")
+		if o.(string) != "" && n.(string) != "" {
+			return fmt.Errorf("updating ha_eip is not allowed")
+		}
+	}
 	if d.HasChange("single_az_ha") {
 		singleAZGateway := &goaviatrix.Gateway{
 			GwName: d.Get("gw_name").(string),

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1057,6 +1057,18 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 	if d.HasChange("insane_mode_az") {
 		return fmt.Errorf("updating insane_mode_az is not allowed")
 	}
+	if d.HasChange("allocate_new_eip") {
+		return fmt.Errorf("updating allocate_new_eip is not allowed")
+	}
+	if d.HasChange("eip") {
+		return fmt.Errorf("updating eip is not allowed")
+	}
+	if d.HasChange("ha_eip") {
+		o, n := d.GetChange("ha_eip")
+		if o.(string) != "" && n.(string) != "" {
+			return fmt.Errorf("updating ha_eip is not allowed")
+		}
+	}
 	if d.HasChange("enable_transit_firenet") && d.Get("cloud_type").(int) == goaviatrix.AZURE {
 		return fmt.Errorf("editing 'enable_transit_firenet' in AZURE is not supported")
 	}


### PR DESCRIPTION
There is no API for updating the following attributes:
- `allocate_new_eip`
- `eip`
- `ha_eip`

On the regular gateway we will prevent user from changing these because it is not actually possible. On transit/spoke gateway we let the user change them but nothing actually happens since there no API. This PR will change transit/spoke gateway to behave the same as the regular gateway, preventing the user from applying an change to update these attributes. The exception is with `ha_eip`, which can be unset or set for the first time, but not modified.
