### PR TITLE
19171: Monitor Gateway Subnets for Transit and Spoke gateways

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -882,15 +882,11 @@ func resourceAviatrixGatewayCreate(d *schema.ResourceData, meta interface{}) err
 		if d.Get("cloud_type").(int) != goaviatrix.AWS && d.Get("cloud_type").(int) != goaviatrix.AWSGOV {
 			return fmt.Errorf("monitor gateway subnets feature only supported for AWS and AWSGOV")
 		}
-		gwMonitorSubnetsServer := &goaviatrix.Gateway{
-			GwName:               d.Get("gw_name").(string),
-			MonitorExcludeGWList: strings.Split(d.Get("monitor_exclude_list").(string), ","),
-		}
-
-		log.Printf("[INFO] Enable Monitor Gatway Subnets: %#v", gwMonitorSubnetsServer)
-		err := client.EnableMonitorGatewaySubnets(gwMonitorSubnetsServer)
+		log.Printf("[INFO] Enable Monitor Gateway Subnets")
+		excludedInstances := strings.Split(d.Get("monitor_exclude_list").(string), ",")
+		err := client.EnableMonitorGatewaySubnets(gateway.GwName, excludedInstances)
 		if err != nil {
-			return fmt.Errorf("fail to enable monitor gateway subnets due to : %s", err)
+			return fmt.Errorf("fail to enable monitor gateway subnets: %v", err)
 		}
 	}
 
@@ -2111,45 +2107,33 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 			if d.Get("cloud_type").(int) != goaviatrix.AWS && d.Get("cloud_type").(int) != goaviatrix.AWSGOV {
 				return fmt.Errorf("monitor gateway subnet feature only supported for AWS and AWSGOV")
 			}
-			gwMonitorSubnetsServer := &goaviatrix.Gateway{
-				GwName:               d.Get("gw_name").(string),
-				MonitorExcludeGWList: strings.Split(d.Get("monitor_exclude_list").(string), ","),
-			}
-			log.Printf("[INFO] Enable Monitor Gatway Subnets: %#v", gwMonitorSubnetsServer)
-			err := client.EnableMonitorGatewaySubnets(gwMonitorSubnetsServer)
+			log.Printf("[INFO] Enable Monitor Gatway Subnets")
+			excludedInstances := strings.Split(d.Get("monitor_exclude_list").(string), ",")
+			err := client.EnableMonitorGatewaySubnets(gateway.GwName, excludedInstances)
 			if err != nil {
-				return fmt.Errorf("fail to enable monitor gateway subnets due to : %s", err)
+				return fmt.Errorf("fail to enable monitor gateway subnets: %v", err)
 			}
 		} else {
-			gwMonitorSubnetsServer := &goaviatrix.Gateway{
-				GwName: d.Get("gw_name").(string),
-			}
-			log.Printf("[INFO] Disable Monitor Gatway Subnets: %#v", gwMonitorSubnetsServer)
-			err := client.DisableMonitorGatewaySubnets(gwMonitorSubnetsServer)
+			log.Printf("[INFO] Disable Monitor Gatway Subnets")
+			err := client.DisableMonitorGatewaySubnets(gateway.GwName)
 			if err != nil {
-				return fmt.Errorf("fail to disable monitor gateway subnets due to : %s", err)
+				return fmt.Errorf("fail to disable monitor gateway subnets: %v", err)
 			}
 		}
 	} else if d.HasChange("monitor_exclude_list") {
-		if d.Get("enable_monitor_gateway_subnets").(bool) {
-			gwMonitorSubnetsServer := &goaviatrix.Gateway{
-				GwName: d.Get("gw_name").(string),
-			}
-			log.Printf("[INFO] Disable Monitor Gatway Subnets: %#v", gwMonitorSubnetsServer)
-			err := client.DisableMonitorGatewaySubnets(gwMonitorSubnetsServer)
-			if err != nil {
-				return fmt.Errorf("fail to disable monitor gateway subnets due to : %s", err)
-			}
-
-			gwMonitorSubnetsServer.MonitorExcludeGWList = strings.Split(d.Get("monitor_exclude_list").(string), ",")
-			log.Printf("[INFO] Enable Monitor Gatway Subnets with updated excluded list due to : %#v", gwMonitorSubnetsServer)
-			err = client.EnableMonitorGatewaySubnets(gwMonitorSubnetsServer)
-			if err != nil {
-				return fmt.Errorf("fail to enable monitor gateway subnets with updated excluded list due to : %s", err)
-			}
-		}
 		if !d.Get("enable_monitor_gateway_subnets").(bool) {
 			return fmt.Errorf("please enable the monitor gateway subnets feature before updating exclude monitor list")
+		}
+		log.Printf("[INFO] Disable Monitor Gatway Subnets")
+		err := client.DisableMonitorGatewaySubnets(gateway.GwName)
+		if err != nil {
+			return fmt.Errorf("fail to disable monitor gateway subnets due to : %s", err)
+		}
+		excludedInstances := strings.Split(d.Get("monitor_exclude_list").(string), ",")
+		log.Printf("[INFO] Enable Monitor Gatway Subnets with updated excluded list")
+		err = client.EnableMonitorGatewaySubnets(gateway.GwName, excludedInstances)
+		if err != nil {
+			return fmt.Errorf("fail to enable monitor gateway subnets with updated excluded list: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -328,6 +328,21 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Default:     false,
 				Description: "Enables Active-Standby Mode, available only with Active Mesh Mode and HA enabled.",
 			},
+			"enable_monitor_gateway_subnets": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Enable [monitor gateway subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet). " +
+					"Only valid for cloud_type = 1 (AWS) or 256 (AWSGOV). Valid values: true, false. Default value: false.",
+			},
+			"monitor_exclude_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A set of monitored instance ids. Only valid when 'enable_monitor_gateway_subnets' = true.",
+			},
 			"lan_interface_cidr": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -515,6 +530,18 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 	if learnedCidrsApproval && d.Get("learned_cidrs_approval_mode").(string) == "connection" {
 		return fmt.Errorf("'enable_learned_cidrs_approval' must be false if 'learned_cidrs_approval_mode' is set to 'connection'")
+	}
+
+	enableMonitorSubnets := d.Get("enable_monitor_gateway_subnets").(bool)
+	var excludedInstances []string
+	for _, v := range d.Get("monitor_exclude_list").(*schema.Set).List() {
+		excludedInstances = append(excludedInstances, v.(string))
+	}
+	if enableMonitorSubnets && cloudType != goaviatrix.AWS && cloudType != goaviatrix.AWSGOV {
+		return fmt.Errorf("'enable_monitor_gateway_subnets' is only valid for cloud_type = 1 (AWS) or 256 (AWSGOV)")
+	}
+	if !enableMonitorSubnets && len(excludedInstances) != 0 {
+		return fmt.Errorf("'monitor_exclude_list' must be empty if 'enable_monitor_gateway_subnets' is false")
 	}
 
 	log.Printf("[INFO] Creating Aviatrix Transit Gateway: %#v", gateway)
@@ -870,6 +897,13 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		}
 	}
 
+	if enableMonitorSubnets {
+		err := client.EnableMonitorGatewaySubnets(gateway.GwName, excludedInstances)
+		if err != nil {
+			return fmt.Errorf("could not enable monitor gateway subnets: %v", err)
+		}
+	}
+
 	return resourceAviatrixTransitGatewayReadIfRequired(d, meta, &flag)
 }
 
@@ -1094,6 +1128,11 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 			log.Printf("[WARN] Error getting lan cidr for transit gateway %s due to %s", gw.GwName, err)
 		}
 		d.Set("lan_interface_cidr", lanCidr)
+
+		d.Set("enable_monitor_gateway_subnets", gw.MonitorSubnetsAction == "enable")
+		if err := d.Set("monitor_exclude_list", gw.MonitorExcludeGWList); err != nil {
+			return fmt.Errorf("setting 'monitor_exclude_list' to state: %v", err)
+		}
 	}
 
 	if gw.CloudType == goaviatrix.AWS || gw.CloudType == goaviatrix.AWSGOV {
@@ -2062,6 +2101,37 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		err := client.UpdateTransitGatewayCustomizedVpcRoute(gateway.GwName, customizeTransitVpcRoute)
 		if err != nil {
 			return fmt.Errorf("couldn't update transit gateway customized vpc route: %s", err)
+		}
+	}
+
+	monitorGatewaySubnets := d.Get("enable_monitor_gateway_subnets").(bool)
+	var excludedInstances []string
+	for _, v := range d.Get("monitor_exclude_list").(*schema.Set).List() {
+		excludedInstances = append(excludedInstances, v.(string))
+	}
+	if !monitorGatewaySubnets && len(excludedInstances) != 0 {
+		return fmt.Errorf("'monitor_exclude_list' must be empty if 'enable_monitor_gateway_subnets' is false")
+	}
+	if d.HasChange("enable_monitor_gateway_subnets") {
+		if monitorGatewaySubnets {
+			err := client.EnableMonitorGatewaySubnets(gateway.GwName, excludedInstances)
+			if err != nil {
+				return fmt.Errorf("could not enable monitor gateway subnets: %v", err)
+			}
+		} else {
+			err := client.DisableMonitorGatewaySubnets(gateway.GwName)
+			if err != nil {
+				return fmt.Errorf("could not disable monitor gateway subnets: %v", err)
+			}
+		}
+	} else if d.HasChange("monitor_exclude_list") {
+		err := client.DisableMonitorGatewaySubnets(gateway.GwName)
+		if err != nil {
+			return fmt.Errorf("could not disable monitor gateway subnets: %v", err)
+		}
+		err = client.EnableMonitorGatewaySubnets(gateway.GwName, excludedInstances)
+		if err != nil {
+			return fmt.Errorf("could not enable monitor gateway subnets: %v", err)
 		}
 	}
 

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -132,6 +132,12 @@ The following arguments are supported:
 * `filtered_spoke_vpc_routes` - (Optional) A list of comma separated CIDRs to be filtered from the spoke VPC route table. When configured, filtering CIDR(s) or it’s subnet will be deleted from VPC routing tables as well as from spoke gateway’s routing table. It applies to this spoke gateway only. Example: "10.2.0.0/116,10.3.0.0/16".
 * `included_advertised_spoke_routes` - (Optional) A list of comma separated CIDRs to be advertised to on-prem as 'Included CIDR List'. When configured, it will replace all advertised routes from this VPC. Example: "10.4.0.0/116,10.5.0.0/16".
 
+### [Monitor Gateway Subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet)
+~> **NOTE:** This feature is only available for AWS gateways.
+
+* `enable_monitor_gateway_subnets` - (Optional) If set to true, the [Monitor Gateway Subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet) feature is enabled. Default value is false. Available in provider version R2.18+.
+* `monitor_exclude_list` - (Optional) Set of monitored instance ids. Only valid when 'enable_monitor_gateway_subnets' = true. Available in provider version R2.18+.
+
 ### Misc.
 * `allocate_new_eip` - (Optional) When value is false, reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway. Available in Controller 4.7+. Valid values: true, false. Default: true. Option not available for AZURE and OCI gateways, they will automatically allocate new EIPs.
 * `eip` - (Optional) Required when `allocate_new_eip` is false. It uses the specified EIP for this gateway. Available in Controller 4.7+. Only available for AWS, GCP and AWSGOV.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -172,6 +172,12 @@ The following arguments are supported:
 * `enable_learned_cidrs_approval` - (Optional) Switch to enable/disable encrypted transit approval for transit gateway. Valid values: true, false. Default value: false.
 * `learned_cidrs_approval_mode` - (Optional) Learned CIDRs approval mode. Either "gateway" (approval on a per gateway basis) or "connection" (approval on a per connection basis). Default value: "gateway". Available as of provider version R2.18+.
 
+### [Monitor Gateway Subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet)
+~> **NOTE:** This feature is only available for AWS gateways.
+
+* `enable_monitor_gateway_subnets` - (Optional) If set to true, the [Monitor Gateway Subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet) feature is enabled. Default value is false. Available in provider version R2.18+.
+* `monitor_exclude_list` - (Optional) Set of monitored instance ids. Only valid when 'enable_monitor_gateway_subnets' = true. Available in provider version R2.18+.
+
 ### Misc.
 * `allocate_new_eip` - (Optional) When value is false, reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway. Available in Controller 4.7+. Valid values: true, false. Default: true. Option not available for Azure and OCI gateways, they will automatically allocate new EIPs.
 * `eip` - (Optional) Required when `allocate_new_eip` is false. It uses the specified EIP for this gateway. Available in Controller version 4.7+. Only available for AWS and GCP.

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -1270,25 +1270,25 @@ func (c *Client) DisableEgressTransitFirenet(transitGateway *TransitVpc) error {
 	return c.PostAPI(action, data, BasicCheck)
 }
 
-func (c *Client) EnableMonitorGatewaySubnets(gateway *Gateway) error {
+func (c *Client) EnableMonitorGatewaySubnets(gwName string, excludedInstances []string) error {
 	action := "enable_monitor_gateway_subnets"
-	form := map[string]interface{}{
+	form := map[string]string{
 		"CID":          c.CID,
 		"action":       action,
-		"gateway_name": gateway.GwName,
+		"gateway_name": gwName,
 	}
-	if len(gateway.MonitorExcludeGWList) != 0 {
-		form["monitor_exclude_gateway_list"] = strings.Join(gateway.MonitorExcludeGWList, ",")
+	if len(excludedInstances) != 0 {
+		form["monitor_exclude_gateway_list"] = strings.Join(excludedInstances, ",")
 	}
 	return c.PostAPI(action, form, BasicCheck)
 }
 
-func (c *Client) DisableMonitorGatewaySubnets(gateway *Gateway) error {
+func (c *Client) DisableMonitorGatewaySubnets(gwName string) error {
 	action := "disable_monitor_gateway_subnets"
-	form := map[string]interface{}{
+	form := map[string]string{
 		"CID":          c.CID,
 		"action":       action,
-		"gateway_name": gateway.GwName,
+		"gateway_name": gwName,
 	}
 	return c.PostAPI(action, form, BasicCheck)
 }


### PR DESCRIPTION
Modified `EnableMonitorGatewaySubnets` and `DisableMonitorGatewaySubnets` to be more generic for use in Transit and Spoke gateways
Add `enable_monitor_gateway_subnets` and `monitor_exclude_list` to transit_gateway and spoke_gateway
