### PR TITLE
tweak: fix 'enable_bgp_over_lan' import

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1207,6 +1207,8 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 	d.Set("enable_active_standby", advancedConfig.ActiveStandbyEnabled)
 	if gw.CloudType == goaviatrix.AZURE {
 		d.Set("enable_bgp_over_lan", advancedConfig.TunnelAddrLocal != "")
+	} else {
+		d.Set("enable_bgp_over_lan", false)
 	}
 
 	isSegmentationEnabled, err := client.IsSegmentationEnabled(transitGateway)


### PR DESCRIPTION
When importing a non-Azure transit gateway we would
not Set anything in state for 'enable_bgp_over_lan'
so it would be effectively set to null. However,
since it has a default value of false, it would be
read as a Diff on the next plan.

So, instead for non-Azure transit gateways we will always
set 'enable_bgp_over_lan' to it's default value of false.