### PR TITLE
18783: Azure BGP over LAN connection

### DIFF
--- a/docs/resources/aviatrix_transit_external_device_conn.md
+++ b/docs/resources/aviatrix_transit_external_device_conn.md
@@ -26,6 +26,20 @@ resource "aviatrix_transit_external_device_conn" "test" {
   remote_gateway_ip = "172.12.13.14"
 }
 ```
+```hcl
+# Create a BGP over LAN Aviatrix Transit External Device Connection with an Azure Transit Gateway
+resource "aviatrix_transit_external_device_conn" "ex-conn" {
+  vpc_id            = aviatrix_transit_gateway.transit-gateway.vpc_id
+  connection_name   = "my_conn"
+  gw_name           = aviatrix_transit_gateway.transit-gateway.gw_name
+  connection_type   = "bgp"
+  tunnel_protocol   = "LAN"
+  bgp_local_as_num  = "123"
+  bgp_remote_as_num = "345"
+  remote_gateway_ip = "172.12.13.14"
+  remote_vpc_name   = "vnet-name:resource-group-name"
+}
+```
 
 ## Argument Reference
 
@@ -36,11 +50,15 @@ The following arguments are supported:
 * `connection_name` - (Required) Transit external device connection name.
 * `gw_name` - (Required) Aviatrix transit gateway name.
 * `remote_gateway_ip` - (Required) Remote gateway IP.
-* `connection_type` - (Required) Connection type. Valid values: 'bpg', 'static'. Default value: 'bgp'.
+* `connection_type` - (Required) Connection type. Valid values: 'bgp', 'static'. Default value: 'bgp'.
 * `tunnel_protocol` - (Optional) Tunnel protocol, only valid with `connection_type` = 'bgp'. Valid values: 'IPsec', 'GRE' or 'LAN'. Default value: 'IPsec'. Available as of provider version R2.18+.
 * `bgp_local_as_num` - (Optional) BGP local ASN (Autonomous System Number). Integer between 1-4294967294. Required for 'bgp' connection.
 * `bgp_remote_as_num` - (Optional) BGP remote ASN (Autonomous System Number). Integer between 1-4294967294. Required for 'bgp' connection.
 * `remote_subnet` - (Optional) Remote CIDRs joined as a string with ','. Required for a 'static' type connection.
+
+~> **NOTE:** To create a BGP over LAN connection with an Azure Transit Gateway, the Transit Gateway must have it's 'enable_bgp_over_lan' attribute set to true.
+
+* `remote_vpc_name` - (Optional) Name of the remote VPC for a LAN BGP connection with an Azure Transit Gateway. Required when 'connection_type' = 'bgp' and tunnel_protocol' = 'LAN' with an Azure transit gateway. Must be in the form "<VNET-name>:<resource-group-name>". Available as of provider version R2.18+.
 
 ### HA
 * `ha_enabled` - (Optional) Set as true if there are two external devices.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -154,6 +154,7 @@ The following arguments are supported:
 * `prepend_as_path` - (Optional) List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
 * `local_as_number` - (Optional) Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations.
 * `bgp_ecmp` - (Optional) Enable Equal Cost Multi Path (ECMP) routing for the next hop. Default value: false.
+* `enable_bgp_over_lan` - (Optional) Pre-allocate a network interface(eth4) for "BGP over LAN" functionality. Must be enabled to create a BGP over LAN `aviatrix_transit_external_device_conn` resource with this Transit Gateway. Only valid for cloud_type = 8 (AZURE). Valid values: true or false. Default value: false. Available as of provider version R2.18+
 
 ### Encryption
 * `enable_encrypt_volume` - (Optional) Enable EBS volume encryption for Gateway. Only supports AWS and AWSGOV. Valid values: true, false. Default value: false.

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -42,6 +42,7 @@ type ExternalDeviceConn struct {
 	EnableIkev2            string `form:"enable_ikev2,omitempty"`
 	ManualBGPCidrs         []string
 	TunnelProtocol         string `form:"tunnel_protocol,omitempty"`
+	PeerVnetId             string `form:"peer_vnet_id,omitempty"`
 }
 
 type EditExternalDeviceConnDetail struct {
@@ -70,6 +71,7 @@ type EditExternalDeviceConnDetail struct {
 	PreSharedKey           string
 	BackupPreSharedKey     string
 	IkeVer                 string `json:"ike_ver"`
+	PeerVnetId             string `json:"peer_vnet_id"`
 }
 
 type ExternalDeviceConnDetailResp struct {
@@ -257,6 +259,7 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 		} else {
 			externalDeviceConn.EnableIkev2 = "disabled"
 		}
+		externalDeviceConn.PeerVnetId = externalDeviceConnDetail.PeerVnetId
 
 		return externalDeviceConn, nil
 	}

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -47,6 +47,7 @@ type TransitVpc struct {
 	EnableTransitFireNet         string `form:"enable_transit_firenet,omitempty"`
 	LearnedCidrsApproval         string `form:"learned_cidrs_approval,omitempty"`
 	EncVolume                    string `form:"enc_volume,omitempty"`
+	BgpOverLan                   string `form:"bgp_over_lan,omitempty"`
 }
 
 type TransitGatewayAdvancedConfig struct {
@@ -58,6 +59,9 @@ type TransitGatewayAdvancedConfig struct {
 	ActiveStandbyConnections          []StandbyConnection
 	LearnedCIDRsApprovalMode          string
 	ConnectionLearnedCIDRApprovalInfo []LearnedCIDRApprovalInfo
+	TunnelAddrLocal                   string
+	TunnelAddrLocalBackup             string
+	PeerVnetId                        []string
 }
 
 type StandbyConnection struct {
@@ -74,6 +78,9 @@ type TransitGatewayAdvancedConfigRespResult struct {
 	ActiveStandbyStatus               map[string]string         `json:"active_standby_status"`
 	LearnedCIDRsApprovalMode          string                    `json:"learned_cidrs_approval_mode"`
 	ConnectionLearnedCIDRApprovalInfo []LearnedCIDRApprovalInfo `json:"connection_learned_cidrs_approval_info"`
+	TunnelAddrLocal                   string                    `json:"tunnel_addr_local"`
+	TunnelAddrLocalBackup             string                    `json:"tunnel_addr_local_backup"`
+	PeerVnetId                        []string                  `json:"peer_vnet_id"`
 }
 
 type LearnedCIDRApprovalInfo struct {
@@ -655,6 +662,9 @@ func (c *Client) GetTransitGatewayAdvancedConfig(transitGateway *TransitVpc) (*T
 		ActiveStandbyConnections:          standbyConnections,
 		LearnedCIDRsApprovalMode:          data.Results.LearnedCIDRsApprovalMode,
 		ConnectionLearnedCIDRApprovalInfo: data.Results.ConnectionLearnedCIDRApprovalInfo,
+		TunnelAddrLocal:                   data.Results.TunnelAddrLocal,
+		TunnelAddrLocalBackup:             data.Results.TunnelAddrLocalBackup,
+		PeerVnetId:                        data.Results.PeerVnetId,
 	}, nil
 }
 


### PR DESCRIPTION
Add two attributes to support Azure BGP over LAN connections

aviatrix_transit_external_device_conn.remote_vpc_name
```go
		"remote_vpc_name": {
				Type:        schema.TypeString,
				Optional:    true,
				ForceNew:    true,
				Description: "Name of the remote VPC for a LAN BGP connection. Only valid when 'connection_type' = 'bgp' and tunnel_protocol' = 'LAN' with an Azure transit gateway. Must be in the form \"<VNET-name>:<resource-group-name>\". Available as of provider version R2.18+.",
			},
```

aviatrix_transit_gateway.enable_bgp_over_lan
```go
		"enable_bgp_over_lan": {
				Type:        schema.TypeBool,
				Optional:    true,
				Default:     false,
				ForceNew:    true,
				Description: "Pre-allocate a network interface(eth4) for \"BGP over LAN\" functionality. Only valid for cloud_type = 8 (AZURE). Valid values: true or false. Default value: false. Available as of provider version R2.18+",
			},
```