### PR TITLE
17952: transit_gateway: fix egress transit firenet destroy

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1848,6 +1848,14 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 
 	log.Printf("[INFO] Deleting Aviatrix Transit Gateway: %#v", gateway)
 
+	enableEgressTransitFirenet := d.Get("enable_egress_transit_firenet").(bool)
+	if enableEgressTransitFirenet {
+		err := client.DisableEgressTransitFirenet(&goaviatrix.TransitVpc{GwName: gateway.GwName})
+		if err != nil {
+			return fmt.Errorf("could not disable egress transit firenet: %v", err)
+		}
+	}
+
 	enableFireNet := d.Get("enable_firenet").(bool)
 	if enableFireNet {
 		gw := &goaviatrix.TransitVpc{


### PR DESCRIPTION
When destroying a transit gateway we need to disable egress transit firenet before disabling transit firenet.