### PR TITLE
18785: transit CIDR approval per connection

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
@@ -235,6 +236,17 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "Switch to enable/disable encrypted transit approval for transit Gateway. Valid values: true, false.",
+			},
+			"learned_cidrs_approval_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "gateway",
+				ValidateFunc: validation.StringInSlice([]string{"gateway", "connection"}, false),
+				Description: "Set the learned CIDRs approval mode. Only valid when 'enable_learned_cidrs_approval' is " +
+					"set to true. If set to 'gateway', learned CIDR approval applies to ALL connections. If set to " +
+					"'connection', learned CIDR approval is configured on a per connection basis. When configuring per " +
+					"connection, use the enable_learned_cidrs_approval attribute within the connection resource to " +
+					"toggle learned CIDR approval. Valid values: 'gateway' or 'connection'. Default value: 'gateway'.",
 			},
 			"security_group_id": {
 				Type:        schema.TypeString,
@@ -468,6 +480,10 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 	learnedCidrsApproval := d.Get("enable_learned_cidrs_approval").(bool)
 	if learnedCidrsApproval {
 		gateway.LearnedCidrsApproval = "on"
+	}
+
+	if learnedCidrsApproval && d.Get("learned_cidrs_approval_mode").(string) == "connection" {
+		return fmt.Errorf("'enable_learned_cidrs_approval' must be false if 'learned_cidrs_approval_mode' is set to 'connection'")
 	}
 
 	log.Printf("[INFO] Creating Aviatrix Transit Gateway: %#v", gateway)
@@ -790,6 +806,13 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		}
 	}
 
+	if mode, ok := d.GetOk("learned_cidrs_approval_mode"); ok {
+		err := client.SetTransitLearnedCIDRsApprovalMode(gateway, mode.(string))
+		if err != nil {
+			return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", mode, err)
+		}
+	}
+
 	return resourceAviatrixTransitGatewayReadIfRequired(d, meta, &flag)
 }
 
@@ -1071,6 +1094,8 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 	}
 	d.Set("enable_segmentation", isSegmentationEnabled)
 
+	d.Set("learned_cidrs_approval_mode", advancedConfig.LearnedCIDRsApprovalMode)
+
 	haGateway := &goaviatrix.Gateway{
 		AccountName: d.Get("account_name").(string),
 		GwName:      d.Get("gw_name").(string) + "-hagw",
@@ -1192,16 +1217,21 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("updating ha_eip is not allowed")
 		}
 	}
+
 	if d.HasChange("enable_transit_firenet") && d.Get("cloud_type").(int) == goaviatrix.AZURE {
 		return fmt.Errorf("editing 'enable_transit_firenet' in AZURE is not supported")
 	}
 	if d.Get("enable_egress_transit_firenet").(bool) && !d.Get("enable_transit_firenet").(bool) {
 		return fmt.Errorf("'enable_egress_transit_firenet' requires 'enable_transit_firenet' to be set to true")
 	}
-
 	if d.Get("enable_egress_transit_firenet").(bool) && gateway.CloudType != goaviatrix.AZURE && gateway.CloudType != goaviatrix.AWS && gateway.CloudType != goaviatrix.AWSGOV {
 		return fmt.Errorf("'enable_egress_transit_firenet' is currently only supported on AWS, AZURE and AWSGOV cloud providers")
 	}
+
+	if d.Get("enable_learned_cidrs_approval").(bool) && d.Get("learned_cidrs_approval_mode").(string) == "connection" {
+		return fmt.Errorf("'enable_learned_cidrs_approval' must be false if 'learned_cidrs_approval_mode' is set to 'connection'")
+	}
+
 	if d.HasChange("single_az_ha") {
 		singleAZGateway := &goaviatrix.Gateway{
 			GwName: d.Get("gw_name").(string),
@@ -1512,6 +1542,17 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if err != nil {
 				return fmt.Errorf("failed to disable Active Mesh Mode: %s", err)
 			}
+		}
+	}
+
+	if d.HasChange("learned_cidrs_approval_mode") {
+		gw := &goaviatrix.TransitVpc{
+			GwName: d.Get("gw_name").(string),
+		}
+		mode := d.Get("learned_cidrs_approval_mode").(string)
+		err := client.SetTransitLearnedCIDRsApprovalMode(gw, mode)
+		if err != nil {
+			return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", mode, err)
 		}
 	}
 

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -56,6 +56,7 @@ type TransitGatewayAdvancedConfig struct {
 	BgpEcmpEnabled           bool
 	ActiveStandbyEnabled     bool
 	ActiveStandbyConnections []StandbyConnection
+	LearnedCIDRsApprovalMode string
 }
 
 type StandbyConnection struct {
@@ -64,12 +65,13 @@ type StandbyConnection struct {
 }
 
 type TransitGatewayAdvancedConfigRespResult struct {
-	BgpPollingTime      int               `json:"bgp_polling_time"`
-	PrependASPath       string            `json:"bgp_prepend_as_path"`
-	LocalASNumber       string            `json:"local_asn_num"`
-	BgpEcmpEnabled      string            `json:"bgp_ecmp"`
-	ActiveStandby       string            `json:"active-standby"`
-	ActiveStandbyStatus map[string]string `json:"active_standby_status"`
+	BgpPollingTime           int               `json:"bgp_polling_time"`
+	PrependASPath            string            `json:"bgp_prepend_as_path"`
+	LocalASNumber            string            `json:"local_asn_num"`
+	BgpEcmpEnabled           string            `json:"bgp_ecmp"`
+	ActiveStandby            string            `json:"active-standby"`
+	ActiveStandbyStatus      map[string]string `json:"active_standby_status"`
+	LearnedCIDRsApprovalMode string            `json:"learned_cidrs_approval_mode"`
 }
 
 type TransitGatewayAdvancedConfigResp struct {
@@ -634,5 +636,16 @@ func (c *Client) GetTransitGatewayAdvancedConfig(transitGateway *TransitVpc) (*T
 		BgpEcmpEnabled:           data.Results.BgpEcmpEnabled == "yes",
 		ActiveStandbyEnabled:     data.Results.ActiveStandby == "yes",
 		ActiveStandbyConnections: standbyConnections,
+		LearnedCIDRsApprovalMode: data.Results.LearnedCIDRsApprovalMode,
 	}, nil
+}
+
+func (c *Client) SetTransitLearnedCIDRsApprovalMode(gw *TransitVpc, mode string) error {
+	data := map[string]string{
+		"action":       "set_transit_learned_cidrs_approval_mode",
+		"CID":          c.CID,
+		"gateway_name": gw.GwName,
+		"mode":         mode,
+	}
+	return c.PostAPI(data["action"], data, BasicCheck)
 }

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -50,13 +50,14 @@ type TransitVpc struct {
 }
 
 type TransitGatewayAdvancedConfig struct {
-	BgpPollingTime           string
-	PrependASPath            []string
-	LocalASNumber            string
-	BgpEcmpEnabled           bool
-	ActiveStandbyEnabled     bool
-	ActiveStandbyConnections []StandbyConnection
-	LearnedCIDRsApprovalMode string
+	BgpPollingTime                    string
+	PrependASPath                     []string
+	LocalASNumber                     string
+	BgpEcmpEnabled                    bool
+	ActiveStandbyEnabled              bool
+	ActiveStandbyConnections          []StandbyConnection
+	LearnedCIDRsApprovalMode          string
+	ConnectionLearnedCIDRApprovalInfo []LearnedCIDRApprovalInfo
 }
 
 type StandbyConnection struct {
@@ -65,13 +66,19 @@ type StandbyConnection struct {
 }
 
 type TransitGatewayAdvancedConfigRespResult struct {
-	BgpPollingTime           int               `json:"bgp_polling_time"`
-	PrependASPath            string            `json:"bgp_prepend_as_path"`
-	LocalASNumber            string            `json:"local_asn_num"`
-	BgpEcmpEnabled           string            `json:"bgp_ecmp"`
-	ActiveStandby            string            `json:"active-standby"`
-	ActiveStandbyStatus      map[string]string `json:"active_standby_status"`
-	LearnedCIDRsApprovalMode string            `json:"learned_cidrs_approval_mode"`
+	BgpPollingTime                    int                       `json:"bgp_polling_time"`
+	PrependASPath                     string                    `json:"bgp_prepend_as_path"`
+	LocalASNumber                     string                    `json:"local_asn_num"`
+	BgpEcmpEnabled                    string                    `json:"bgp_ecmp"`
+	ActiveStandby                     string                    `json:"active-standby"`
+	ActiveStandbyStatus               map[string]string         `json:"active_standby_status"`
+	LearnedCIDRsApprovalMode          string                    `json:"learned_cidrs_approval_mode"`
+	ConnectionLearnedCIDRApprovalInfo []LearnedCIDRApprovalInfo `json:"connection_learned_cidrs_approval_info"`
+}
+
+type LearnedCIDRApprovalInfo struct {
+	ConnName        string `json:"conn_name"`
+	EnabledApproval string `json:"conn_learned_cidrs_approval"`
 }
 
 type TransitGatewayAdvancedConfigResp struct {
@@ -630,13 +637,14 @@ func (c *Client) GetTransitGatewayAdvancedConfig(transitGateway *TransitVpc) (*T
 	}
 
 	return &TransitGatewayAdvancedConfig{
-		BgpPollingTime:           strconv.Itoa(data.Results.BgpPollingTime),
-		PrependASPath:            filteredStrings,
-		LocalASNumber:            data.Results.LocalASNumber,
-		BgpEcmpEnabled:           data.Results.BgpEcmpEnabled == "yes",
-		ActiveStandbyEnabled:     data.Results.ActiveStandby == "yes",
-		ActiveStandbyConnections: standbyConnections,
-		LearnedCIDRsApprovalMode: data.Results.LearnedCIDRsApprovalMode,
+		BgpPollingTime:                    strconv.Itoa(data.Results.BgpPollingTime),
+		PrependASPath:                     filteredStrings,
+		LocalASNumber:                     data.Results.LocalASNumber,
+		BgpEcmpEnabled:                    data.Results.BgpEcmpEnabled == "yes",
+		ActiveStandbyEnabled:              data.Results.ActiveStandby == "yes",
+		ActiveStandbyConnections:          standbyConnections,
+		LearnedCIDRsApprovalMode:          data.Results.LearnedCIDRsApprovalMode,
+		ConnectionLearnedCIDRApprovalInfo: data.Results.ConnectionLearnedCIDRApprovalInfo,
 	}, nil
 }
 
@@ -652,7 +660,7 @@ func (c *Client) SetTransitLearnedCIDRsApprovalMode(gw *TransitVpc, mode string)
 
 func (c *Client) EnableTransitConnectionLearnedCIDRApproval(gwName, connName string) error {
 	data := map[string]string{
-		"action":          "enable_transit_connection_learned_cidr_approval",
+		"action":          "enable_transit_connection_learned_cidrs_approval",
 		"CID":             c.CID,
 		"gateway_name":    gwName,
 		"connection_name": connName,
@@ -662,7 +670,7 @@ func (c *Client) EnableTransitConnectionLearnedCIDRApproval(gwName, connName str
 
 func (c *Client) DisableTransitConnectionLearnedCIDRApproval(gwName, connName string) error {
 	data := map[string]string{
-		"action":          "disable_transit_connection_learned_cidr_approval",
+		"action":          "disable_transit_connection_learned_cidrs_approval",
 		"CID":             c.CID,
 		"gateway_name":    gwName,
 		"connection_name": connName,

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -649,3 +649,23 @@ func (c *Client) SetTransitLearnedCIDRsApprovalMode(gw *TransitVpc, mode string)
 	}
 	return c.PostAPI(data["action"], data, BasicCheck)
 }
+
+func (c *Client) EnableTransitConnectionLearnedCIDRApproval(gwName, connName string) error {
+	data := map[string]string{
+		"action":          "enable_transit_connection_learned_cidr_approval",
+		"CID":             c.CID,
+		"gateway_name":    gwName,
+		"connection_name": connName,
+	}
+	return c.PostAPI(data["action"], data, BasicCheck)
+}
+
+func (c *Client) DisableTransitConnectionLearnedCIDRApproval(gwName, connName string) error {
+	data := map[string]string{
+		"action":          "disable_transit_connection_learned_cidr_approval",
+		"CID":             c.CID,
+		"gateway_name":    gwName,
+		"connection_name": connName,
+	}
+	return c.PostAPI(data["action"], data, BasicCheck)
+}

--- a/website/docs/r/aviatrix_device_transit_gateway_attachment.html.markdown
+++ b/website/docs/r/aviatrix_device_transit_gateway_attachment.html.markdown
@@ -49,6 +49,7 @@ The following arguments are supported:
 * `pre_shared_key` - Pre-shared Key.
 * `local_tunnel_ip` - Local tunnel IP.
 * `remote_tunnel_ip` - Remote tunnel IP.
+* `enable_learned_cidrs_approval` - (Optional) Enable learned CIDRs approval for the connection. Requires the transit_gateway's 'learned_cidrs_approval_mode' attribute be set to 'connection'. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
 
 
 ## Import

--- a/website/docs/r/aviatrix_transit_external_device_conn.html.markdown
+++ b/website/docs/r/aviatrix_transit_external_device_conn.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 * `remote_tunnel_cidr` - (Optional) Destination CIDR for the tunnel to the external device.
 * `enable_edge_segmentation` - (Optional) Switch to allow this connection to communicate with a Security Domain via Connection Policy.
 * `switch_to_ha_standby_gateway` - (Optional) Switch to HA Standby Transit Gateway connection. Only valid with Transit Gateway that has [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby) enabled and for non-HA external device. Valid values: true, false. Default: false. Available in provider version R2.17.1+.
+* `enable_learned_cidrs_approval` - (Optional) Enable learned CIDRs approval for the connection. Only valid with 'connection_type' = 'bgp'. Requires the transit_gateway's 'learned_cidrs_approval_mode' attribute be set to 'connection'. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
 
 ## Import
 

--- a/website/docs/r/aviatrix_transit_gateway.html.markdown
+++ b/website/docs/r/aviatrix_transit_gateway.html.markdown
@@ -160,13 +160,19 @@ The following arguments are supported:
 * `filtered_spoke_vpc_routes` - (Optional) A list of comma separated CIDRs to be filtered from the spoke VPC route table. When configured, filtering CIDR(s) or it’s subnet will be deleted from VPC routing tables as well as from spoke gateway’s routing table. It applies to all spoke gateways attached to this transit gateway. Example: "10.2.0.0/116,10.3.0.0/16".
 * `excluded_advertised_spoke_routes` - (Optional) A list of comma separated CIDRs to be advertised to on-prem as 'Excluded CIDR List'. When configured, it inspects all the advertised CIDRs from its spoke gateways and remove those included in the 'Excluded CIDR List'. Example: "10.4.0.0/116,10.5.0.0/16".
 
+### [Learned CIDRs Approval](https://docs.aviatrix.com/HowTos/transit_approval.html)
+
+-> **NOTE:** `enable_learned_cidrs_approval` can be set to true only if `learned_cidrs_approval_mode` is set to 'gateway'. If `learned_cidrs_approval_mode` is set to 'connection' then enabling learned CIDRs approval is handled within each individual connection resource.
+
+* `enable_learned_cidrs_approval` - (Optional) Switch to enable/disable encrypted transit approval for transit gateway. Valid values: true, false. Default value: false.
+* `learned_cidrs_approval_mode` - (Optional) Learned CIDRs approval mode. Either "gateway" (approval on a per gateway basis) or "connection" (approval on a per connection basis). Default value: "gateway". Available as of provider version R2.18+.
+
 ### Misc.
 * `allocate_new_eip` - (Optional) When value is false, reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway. Available in Controller 4.7+. Valid values: true, false. Default: true. Option not available for Azure and OCI gateways, they will automatically allocate new EIPs.
 * `eip` - (Optional) Required when `allocate_new_eip` is false. It uses the specified EIP for this gateway. Available in Controller version 4.7+. Only available for AWS and GCP.
 * `tag_list` - (Optional) Instance tag of cloud provider. Only supported for AWS and AWSGOV. Example: ["key1:value1","key2:value2"].
 * `enable_active_mesh` - (Optional) Switch to enable/disable [Active Mesh Mode](https://docs.aviatrix.com/HowTos/activemesh_faq.html) for Transit Gateway. Valid values: true, false. Default value: false.
 * `enable_vpc_dns_server` - (Optional) Enable VPC DNS Server for Gateway. Currently only supports AWS and AWSGOV. Valid values: true, false. Default value: false.
-* `enable_learned_cidrs_approval` - (Optional) Switch to enable/disable [encrypted transit approval](https://docs.aviatrix.com/HowTos/transit_approval.html) for transit Gateway. Valid values: true, false. Default value: false.
 * `zone` - (Optional) Availability Zone. Only available for cloud_type = 8 (AZURE). Must be in the form 'az-n', for example, 'az-2'. Available in provider version R2.17+.
 * `enable_active_standby` - (Optional) Enables [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby). Available only with Active Mesh Mode enabled and HA enabled. Valid values: true, false. Default value: false. Available in provider version R2.17.1+.
 


### PR DESCRIPTION
Adds the ability to configure Learned CIDRs Approval on a per Connection basis (Currently we only support this feature on a per Gateway basis).

To accomplish this we first need to allow configuring of the Approval Mode on the transit_gateway. We add a single String attribute `learned_cidrs_approval_mode` to the transit_gateway resource. To configure connection based approval, this attribute must be set to "connection", by default the mode is "gateway".

To configure the approval per connection we added a Boolean attribute `enable_learned_cidrs_approval` to the 2 transit gateway attachment resources that allow configuring this.
- aviatrix_device_transit_gateway_attachment
- aviatrix_transit_external_device_conn