### PR TITLE
18394: update firenet Read for import

### DIFF
--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -298,6 +298,7 @@ func resourceAviatrixFireNetRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if isImport || d.Get("manage_firewall_instance_association").(bool) {
+		d.Set("manage_firewall_instance_association", true)
 		if err := d.Set("firewall_instance_association", firewallInstance); err != nil {
 			log.Printf("[WARN] Error setting 'firewall_instance' for (%s): %s", d.Id(), err)
 		}

--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -233,8 +233,10 @@ func resourceAviatrixFireNetReadIfRequired(d *schema.ResourceData, meta interfac
 func resourceAviatrixFireNetRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 
+	var isImport bool
 	vpcID := d.Get("vpc_id").(string)
 	if vpcID == "" {
+		isImport = true
 		id := d.Id()
 		log.Printf("[DEBUG] Looks like an import, no vpc_id received. Import Id is %s", id)
 		d.Set("vpc_id", id)
@@ -295,7 +297,7 @@ func resourceAviatrixFireNetRead(d *schema.ResourceData, meta interface{}) error
 		firewallInstance = append(firewallInstance, fI)
 	}
 
-	if d.Get("manage_firewall_instance_association").(bool) {
+	if isImport || d.Get("manage_firewall_instance_association").(bool) {
 		if err := d.Set("firewall_instance_association", firewallInstance); err != nil {
 			log.Printf("[WARN] Error setting 'firewall_instance' for (%s): %s", d.Id(), err)
 		}


### PR DESCRIPTION
The rule is 
```
For import the value of the "manage_****" attribute should be treated as its default value.
```

So, for firenet I need to treat import the same as if the manage_* attr is set to true.