### PR TITLE
19458: change gateway monitor subnets type

### DIFF
--- a/aviatrix/resource_aviatrix_gateway_migrate.go
+++ b/aviatrix/resource_aviatrix_gateway_migrate.go
@@ -1,0 +1,30 @@
+package aviatrix
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAviatrixGatewayResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"monitor_exclude_list": {
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func resourceAviatrixGatewayStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if v, ok := rawState["monitor_exclude_list"]; ok {
+		excludedInstances, ok := v.(string)
+		if !ok {
+			rawState["monitor_exclude_list"] = []string{}
+		} else {
+			rawState["monitor_exclude_list"] = strings.Split(excludedInstances, ",")
+		}
+	}
+	return rawState, nil
+}

--- a/docs/resources/aviatrix_gateway.md
+++ b/docs/resources/aviatrix_gateway.md
@@ -247,7 +247,10 @@ The following arguments are supported:
 ~> **NOTE:** This feature is only available for AWS gateways.
 
 * `enable_monitor_gateway_subnets` - (Optional) If set to true, the [Monitor Gateway Subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet) feature is enabled. Default value is false. Available in provider version R2.17.1+.
-* `monitor_exclude_list` - (Optional) A list of monitored instance IDs separated by comma when monitoring feature is enabled. Default value is "". Available in provider version R2.17.1+.
+
+~> **NOTE:** In provider version R2.18 release, the attribute `monitor_exclude_list` changed type from a string of comma separated values to a set of strings. For example, if your `monitor_exclude_list` was "instance-1,instance-2,instance-3", now it would be ["instance-1", "instance-2", "instance-3"]. Please update your Terraform config files as necessary.
+
+* `monitor_exclude_list` - (Optional) Set of monitored instance ids. Only valid when 'enable_monitor_gateway_subnets' = true. Available in provider version R2.17.1+.
 
 ### FQDN Gateway
 ~> **NOTE:** This attribute is only to be used in Azure FQDN FireNet workflows.


### PR DESCRIPTION
Change aviatrix_gateway.monitor_exclude_list from TypeString to TypeSet
To make this change seamless to the user, we also bump the SchemaVersion and use a StateUpgrader to update the type in the state file. (Without this StateUpgrader the user would be forced to remove the resource from state and import it back to successfully change the attribute type)