### PR TITLE
18784: manual advertise cidrs per conn

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -355,18 +355,3 @@ func resourceAviatrixTransitGatewayPeeringDelete(d *schema.ResourceData, meta in
 
 	return nil
 }
-
-func setConfigValueIfEquivalent(d *schema.ResourceData, k string, fromConfig, fromAPI []string) error {
-	if goaviatrix.Equivalent(fromConfig, fromAPI) {
-		return d.Set(k, fromConfig)
-	}
-	return d.Set(k, fromAPI)
-}
-
-func getStringList(d *schema.ResourceData, k string) []string {
-	var sl []string
-	for _, v := range d.Get(k).([]interface{}) {
-		sl = append(sl, v.(string))
-	}
-	return sl
-}

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -58,3 +58,28 @@ func DiffSuppressFuncIgnoreSpaceInString(k, old, new string, d *schema.ResourceD
 
 	return goaviatrix.Equivalent(oldValue, newValue)
 }
+
+func setConfigValueIfEquivalent(d *schema.ResourceData, k string, fromConfig, fromAPI []string) error {
+	if goaviatrix.Equivalent(fromConfig, fromAPI) {
+		return d.Set(k, fromConfig)
+	}
+	return d.Set(k, fromAPI)
+}
+
+// getStringList will convert a TypeList attribute to a slice of string
+func getStringList(d *schema.ResourceData, k string) []string {
+	var sl []string
+	for _, v := range d.Get(k).([]interface{}) {
+		sl = append(sl, v.(string))
+	}
+	return sl
+}
+
+// getStringSet will convert a TypeSet attribute to a slice of string
+func getStringSet(d *schema.ResourceData, k string) []string {
+	var sl []string
+	for _, v := range d.Get(k).(*schema.Set).List() {
+		sl = append(sl, v.(string))
+	}
+	return sl
+}

--- a/goaviatrix/device_transit_gateway_attachment.go
+++ b/goaviatrix/device_transit_gateway_attachment.go
@@ -26,6 +26,7 @@ type DeviceTransitGatewayAttachment struct {
 	PreSharedKey            string `form:"pre_shared_key,omitempty"`
 	LocalTunnelIP           string `form:"local_tunnel_ip,omitempty"`
 	RemoteTunnelIP          string `form:"remote_tunnel_ip,omitempty"`
+	ManualBGPCidrs          []string
 	Action                  string `form:"action"`
 	CID                     string `form:"CID"`
 }
@@ -119,6 +120,7 @@ func (c *Client) GetDeviceTransitGatewayAttachment(attachment *DeviceTransitGate
 		EnableGlobalAccelerator: strconv.FormatBool(data.Results.Connections.EnableGlobalAccelerator),
 		LocalTunnelIP:           data.Results.Connections.BgpLocalIP,
 		RemoteTunnelIP:          data.Results.Connections.BgpRemoteIP,
+		ManualBGPCidrs:          data.Results.Connections.ManualBGPCidrs,
 	}, nil
 }
 

--- a/goaviatrix/site2cloud.go
+++ b/goaviatrix/site2cloud.go
@@ -142,6 +142,7 @@ type EditSite2CloudConnDetail struct {
 	LocalSourceVirtualCIDRs       string        `json:"local_src_virt_cidrs"`
 	LocalDestinationRealCIDRs     string        `json:"local_dst_real_cidrs"`
 	LocalDestinationVirtualCIDRs  string        `json:"local_dst_virt_cidrs"`
+	ManualBGPCidrs                []string      `json:"conn_bgp_manual_advertise_cidrs"`
 }
 
 type Site2CloudConnDetailResp struct {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"net/url"
 	"strconv"
 	"strings"
 )
@@ -40,6 +39,7 @@ type ExternalDeviceConn struct {
 	BackupRemoteTunnelCidr string `form:"backup_remote_tunnel_ip,omitempty"`
 	BackupDirectConnect    string `form:"backup_direct_connect,omitempty"`
 	EnableEdgeSegmentation string `form:"connection_policy,omitempty"`
+	ManualBGPCidrs         []string
 }
 
 type EditExternalDeviceConnDetail struct {
@@ -63,6 +63,7 @@ type EditExternalDeviceConnDetail struct {
 	EnableEdgeSegmentation bool          `json:"enable_edge_segmentation,omitempty"`
 	Tunnels                []TunnelInfo  `json:"tunnels,omitempty"`
 	ActiveActiveHA         string        `json:"active_active_ha,omitempty"`
+	ManualBGPCidrs         []string      `json:"conn_bgp_manual_advertise_cidrs"`
 	BackupRemoteGatewayIP  string
 	PreSharedKey           string
 	BackupPreSharedKey     string
@@ -100,34 +101,25 @@ func (c *Client) CreateExternalDeviceConn(externalDeviceConn *ExternalDeviceConn
 }
 
 func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceConn) (*ExternalDeviceConn, error) {
-	Url, err := url.Parse(c.baseURL)
-	if err != nil {
-		return nil, errors.New(("url Parsing failed for 'GetExternalDeviceConnDetail': ") + err.Error())
+	params := map[string]string{
+		"CID":       c.CID,
+		"action":    "get_site2cloud_conn_detail",
+		"conn_name": externalDeviceConn.ConnectionName,
+		"vpc_id":    externalDeviceConn.VpcID,
 	}
-
-	getExternalDeviceConnDetail := url.Values{}
-	getExternalDeviceConnDetail.Add("CID", c.CID)
-	getExternalDeviceConnDetail.Add("action", "get_site2cloud_conn_detail")
-	getExternalDeviceConnDetail.Add("conn_name", externalDeviceConn.ConnectionName)
-	getExternalDeviceConnDetail.Add("vpc_id", externalDeviceConn.VpcID)
-	Url.RawQuery = getExternalDeviceConnDetail.Encode()
-	resp, err := c.Get(Url.String(), nil)
-	if err != nil {
-		return nil, errors.New("HTTP Get 'get_site2cloud_conn_detail' failed: " + err.Error())
+	checkFunc := func(action, reason string, ret bool) error {
+		if !ret {
+			if strings.Contains(reason, "does not exist") {
+				return ErrNotFound
+			}
+			return errors.New("Rest API 'get_site2cloud_conn_detail' Get failed: " + reason)
+		}
+		return nil
 	}
 	var data ExternalDeviceConnDetailResp
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
-	bodyString := buf.String()
-	bodyIoCopy := strings.NewReader(bodyString)
-	if err = json.NewDecoder(bodyIoCopy).Decode(&data); err != nil {
-		return nil, errors.New("Json Decode 'get_site2cloud_conn_detail' failed: " + err.Error() + "\n Body: " + bodyString)
-	}
-	if !data.Return {
-		if strings.Contains(data.Reason, "does not exist") {
-			return nil, ErrNotFound
-		}
-		return nil, errors.New("Rest API 'get_site2cloud_conn_detail' Get failed: " + data.Reason)
+	err := c.GetAPI(&data, params["action"], params, checkFunc)
+	if err != nil {
+		return nil, err
 	}
 
 	externalDeviceConnDetail := data.Results.Connections
@@ -241,6 +233,7 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 		} else {
 			externalDeviceConn.EnableEdgeSegmentation = "disabled"
 		}
+		externalDeviceConn.ManualBGPCidrs = externalDeviceConnDetail.ManualBGPCidrs
 
 		return externalDeviceConn, nil
 	}

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -677,3 +677,14 @@ func (c *Client) DisableTransitConnectionLearnedCIDRApproval(gwName, connName st
 	}
 	return c.PostAPI(data["action"], data, BasicCheck)
 }
+
+func (c *Client) EditTransitConnectionBGPManualAdvertiseCIDRs(gwName, connName string, cidrs []string) error {
+	data := map[string]string{
+		"action":                                "edit_transit_connection_bgp_manual_advertise_cidrs",
+		"CID":                                   c.CID,
+		"gateway_name":                          gwName,
+		"connection_name":                       connName,
+		"connection_bgp_manual_advertise_cidrs": strings.Join(cidrs, ","),
+	}
+	return c.PostAPI(data["action"], data, BasicCheck)
+}

--- a/website/docs/r/aviatrix_device_transit_gateway_attachment.html.markdown
+++ b/website/docs/r/aviatrix_device_transit_gateway_attachment.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `local_tunnel_ip` - Local tunnel IP.
 * `remote_tunnel_ip` - Remote tunnel IP.
 * `enable_learned_cidrs_approval` - (Optional) Enable learned CIDRs approval for the connection. Requires the transit_gateway's 'learned_cidrs_approval_mode' attribute be set to 'connection'. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
+* `manual_bgp_advertised_cidrs` - (Optional) Configure manual BGP advertised CIDRs for this connection. Available as of provider version R2.18+.
 
 
 ## Import

--- a/website/docs/r/aviatrix_transit_external_device_conn.html.markdown
+++ b/website/docs/r/aviatrix_transit_external_device_conn.html.markdown
@@ -67,6 +67,7 @@ The following arguments are supported:
 * `enable_edge_segmentation` - (Optional) Switch to allow this connection to communicate with a Security Domain via Connection Policy.
 * `switch_to_ha_standby_gateway` - (Optional) Switch to HA Standby Transit Gateway connection. Only valid with Transit Gateway that has [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby) enabled and for non-HA external device. Valid values: true, false. Default: false. Available in provider version R2.17.1+.
 * `enable_learned_cidrs_approval` - (Optional) Enable learned CIDRs approval for the connection. Only valid with 'connection_type' = 'bgp'. Requires the transit_gateway's 'learned_cidrs_approval_mode' attribute be set to 'connection'. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
+* `manual_bgp_advertised_cidrs` - (Optional) Configure manual BGP advertised CIDRs for this connection. Only valid with 'connection_type'= 'bgp'. Available as of provider version R2.18+.
 
 ## Import
 

--- a/website/docs/r/aviatrix_vgw_conn.html.markdown
+++ b/website/docs/r/aviatrix_vgw_conn.html.markdown
@@ -40,6 +40,7 @@ The following arguments are supported:
 
 ### Optional
 * `enable_learned_cidrs_approval` - (Optional) Enable learned CIDRs approval for the connection. Requires the transit_gateway's 'learned_cidrs_approval_mode' attribute be set to 'connection'. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
+* `manual_bgp_advertised_cidrs` - (Optional) Configure manual BGP advertised CIDRs for this connection. Available as of provider version R2.18+.
 
 The following arguments are deprecated:
 


### PR DESCRIPTION
This PR adds the ability to set the manual BGP advertised cidrs on a per connection basis.
New attribute TypeSet of String: `manual_bgp_advertised_cidrs` added to 3 new resources:
- device_transit_gateway_attachment
- transit_external_device_conn (connection_type == bgp only)
- vgw_conn
