### PR TITLE
18218&18217&18130 Implement support of bootstrap support in Azure and more

### DIFF
--- a/aviatrix/resource_aviatrix_firewall_instance.go
+++ b/aviatrix/resource_aviatrix_firewall_instance.go
@@ -75,18 +75,6 @@ func resourceAviatrixFirewallInstance() *schema.Resource {
 				ForceNew:    true,
 				Description: "The .pem file name for SSH access to the firewall instance.",
 			},
-			"iam_role": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "IAM role.",
-			},
-			"bootstrap_bucket_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Bootstrap bucket name.",
-			},
 			"username": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -98,7 +86,14 @@ func resourceAviatrixFirewallInstance() *schema.Resource {
 				Optional:    true,
 				Sensitive:   true,
 				ForceNew:    true,
-				Description: "Applicable to Azure deployment only.",
+				Description: "Authentication method. Applicable to Azure deployment only.",
+			},
+			"ssh_public_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Sensitive:   true,
+				Description: "Authentication method. Applicable to Azure deployment only.",
 			},
 			"zone": {
 				Type:         schema.TypeString,
@@ -106,6 +101,78 @@ func resourceAviatrixFirewallInstance() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateAzureAZ,
 				Description:  "Availability Zone. Only available for AZURE. Must be in the form 'az-n', for example, 'az-2'.",
+			},
+			"iam_role": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Advanced option. IAM role. Only available for AWS.",
+			},
+			"bootstrap_bucket_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Advanced option. Bootstrap bucket name. Only available for AWS.",
+			},
+			"bootstrap_storage_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "Advanced option. Bootstrap storage name. Applicable to Azure and Palo Alto Networks " +
+					"VM-Series/Fortinet Series deployment only.",
+			},
+			"storage_access_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				ForceNew:  true,
+				Description: "Advanced option. Storage access key. Applicable to Azure and Palo Alto Networks " +
+					"VM-Series deployment only.",
+			},
+			"file_share_folder": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "Advanced option. File share folder. Applicable to Azure and Palo Alto Networks " +
+					"VM-Series deployment only.",
+			},
+			"share_directory": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "Advanced option. Share directory. Applicable to Azure and Palo Alto Networks " +
+					"VM-Series deployment only.",
+			},
+			"sic_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				ForceNew:    true,
+				Description: "Advanced option. Bic key. Applicable to Azure and Check Point Series deployment only.",
+			},
+			"container_folder": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Advanced option. Bootstrap storage name. Applicable to Azure and Fortinet Series deployment only.",
+			},
+			"sas_url_config": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Advanced option. Bootstrap storage name. Applicable to Azure and Fortinet Series deployment only.",
+			},
+			"sas_url_license": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Advanced option. Bootstrap storage name. Applicable to Azure and Fortinet Series deployment only.",
+			},
+			"user_data": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Advanced option. Bootstrap storage name. Applicable to Check Point Series and Fortinet Series deployment only.",
 			},
 			"instance_id": {
 				Type:        schema.TypeString,
@@ -153,6 +220,16 @@ func resourceAviatrixFirewallInstanceCreate(d *schema.ResourceData, meta interfa
 		BootstrapBucketName:  d.Get("bootstrap_bucket_name").(string),
 		Username:             d.Get("username").(string),
 		Password:             d.Get("password").(string),
+		SshPublicKey:         d.Get("ssh_public_key").(string),
+		BootstrapStorageName: d.Get("bootstrap_storage_name").(string),
+		StorageAccessKey:     d.Get("storage_access_key").(string),
+		FileShareFolder:      d.Get("file_share_folder").(string),
+		ShareDirectory:       d.Get("share_directory").(string),
+		SicKey:               d.Get("sic_key").(string),
+		ContainerFolder:      d.Get("container_folder").(string),
+		SasUrlConfig:         d.Get("sas_url_config").(string),
+		SasUriLicense:        d.Get("sas_url_license").(string),
+		UserData:             d.Get("user_data").(string),
 	}
 
 	if strings.HasPrefix(firewallInstance.FirewallImage, "Palo Alto Networks") {
@@ -162,7 +239,7 @@ func resourceAviatrixFirewallInstanceCreate(d *schema.ResourceData, meta interfa
 	} else if strings.HasPrefix(firewallInstance.FirewallImage, "Check Point CloudGuard") ||
 		strings.HasPrefix(firewallInstance.FirewallImage, "Fortinet FortiGate") {
 		if firewallInstance.ManagementSubnet != "" {
-			return fmt.Errorf("'management_subnet' is required to be empty for Check Point or Fortinet series")
+			return fmt.Errorf("'management_subnet' is required to be empty for Check Point or Fortinet FortiGate series")
 		}
 	} else {
 		return fmt.Errorf("firewall image: %s is not supported", firewallInstance.FirewallImage)
@@ -182,6 +259,43 @@ func resourceAviatrixFirewallInstanceCreate(d *schema.ResourceData, meta interfa
 	if zone != "" {
 		firewallInstance.EgressSubnet = fmt.Sprintf("%s~~%s~~", firewallInstance.EgressSubnet, zone)
 		firewallInstance.ManagementSubnet = fmt.Sprintf("%s~~%s~~", firewallInstance.ManagementSubnet, zone)
+	}
+
+	if firewallInstance.Username != "" || firewallInstance.Password != "" || firewallInstance.SshPublicKey != "" {
+		if cloudType != goaviatrix.AZURE {
+			return fmt.Errorf("'username' and 'password' or 'ssh_public_key' are only supported for Azure")
+		}
+	}
+	if firewallInstance.Password != "" && firewallInstance.SshPublicKey != "" {
+		return fmt.Errorf("anthentication method can be either a password or an SSH public key. Please specify one of them and set the other one to empty")
+	}
+	if firewallInstance.IamRole != "" || firewallInstance.BootstrapBucketName != "" {
+		if cloudType != goaviatrix.AWS {
+			return fmt.Errorf("advanced options of 'iam_role' and 'bootstrap_bucket_name' are only supported for AWS provider, please set them to empty")
+		}
+	}
+	if firewallInstance.UserData != "" && strings.HasPrefix(firewallInstance.FirewallImage, "Palo Alto Networks") {
+		return fmt.Errorf("advanced option of 'user_data' is only supported for Check Point Series and Fortinet FortiGate Series, not for %s", firewallInstance.FirewallImage)
+	}
+	if firewallInstance.StorageAccessKey != "" || firewallInstance.FileShareFolder != "" || firewallInstance.ShareDirectory != "" {
+		if !strings.HasPrefix(firewallInstance.FirewallImage, "Palo Alto Networks") || cloudType != goaviatrix.AZURE {
+			return fmt.Errorf("advanced options of 'storage_access_key', 'file_share_folder' and 'share_directory' are only supported for Azure and Palo Alto Networks VM-Series")
+		}
+	}
+	if firewallInstance.ContainerFolder != "" || firewallInstance.SasUrlConfig != "" || firewallInstance.SasUriLicense != "" {
+		if !strings.HasPrefix(firewallInstance.FirewallImage, "Fortinet FortiGate") || cloudType != goaviatrix.AZURE {
+			return fmt.Errorf("advanced options of 'container_folder', 'sas_url_config' and 'sas_url_license' are only supported for Azure and Fortinet FortiGate series")
+		}
+	}
+	if firewallInstance.BootstrapStorageName != "" {
+		if strings.HasPrefix(firewallInstance.FirewallImage, "Check Point CloudGuard") || cloudType != goaviatrix.AZURE {
+			return fmt.Errorf("advanced option of 'bootstrap_storage_name' is only supported for Azure and Palo Alto Networks VM-Series/Fortinet FortiGate series")
+		}
+	}
+	if firewallInstance.SicKey != "" {
+		if !strings.HasPrefix(firewallInstance.FirewallImage, "Check Point CloudGuard") || cloudType != goaviatrix.AZURE {
+			return fmt.Errorf("advanced option of 'bootstrap_storage_name' is only supported for Azure and Check Point Series")
+		}
 	}
 
 	instanceID, err := client.CreateFirewallInstance(firewallInstance)
@@ -259,6 +373,27 @@ func resourceAviatrixFirewallInstanceRead(d *schema.ResourceData, meta interface
 	}
 	if fI.Username != "" {
 		d.Set("username", fI.Username)
+	}
+	if fI.BootstrapStorageName != "" {
+		d.Set("bootstrap_storage_name", fI.BootstrapStorageName)
+	}
+	if fI.FileShareFolder != "" {
+		d.Set("file_share_folder", fI.FileShareFolder)
+	}
+	if fI.ShareDirectory != "" {
+		d.Set("share_directory", fI.ShareDirectory)
+	}
+	if fI.ContainerFolder != "" {
+		d.Set("container_folder", fI.ContainerFolder)
+	}
+	if fI.SasUrlConfig != "" {
+		d.Set("sas_url_config", fI.SasUrlConfig)
+	}
+	if fI.SasUriLicense != "" {
+		d.Set("sas_url_license", fI.SasUriLicense)
+	}
+	if fI.UserData != "" {
+		d.Set("user_data", fI.UserData)
 	}
 
 	return nil

--- a/goaviatrix/firewall_instance.go
+++ b/goaviatrix/firewall_instance.go
@@ -34,6 +34,16 @@ type FirewallInstance struct {
 	Password             string `form:"password,omitempty"`
 	AvailabilityZone     string `json:"availability_zone,omitempty"`
 	CloudVendor          string `json:"cloud_vendor,omitempty"`
+	SshPublicKey         string `form:"ssh_public_key,omitempty" json:"ssh_public_key,omitempty"`
+	BootstrapStorageName string `form:"bootstrap_storage_name,omitempty" json:"bootstrap_storage_name,omitempty"`
+	StorageAccessKey     string `form:"storage_access_key,omitempty" json:"storage_access_key,omitempty"`
+	FileShareFolder      string `form:"file_share_folder,omitempty" json:"file_share_folder,omitempty"`
+	ShareDirectory       string `form:"share_directory,omitempty" json:"share_directory,omitempty"`
+	SicKey               string `form:"sic_key,omitempty" json:"sic_key,omitempty"`
+	ContainerFolder      string `form:"container_folder,omitempty" json:"container_folder,omitempty"`
+	SasUrlConfig         string `form:"sas_url_config,omitempty" json:"sas_url_config,omitempty"`
+	SasUriLicense        string `form:"sas_url_license,omitempty" json:"sas_url_license,omitempty"`
+	UserData             string `form:"user_data,omitempty" json:"user_data,omitempty"`
 }
 
 type FirewallInstanceResp struct {
@@ -74,6 +84,36 @@ func (c *Client) CreateFirewallInstance(firewallInstance *FirewallInstance) (str
 	addFirewallInstance.Add("no_associate", strconv.FormatBool(true))
 	addFirewallInstance.Add("username", firewallInstance.Username)
 	addFirewallInstance.Add("password", firewallInstance.Password)
+	if firewallInstance.SshPublicKey != "" {
+		addFirewallInstance.Add("ssh_public_key", firewallInstance.SshPublicKey)
+	}
+	if firewallInstance.BootstrapStorageName != "" {
+		addFirewallInstance.Add("bootstrap_storage_name", firewallInstance.BootstrapStorageName)
+	}
+	if firewallInstance.StorageAccessKey != "" {
+		addFirewallInstance.Add("storage_access_key", firewallInstance.StorageAccessKey)
+	}
+	if firewallInstance.FileShareFolder != "" {
+		addFirewallInstance.Add("file_share_folder", firewallInstance.FileShareFolder)
+	}
+	if firewallInstance.ShareDirectory != "" {
+		addFirewallInstance.Add("share_directory", firewallInstance.ShareDirectory)
+	}
+	if firewallInstance.SicKey != "" {
+		addFirewallInstance.Add("sic_key", firewallInstance.SicKey)
+	}
+	if firewallInstance.ContainerFolder != "" {
+		addFirewallInstance.Add("container_folder", firewallInstance.ContainerFolder)
+	}
+	if firewallInstance.SasUrlConfig != "" {
+		addFirewallInstance.Add("sas_url_config", firewallInstance.SasUrlConfig)
+	}
+	if firewallInstance.SasUriLicense != "" {
+		addFirewallInstance.Add("sas_url_license", firewallInstance.SasUriLicense)
+	}
+	if firewallInstance.UserData != "" {
+		addFirewallInstance.Add("user_data", firewallInstance.UserData)
+	}
 	Url.RawQuery = addFirewallInstance.Encode()
 	resp, err := c.Get(Url.String(), nil)
 	if err != nil {

--- a/website/docs/r/aviatrix_firewall_instance.html.markdown
+++ b/website/docs/r/aviatrix_firewall_instance.html.markdown
@@ -38,14 +38,26 @@ The following arguments are supported:
 * `management_subnet` - (Optional) Management Interface Subnet. Select the subnet whose name contains “gateway and firewall management”. Required for Palo Alto Networks VM-Series, and required to be empty for Check Point or Fortinet series.
 * `egress_subnet` - (Required) Egress Interface Subnet. Select the subnet whose name contains “FW-ingress-egress”.
 * `firewall_image_version` - (Optional) Version of firewall image. If not specified, Controller will automatically select the latest version available.
+* `zone` - (Optional) Availability Zone. Applicable to Azure deployment only. Available as of provider version R2.17+.
 
-### Advanced Options
-* `key_name`- (Optional) The **.pem** filename for SSH access to the firewall instance.
-* `iam_role` - (Optional) In advanced mode, create an IAM Role on the AWS account that launched the FireNet gateway. Create a policy to attach to the role. The policy is to allow access to “Bootstrap Bucket”.
-* `bootstrap_bucket_name`- (Optional) In advanced mode, specify a bootstrap bucket name where the initial configuration and policy file is stored.
+### Authentication method
+* `key_name`- (Optional) Applicable to AWS deployment only. The **.pem** filename for SSH access to the firewall instance.
 * `username`- (Optional) Applicable to Azure deployment only. "admin" as a username is not accepted.
 * `password`- (Optional) Applicable to Azure deployment only.
-* `zone` - (Optional) Availability Zone. Applicable to Azure deployment only. Available as of provider version R2.17+.
+* `ssh_public_key` - (Optional) Applicable to Azure deployment only.
+
+### Advanced Options
+* `iam_role` - (Optional) Only available for AWS. In advanced mode, create an IAM Role on the AWS account that launched the FireNet gateway. Create a policy to attach to the role. The policy is to allow access to “Bootstrap Bucket”.
+* `bootstrap_bucket_name`- (Optional) Only available for AWS. In advanced mode, specify a bootstrap bucket name where the initial configuration and policy file is stored.
+* `bootstrap_storage_name` - (Optional) Advanced option. Bootstrap storage name. Applicable to Azure and Palo Alto Networks VM-Series/Fortinet Series deployment only.
+* `storage_access_key` - (Optional) Advanced option. Storage access key. Applicable to Azure and Palo Alto Networks VM-Series deployment only.
+* `file_share_folder` - (Optional) Advanced option. File share folder. Applicable to Azure and Palo Alto Networks VM-Series deployment only.
+* `share_directory` - (Optional) Advanced option. Share directory. Applicable to Azure and Palo Alto Networks VM-Series deployment only.
+* `sic_key` - (Optional) Advanced option. Bic key. Applicable to Azure and Check Point Series deployment only.
+* `container_folder` - (Optional) Advanced option. Bootstrap storage name. Applicable to Azure and Fortinet Series deployment only.
+* `sas_url_config` - (Optional) Advanced option. Bootstrap storage name. Applicable to Azure and Fortinet Series deployment only.
+* `sas_url_license` - (Optional) Advanced option. Bootstrap storage name. Applicable to Azure and Fortinet Series deployment only.
+* `user_data` - (Optional) Advanced option. Bootstrap storage name. Applicable to Check Point Series and Fortinet Series deployment only.
 
 ## Attribute Reference
 


### PR DESCRIPTION
This PR adds support of following:
1. Bootstrap support in AWS FireNet on Check Point and FortiGate 
2. Bootstrap support in Azure FireNet on Palo Alto Networks VM-Series, Check Point and FortiGate
3. A configurable attribute for Checkpoint "SIC Key" in the Aviatrix Terraform deployment of CheckPoint FW