### PR TITLE
0018744: Add support to connection based BGP prepending on resource aviatrix_transit_gateway_peering

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -244,7 +244,7 @@ func resourceAviatrixTransitGatewayPeeringRead(d *schema.ResourceData, meta inte
 			return fmt.Errorf("could not set prepend_as_path1: %v", err)
 		}
 	}
-	if transitGatewayPeering.PrependAsPath1 != "" {
+	if transitGatewayPeering.PrependAsPath2 != "" {
 		var prependAsPath []string
 		for _, str := range strings.Split(transitGatewayPeering.PrependAsPath2, " ") {
 			prependAsPath = append(prependAsPath, strings.TrimSpace(str))

--- a/website/docs/r/aviatrix_transit_gateway_peering.html.markdown
+++ b/website/docs/r/aviatrix_transit_gateway_peering.html.markdown
@@ -46,8 +46,8 @@ The following arguments are supported:
 * `gateway2_excluded_network_cidrs` - (Optional) List of excluded network CIDRs for the second transit gateway.
 * `gateway1_excluded_tgw_connections` - (Optional) List of excluded TGW connections for the first transit gateway.
 * `gateway2_excluded_tgw_connections` - (Optional) List of excluded TGW connections for the second transit gateway.
-* `prepend_as_path1` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name1.
-* `prepend_as_path2` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name2.
+* `prepend_as_path1` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name1. Available as of provider version R2.17.2.
+* `prepend_as_path2` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name2. Available as of provider version R2.17.2.
 * `enable_peering_over_private_network` - (Optional) Enable peering over private network. ActiveMesh and Insane Mode is required on both transit gateways. Available in provider version R2.17.1+.
 
 ## Import

--- a/website/docs/r/aviatrix_transit_gateway_peering.html.markdown
+++ b/website/docs/r/aviatrix_transit_gateway_peering.html.markdown
@@ -21,6 +21,14 @@ resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering" {
   gateway2_excluded_network_cidrs     = ["10.0.0.48/28"]
   gateway1_excluded_tgw_connections   = ["vpn_connection_a"]
   gateway2_excluded_tgw_connections   = ["vpn_connection_b"]
+  prepend_as_path1                    = [
+    "111",
+    "222"
+  ]
+  prepend_as_path2                    = [
+    "333",
+    "444"
+  ]
   enable_peering_over_private_network = false
 }
 ```
@@ -38,6 +46,8 @@ The following arguments are supported:
 * `gateway2_excluded_network_cidrs` - (Optional) List of excluded network CIDRs for the second transit gateway.
 * `gateway1_excluded_tgw_connections` - (Optional) List of excluded TGW connections for the first transit gateway.
 * `gateway2_excluded_tgw_connections` - (Optional) List of excluded TGW connections for the second transit gateway.
+* `prepend_as_path1` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name1.
+* `prepend_as_path2` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name2.
 * `enable_peering_over_private_network` - (Optional) Enable peering over private network. ActiveMesh and Insane Mode is required on both transit gateways. Available in provider version R2.17.1+.
 
 ## Import


### PR DESCRIPTION
Add two parameters "prepend_as_path1" and "prepend_as_path2" to support connection based BGP prepending for both source and destination transit gateways on resource aviatrix_transit_gateway_peering