### PR TITLE
19804: Make firenet_gw_name Optional

### DIFF
--- a/aviatrix/resource_aviatrix_firewall_instance_association.go
+++ b/aviatrix/resource_aviatrix_firewall_instance_association.go
@@ -27,7 +27,7 @@ func resourceAviatrixFirewallInstanceAssociation() *schema.Resource {
 			},
 			"firenet_gw_name": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 				Description: "Name of the gateway to launch the firewall instance.",
 			},

--- a/docs/resources/aviatrix_firewall_instance.md
+++ b/docs/resources/aviatrix_firewall_instance.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `management_subnet` - (Optional) Management Interface Subnet. Select the subnet whose name contains “gateway and firewall management”. Required for Palo Alto Networks VM-Series, and required to be empty for Check Point or Fortinet series.
 * `egress_subnet` - (Required) Egress Interface Subnet. Select the subnet whose name contains “FW-ingress-egress”.
 * `firewall_image_version` - (Optional) Version of firewall image. If not specified, Controller will automatically select the latest version available.
-* `zone` - (Optional) Availability Zone. Applicable to Azure and AWS only. Available as of provider version R2.17+.
+* `zone` - (Optional) Availability Zone. Required if creating a Firewall Instance with a Native AWS GWLB enabled VPC. Applicable to Azure and AWS only. Available as of provider version R2.17+.
 
 ### Authentication method
 * `key_name`- (Optional) Applicable to AWS deployment only. The **.pem** filename for SSH access to the firewall instance.

--- a/docs/resources/aviatrix_firewall_instance.md
+++ b/docs/resources/aviatrix_firewall_instance.md
@@ -24,6 +24,18 @@ resource "aviatrix_firewall_instance" "test_firewall_instance" {
   egress_subnet     = "10.4.0.32/28"
 }
 ```
+```hcl
+# Create an Aviatrix Firewall Instance with Native GWLB Enabled VPC
+resource "aviatrix_firewall_instance" "test_firewall_instance" {
+  vpc_id            = "vpc-032005cc371"
+  firewall_name     = "avx-firewall-instance"
+  firewall_image    = "Palo Alto Networks VM-Series Next-Generation Firewall Bundle 1"
+  firewall_size     = "m5.xlarge"
+  management_subnet = "10.4.0.16/28"
+  egress_subnet     = "10.4.0.32/28"
+  zone              = "us-east-1a"
+}
+```
 
 ## Argument Reference
 
@@ -31,14 +43,14 @@ The following arguments are supported:
 
 ### Required
 * `vpc_id` - (Required) VPC ID of the Security VPC.
-* `firenet_gw_name` - (Required) Name of the primary FireNet gateway.
+* `firenet_gw_name` - (Optional) Name of the primary FireNet gateway. Required for FireNet without Native GWLB VPC.
 * `firewall_name` - (Required) Name of the firewall instance to be created.
 * `firewall_image` - (Required) One of the AWS/Azure AMIs from Palo Alto Networks.
 * `firewall_size` - (Required) Instance size of the firewall. Example: "m5.xlarge".  
 * `management_subnet` - (Optional) Management Interface Subnet. Select the subnet whose name contains “gateway and firewall management”. Required for Palo Alto Networks VM-Series, and required to be empty for Check Point or Fortinet series.
 * `egress_subnet` - (Required) Egress Interface Subnet. Select the subnet whose name contains “FW-ingress-egress”.
 * `firewall_image_version` - (Optional) Version of firewall image. If not specified, Controller will automatically select the latest version available.
-* `zone` - (Optional) Availability Zone. Applicable to Azure deployment only. Available as of provider version R2.17+.
+* `zone` - (Optional) Availability Zone. Applicable to Azure and AWS only. Available as of provider version R2.17+.
 
 ### Authentication method
 * `key_name`- (Optional) Applicable to AWS deployment only. The **.pem** filename for SSH access to the firewall instance.

--- a/docs/resources/aviatrix_firewall_instance_association.md
+++ b/docs/resources/aviatrix_firewall_instance_association.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 -> **NOTE:** If associating FQDN gateway to FireNet, `single_az_ha` needs to be enabled for the FQDN gateway.
 
-* `firenet_gw_name` - (Required) Name of the primary FireNet gateway.
+* `firenet_gw_name` - (Optional) Name of the primary FireNet gateway. Required for FireNet without Native GWLB VPC.
 * `instance_id` - (Required) ID of Firewall instance.
 
 -> **NOTE:** If associating FQDN gateway to FireNet, it is FQDN gateway's `gw_name`. For Azure FireNet, it is the `firewall_name` concatenated with a ":" and the Resource Group of the `vpc_id` set for that instance.
@@ -56,4 +56,10 @@ The following arguments are supported:
 
 ```
 $ terraform import aviatrix_firewall_instance_association.test vpc_id~~firenet_gw_name~~instance_id
+```
+
+When using a Native GWLB VPC where there is no `firenet_gw_name` but the ID is in the same form e.g.
+
+```
+$ terraform import aviatrix_firewall_instance_association.test vpc_id~~~~instance_id
 ```

--- a/goaviatrix/firewall_instance.go
+++ b/goaviatrix/firewall_instance.go
@@ -71,7 +71,11 @@ func (c *Client) CreateFirewallInstance(firewallInstance *FirewallInstance) (str
 	addFirewallInstance := url.Values{}
 	addFirewallInstance.Add("CID", c.CID)
 	addFirewallInstance.Add("action", "add_firewall_instance")
-	addFirewallInstance.Add("gw_name", firewallInstance.GwName)
+	if firewallInstance.GwName != "" {
+		addFirewallInstance.Add("gw_name", firewallInstance.GwName)
+	} else {
+		addFirewallInstance.Add("vpc_id", firewallInstance.VpcID)
+	}
 	addFirewallInstance.Add("firewall_name", firewallInstance.FirewallName)
 	addFirewallInstance.Add("firewall_image", firewallInstance.FirewallImage)
 	addFirewallInstance.Add("firewall_image_version", firewallInstance.FirewallImageVersion)

--- a/goaviatrix/vpc.go
+++ b/goaviatrix/vpc.go
@@ -158,6 +158,26 @@ func (c *Client) GetVpcCloudTypeById(ID string) (int, error) {
 	return 0, ErrNotFound
 }
 
+func (c *Client) GetCloudTypeFromVpcID(vpcID string) (int, error) {
+	data := map[string]string{
+		"action": "list_custom_vpcs",
+		"CID":    c.CID,
+	}
+	var respData VpcResp
+	err := c.GetAPI(&respData, data["action"], data, BasicCheck)
+	if err != nil {
+		return 0, err
+	}
+	for _, vpcPool := range respData.Results.AllVpcPoolVpcList {
+		for _, id := range vpcPool.VpcID {
+			if id == vpcID {
+				return vpcPool.CloudType, nil
+			}
+		}
+	}
+	return 0, ErrNotFound
+}
+
 func (c *Client) GetVpc(vpc *Vpc) (*Vpc, error) {
 	Url, err := url.Parse(c.baseURL)
 	if err != nil {


### PR DESCRIPTION
Within firewall_instance and firewall_instance_association change
firenet_gw_name from Required to Optional.

Also since GWLB FireNet firewall_instance requires a 'zone' parameter
we expand the use of the 'zone' parameter to allow use with AWS
GWLB. Previously, 'zone' was only for Azure.

Test:
Create firewall_instance with GWLB enabled VPC and no firenet_gw_name
PASS

Create firewall_instance without GWLB and a firenet_gw_name
PASS

Create firewall_instance_association with GWLB enabled VPC and no firenet_gw_name
PASS

Create firewall_instance_association without GWLB and a firenet_gw_name
PASS