### PR TITLE
18605: add ha_lan_interface_cidr to transit_gateway

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -325,6 +325,11 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Computed:    true,
 				Description: "Transit gateway lan interface cidr.",
 			},
+			"ha_lan_interface_cidr": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Transit gateway lan interface cidr for the HA gateway.",
+			},
 		},
 	}
 }
@@ -1142,6 +1147,11 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		d.Set("ha_cloud_instance_id", haGw.CloudnGatewayInstID)
 		d.Set("ha_gw_name", haGw.GwName)
 		d.Set("ha_private_ip", haGw.PrivateIP)
+		lanCidr, err := client.GetTransitGatewayLanCidr(haGw.GwName)
+		if err != nil && err != goaviatrix.ErrNotFound {
+			log.Printf("[WARN] Error getting lan cidr for HA transit gateway %s due to %s", haGw.GwName, err)
+		}
+		d.Set("ha_lan_interface_cidr", lanCidr)
 	}
 
 	if haGw.InsaneMode == "yes" && (haGw.CloudType == goaviatrix.AWS || haGw.CloudType == goaviatrix.AWSGOV) {

--- a/website/docs/r/aviatrix_transit_gateway.html.markdown
+++ b/website/docs/r/aviatrix_transit_gateway.html.markdown
@@ -190,6 +190,7 @@ In addition to all arguments above, the following attributes are exported:
 * `ha_gw_name` - Aviatrix transit gateway unique name of HA transit gateway.
 * `ha_private_ip` - Private IP address of the HA transit gateway created.
 * `lan_interface_cidr` - Lan interface cidr of the transit gateway created (will be used when enabling FQDN Firenet in Azure). Available in provider version R2.17.1+.
+* `ha_lan_interface_cidr` - Lan interface cidr of the HA transit gateway created (will be used when enabling FQDN Firenet in Azure). Available in provider version R2.18+.
 
 The following arguments are deprecated:
 


### PR DESCRIPTION
PR 7️⃣ 0️⃣ 0️⃣ 🎉 

This PR adds a Computed attribute to transit_gateway to get the LAN interface CIDR of the ha transit gateway. This is used in the Azure fqdn gateway use case.