### PR TITLE
(16802) Add aws tgw multicast option

### DIFF
--- a/aviatrix/resource_aviatrix_aws_tgw.go
+++ b/aviatrix/resource_aviatrix_aws_tgw.go
@@ -159,6 +159,12 @@ func resourceAviatrixAWSTgw() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"enable_multicast": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -173,6 +179,7 @@ func resourceAviatrixAWSTgwCreate(d *schema.ResourceData, meta interface{}) erro
 		AwsSideAsNumber:           d.Get("aws_side_as_number").(string),
 		AttachedAviatrixTransitGW: make([]string, 0),
 		SecurityDomains:           make([]goaviatrix.SecurityDomainRule, 0),
+		EnableMulticast:           d.Get("enable_multicast").(bool),
 	}
 
 	manageVpcAttachment := d.Get("manage_vpc_attachment").(bool)
@@ -465,6 +472,7 @@ func resourceAviatrixAWSTgwRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("account_name", awsTgw.AccountName)
 	d.Set("tgw_name", awsTgw.Name)
 	d.Set("region", awsTgw.Region)
+	d.Set("enable_multicast", awsTgw.EnableMulticast)
 
 	log.Printf("[INFO] Reading AWS TGW")
 

--- a/goaviatrix/aws_tgw.go
+++ b/goaviatrix/aws_tgw.go
@@ -24,6 +24,7 @@ type AWSTgw struct {
 	AttachedAviatrixTransitGW []string             `form:"attached_aviatrix_transit_gateway,omitempty"`
 	SecurityDomains           []SecurityDomainRule `form:"security_domains,omitempty"`
 	ManageVpcAttachment       string
+	EnableMulticast           bool `form:"multicast_enable"`
 }
 
 type AWSTgwAPIResp struct {
@@ -106,6 +107,7 @@ type TgwInfoDetail struct {
 	AccountName     string `json:"acct_name"`
 	Region          string `json:"region"`
 	AwsSideAsNumber int    `json:"tgw_aws_asn"`
+	EnableMulticast bool   `json:"multicast_enable"`
 }
 
 type listAttachedVpcNamesResp struct {
@@ -722,6 +724,7 @@ func (c *Client) ListTgwDetails(awsTgw *AWSTgw) (*AWSTgw, error) {
 		awsTgw.AccountName = tgwInfoDetail.AccountName
 		awsTgw.Region = tgwInfoDetail.Region
 		awsTgw.AwsSideAsNumber = strconv.Itoa(tgwInfoDetail.AwsSideAsNumber)
+		awsTgw.EnableMulticast = tgwInfoDetail.EnableMulticast
 		return awsTgw, nil
 	}
 	return nil, ErrNotFound

--- a/website/docs/r/aviatrix_aws_tgw.html.markdown
+++ b/website/docs/r/aviatrix_aws_tgw.html.markdown
@@ -135,6 +135,7 @@ The following arguments are supported:
 
 -> **NOTE:** `manage_vpc_attachment` - If you are using/upgraded to Aviatrix Terraform Provider R1.5+, and an **aviatrix_aws_tgw** resource was originally created with a provider version <R1.5, you must do 'terraform refresh' to update and apply the attribute's default value (true) into the state file.
 
+* `enable_multicast` - (Optional) Enable multicast. Default value: false. Valid values: true, false.
 
 ## Import
 


### PR DESCRIPTION
- Add `enable_multicast` option to AWS TGW resource
- ForceNew attribute so only updated the Create and Read functions
- Updated docs