### PR TITLE
19413: Fix issue where editing 'included_advertised_spoke_routes' after attaching to transit gateway encounters error

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -571,7 +571,8 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			if err == nil {
 				break
 			}
-			if i <= 18 && (strings.Contains(err.Error(), "is down")) {
+			if i <= 18 && (strings.Contains(err.Error(), "when it is down") || strings.Contains(err.Error(), "hagw is down") ||
+				strings.Contains(err.Error(), "gateway is down")) {
 				time.Sleep(10 * time.Second)
 			} else {
 				return fmt.Errorf("failed to edit filtered spoke vpc routes of spoke gateway: %s due to: %s", transitGateway.GwName, err)
@@ -590,7 +591,8 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			if err == nil {
 				break
 			}
-			if i <= 30 && (strings.Contains(err.Error(), "is down")) {
+			if i <= 30 && (strings.Contains(err.Error(), "when it is down") || strings.Contains(err.Error(), "hagw is down") ||
+				strings.Contains(err.Error(), "gateway is down")) {
 				time.Sleep(10 * time.Second)
 			} else {
 				return fmt.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %s due to: %s", transitGateway.GwName, err)


### PR DESCRIPTION
Error message encountered:
"Error: failed to edit advertised spoke vpc routes of spoke gateway: transit-spoke-1 due to: Rest API 'edit_gateway_advertised_cidr' Get failed: All connections between spoke transit-spoke-1 and transit transit-gw-C are down. Please fix this issue before configuring Advertise spoke cidr"
1. Move attaching to transit gateway to the end in both creation and update functions;
2. Also modify repeating preconditions due to backend error message change from "when it is down" to "when gateway is down"