### PR TITLE
17954: spoke_gateway: fix transit gw detachment order

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -740,11 +740,11 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	if manageTransitGwAttachment {
 		if gw.SpokeVpc == "yes" {
 			var transitGws []string
-			if gw.TransitGwName != "" {
-				transitGws = append(transitGws, gw.TransitGwName)
-			}
 			if gw.EgressTransitGwName != "" {
 				transitGws = append(transitGws, gw.EgressTransitGwName)
+			}
+			if gw.TransitGwName != "" {
+				transitGws = append(transitGws, gw.TransitGwName)
 			}
 			d.Set("transit_gw", strings.Join(transitGws, ","))
 		} else {


### PR DESCRIPTION
We detach the spoke from it's transit gateways in the order in which the gateway names are stored in the state file. Currently there is a bug in the backend that requires us to detach the spoke from it's egress transit gw  before it's east-west transit gw. This commit changes the order we store the names of the transit gws so that on delete we will always detach from the egress gw first.