### PR TITLE
19871: Fix issue where aviatrix_aws_tgw_vpc_attahcment exports subnets in reverse order

### DIFF
--- a/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
@@ -53,11 +53,12 @@ func resourceAviatrixAwsTgwVpcAttachment() *schema.Resource {
 				Description: "Advanced option. Customized Spoke VPC Routes. It allows the admin to enter non-RFC1918 routes in the VPC route table targeting the TGW.",
 			},
 			"subnets": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
-				Description: "Advanced option. VPC subnets separated by ',' to attach to the VPC. If left blank, Aviatrix Controller automatically selects a subnet representing each AZ for the VPC attachment.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Computed:         true,
+				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceInString,
+				Description:      "Advanced option. VPC subnets separated by ',' to attach to the VPC. If left blank, Aviatrix Controller automatically selects a subnet representing each AZ for the VPC attachment.",
 			},
 			"route_tables": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
I could not reproduce. However, the enhancement is to add a DiffSuppressFunc to ignore the white spaces and order of subnets separated by comma for "subnets" for aviatrix_aws_tgw_vpc_attachment, since updating "subnets" is not supported and it is ForceNew.