### PR TITLE
18662: made splunk logging support file path, not content

### DIFF
--- a/aviatrix/resource_aviatrix_splunk_logging_test.go
+++ b/aviatrix/resource_aviatrix_splunk_logging_test.go
@@ -34,9 +34,10 @@ func TestAccAviatrixSplunkLogging_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"custom_output_config_file_path"},
 			},
 		},
 	})
@@ -61,9 +62,9 @@ func testAccCheckSplunkLoggingExists(resourceName string) resource.TestCheckFunc
 
 		client := testAccProvider.Meta().(*goaviatrix.Client)
 
-		resp, _ := client.GetSplunkLoggingStatus()
-		if resp.Status != "enabled" {
-			return fmt.Errorf("splunk logging not found")
+		_, err := client.GetSplunkLoggingStatus()
+		if err == goaviatrix.ErrNotFound {
+			return fmt.Errorf("splunk logging not found: %s", resourceName)
 		}
 
 		return nil
@@ -90,8 +91,8 @@ func testAccCheckSplunkLoggingDestroy(s *terraform.State) error {
 			continue
 		}
 
-		resp, _ := client.GetSplunkLoggingStatus()
-		if resp.Status == "enabled" {
+		_, err := client.GetSplunkLoggingStatus()
+		if err != goaviatrix.ErrNotFound {
 			return fmt.Errorf("splunk_logging still exists")
 		}
 	}

--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -233,11 +233,8 @@ func (c *Client) Delete(path string, i interface{}) (*http.Response, error) {
 }
 
 type File struct {
-	Path        string
-	ParamName   string
-	RealFile    bool   // when using the file content instead of file path, set this to true
-	FileName    string // use when RealFile is true
-	FileContent string // use when RealFile is true
+	Path      string
+	ParamName string
 }
 
 // PostFile will encode the files and parameters with multipart form encoding.
@@ -247,39 +244,27 @@ func (c *Client) PostFile(path string, params map[string]string, files []File) (
 
 	// Encode the files
 	for _, f := range files {
-		if !f.RealFile {
-			if f.Path == "" {
-				continue
-			}
-
-			file, err := os.Open(f.Path)
-			if err != nil {
-				return nil, err
-			}
-			fileContents, err := ioutil.ReadAll(file)
-			if err != nil {
-				return nil, err
-			}
-			fi, err := file.Stat()
-			if err != nil {
-				return nil, err
-			}
-			_ = file.Close()
-			part, err := createFormFile(f.ParamName, fi.Name(), http.DetectContentType(fileContents), writer)
-			if err != nil {
-				return nil, err
-			}
-			_, _ = part.Write(fileContents)
-		} else {
-			fileContents := []byte(f.FileContent)
-
-			part, err := createFormFile(f.ParamName, f.FileName, http.DetectContentType(fileContents), writer)
-			if err != nil {
-				return nil, err
-			}
-			_, _ = part.Write(fileContents)
+		if f.Path == "" {
+			continue
 		}
-
+		file, err := os.Open(f.Path)
+		if err != nil {
+			return nil, err
+		}
+		fileContents, err := ioutil.ReadAll(file)
+		if err != nil {
+			return nil, err
+		}
+		fi, err := file.Stat()
+		if err != nil {
+			return nil, err
+		}
+		_ = file.Close()
+		part, err := createFormFile(f.ParamName, fi.Name(), http.DetectContentType(fileContents), writer)
+		if err != nil {
+			return nil, err
+		}
+		_, _ = part.Write(fileContents)
 	}
 
 	// Encode the other params

--- a/goaviatrix/splunk_logging.go
+++ b/goaviatrix/splunk_logging.go
@@ -8,7 +8,7 @@ type SplunkLogging struct {
 	CID                   string
 	Server                string
 	Port                  int
-	ConfigFile            string
+	ConfigFilePath        string
 	CustomConfig          string
 	ExcludedGatewaysInput string
 	UseConfigFile         bool
@@ -17,7 +17,6 @@ type SplunkLogging struct {
 type SplunkLoggingResp struct {
 	Server           string   `json:"server_ip"`
 	Port             string   `json:"server_port"`
-	ConfigFile       string   `json:"custom_input_file"`
 	CustomConfig     string   `json:"custom_input_cfg"`
 	ExcludedGateways []string `json:"excluded_gateway"`
 	Status           string   `json:"status"`
@@ -34,10 +33,8 @@ func (c *Client) EnableSplunkLogging(r *SplunkLogging) error {
 
 		files := []File{
 			{
-				ParamName:   "cu_output_cfg",
-				RealFile:    true,
-				FileName:    "configuration.txt", // fake name for configuration file
-				FileContent: r.ConfigFile,
+				Path:      r.ConfigFilePath,
+				ParamName: "cu_output_cfg",
 			},
 		}
 
@@ -73,6 +70,10 @@ func (c *Client) GetSplunkLoggingStatus() (*SplunkLoggingResp, error) {
 	err := c.GetAPI(&data, params["action"], params, BasicCheck)
 	if err != nil {
 		return nil, err
+	}
+
+	if data.Results.Status == "disabled" {
+		return nil, ErrNotFound
 	}
 
 	return &data.Results, nil

--- a/test-infra/README_accep_test.md
+++ b/test-infra/README_accep_test.md
@@ -82,7 +82,7 @@ Passing an environment value of "yes" to the skip parameter allows you to skip t
 | aviatrix_segmentation_security_domain_association | SKIP_SEGMENTATION_SECURITY_DOMAIN_ASSOCIATION | aviatrix_gateway + AWS_VPC_ID2, AWS_REGION2, AWS_SUBNET2 |
 | aviatrix_segmentation_security_domain_connection_policy | SKIP_SEGMENTATION_SECURITY_DOMAIN_CONNECTION_POLICY | N/A                                        |
 | aviatrix_site2cloud                  | SKIP_S2C                           | aviatrix_gateway                                                               |
-| aviatrix_splunk_logging              | SKIP_SPLUNK_LOGGING                | N/A
+| aviatrix_splunk_logging              | SKIP_SPLUNK_LOGGING                | N/A                                                                            |
 | aviatrix_spoke_gateway               | SKIP_SPOKE_GATEWAY                 | aviatrix_gateway                                                               |
 |                                      | SKIP_SPOKE_GATEWAY_AWS             |         + AWS_VPC_ID, AWS_REGION, AWS_SUBNET, AWS_GW_SIZE (optional)           |
 |                                      | SKIP_SPOKE_GATEWAY_GCP             |         + GCP_VPC_ID, GCP_ZONE, GCP_SUBNET, GCP_GW_SIZE (optional)             |

--- a/website/docs/r/aviatrix_splunk_logging.html.markdown
+++ b/website/docs/r/aviatrix_splunk_logging.html.markdown
@@ -23,7 +23,7 @@ resource "aviatrix_splunk_logging" "test_splunk_logging" {
 ```hcl
 # Enable splunk logging using configuration file
 resource "aviatrix_splunk_logging" "test_splunk_logging" {
-  custom_output_configuration = file("/path/to/configuration.file")
+  custom_output_config_file_path = "/path/to/configuration.file"
 }
 ```
 
@@ -34,10 +34,10 @@ The following arguments are supported:
 ### Required
 * `server` (Optional) Server IP. Either `server` and `port` combination or `cu_output_configuration` is required.
 * `port` (Optional) Port number.
-* `custom_output_configuration` (Optional) Configuration file. Use the file function to read from a file.
+* `custom_output_config_file_path` (Optional) Configuration file path.
 
 ### Optional
-* `custom_input_configuration` (Optional) Custom configuration.
+* `custom_input_config` (Optional) Custom configuration.
 * `excluded_gateways` (Optional) List of gateways to be excluded from logging. e.g.: ["gateway01", "gateway02", "gateway01-hagw"].
 
 ## Attribute Reference


### PR DESCRIPTION
The config file is a zip file of several files, so the file content cannot be supported. 
PostFile() was also changed back.
Made sure ErrNotFound is returned when the resource is not found.