### PR TITLE
19804: Deprecate in-line firewall_instance_association

### DIFF
--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -39,6 +39,7 @@ func resourceAviatrixFireNet() *schema.Resource {
 			"firewall_instance_association": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Deprecated:  "Please use the standalone aviatrix_firewall_instance_association resource instead.",
 				Description: "List of firewall instances to be associated with fireNet.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/docs/resources/aviatrix_firenet.md
+++ b/docs/resources/aviatrix_firenet.md
@@ -15,16 +15,7 @@ The **aviatrix_firenet** resource allows the creation and management of [Aviatri
 ## Example Usage
 
 ```hcl
-# Create an Aviatrix FireNet associated to a Firewall Instance
-resource "aviatrix_firenet" "test_firenet" {
-  vpc_id                               = "vpc-032005cc371"
-  inspection_enabled                   = true
-  egress_enabled                       = false
-  manage_firewall_instance_association = false
-}
-```
-```hcl
-# Create an Aviatrix FireNet associated to an FQDN Gateway (AWS)
+# Create an Aviatrix FireNet
 resource "aviatrix_firenet" "test_firenet" {
   vpc_id                               = "vpc-032005cc371"
   inspection_enabled                   = true
@@ -33,15 +24,6 @@ resource "aviatrix_firenet" "test_firenet" {
 }
 ```
 
-```hcl
-# Create an Aviatrix FireNet associated to an FQDN Gateway (Azure)
-resource "aviatrix_firenet" "test_firenet" {
-  vpc_id                               = "vpc-032005cc371"
-  inspection_enabled                   = true
-  egress_enabled                       = false
-  manage_firewall_instance_association = true
-}
-```
 ## Argument Reference
 
 The following arguments are supported:

--- a/docs/resources/aviatrix_firenet.md
+++ b/docs/resources/aviatrix_firenet.md
@@ -17,51 +17,29 @@ The **aviatrix_firenet** resource allows the creation and management of [Aviatri
 ```hcl
 # Create an Aviatrix FireNet associated to a Firewall Instance
 resource "aviatrix_firenet" "test_firenet" {
-  vpc_id             = "vpc-032005cc371"
-  inspection_enabled = true
-  egress_enabled     = false
-
-  firewall_instance_association {
-    firenet_gw_name      = "avx-firenet-gw"
-    instance_id          = "i-09dc118db6a1eb901"
-    firewall_name        = "avx-firewall-instance"
-    attached             = true
-    lan_interface        = "eni-0a34b1827bf222353"
-    management_interface = "eni-030e53176c7f7d34a"
-    egress_interface     = "eni-03b8dd53a1a731481"
-  }
+  vpc_id                               = "vpc-032005cc371"
+  inspection_enabled                   = true
+  egress_enabled                       = false
+  manage_firewall_instance_association = false
 }
 ```
 ```hcl
 # Create an Aviatrix FireNet associated to an FQDN Gateway (AWS)
 resource "aviatrix_firenet" "test_firenet" {
-  vpc_id             = "vpc-032005cc371"
-  inspection_enabled = true
-  egress_enabled     = false
-
-  firewall_instance_association {
-    firenet_gw_name = "avx-firenet-gw"
-    instance_id     = "avx-fqdn-gateway"
-    vendor_type     = "fqdn_gateway"
-    attached        = true
-  }
+  vpc_id                               = "vpc-032005cc371"
+  inspection_enabled                   = true
+  egress_enabled                       = false
+  manage_firewall_instance_association = false
 }
 ```
 
 ```hcl
 # Create an Aviatrix FireNet associated to an FQDN Gateway (Azure)
 resource "aviatrix_firenet" "test_firenet" {
-  vpc_id             = "vpc-032005cc371"
-  inspection_enabled = true
-  egress_enabled     = false
-
-  firewall_instance_association {
-    firenet_gw_name = "avx-firenet-gw"
-    instance_id     = "avx-fqdn-gateway"
-    vendor_type     = "fqdn_gateway"
-    attached        = true
-    lan_interface   = "<< LAN interface id of the FQDN gateway created with additional LAN interface >>"
-  }
+  vpc_id                               = "vpc-032005cc371"
+  inspection_enabled                   = true
+  egress_enabled                       = false
+  manage_firewall_instance_association = true
 }
 ```
 ## Argument Reference
@@ -82,6 +60,10 @@ The following arguments are supported:
 * `manage_firewall_instance_association` - (Optional) Enable this attribute to manage firewall associations in-line. If set to true, in-line `firewall_instance_association` blocks can be used. If set to false, all firewall associations must be managed via standalone `aviatrix_firewall_instance_association` resources. Default value: true. Valid values: true or false. Available in provider version R2.17.1+.
 
 ### Firewall Association
+
+!> **WARNING:** Attribute `firewall_instance_association` has been deprecated as of provider version R2.18+ and will not receive further updates. Please use the standalone `aviatrix_firewall_instance_association` resource instead.
+
+-> **NOTE:** `firewall_instance_association` - Associating a firewall instance with a Native GWLB enabled VPC is not supported in the in-line `firewall_instance_association` attribute. Please use the standalone `aviatrix_firewall_instance_association` resource instead.
 
 -> **NOTE:** `firewall_instance_association` - If associating FQDN gateway to FireNet, `single_az_ha` needs to be enabled for the FQDN gateway.
 


### PR DESCRIPTION
Deprecate in-line firewall_instance_association in favor of standalone aviatrix_firewall_instance_association.

Deprecation warning looks like
```
Warning: Attribute is deprecated
  on main.tf line 58, in resource "aviatrix_firenet" "fnet":
  58: resource "aviatrix_firenet" "fnet" {
Please use the standalone aviatrix_firewall_instance_association resource
instead.
```

Also update the documentation to reflect the deprecation.