### PR TITLE
19465: FireNet Keep Alive via Firewall Lan Interface

### DIFF
--- a/aviatrix/data_source_aviatrix_firenet.go
+++ b/aviatrix/data_source_aviatrix_firenet.go
@@ -82,6 +82,11 @@ func dataSourceAviatrixFireNet() *schema.Resource {
 				Computed:    true,
 				Description: "Hashing algorithm to load balance traffic across the firewall.",
 			},
+			"keep_alive_via_lan_interface_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Enable Keep Alive via Firewall LAN Interface.",
+			},
 		},
 	}
 }
@@ -104,6 +109,7 @@ func dataSourceAviatrixFireNetRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("vpc_id", fireNetDetail.VpcID)
 	d.Set("hashing_algorithm", fireNetDetail.HashingAlgorithm)
+	d.Set("keep_alive_via_lan_interface_enabled", fireNetDetail.LanPing == "yes")
 
 	if fireNetDetail.Inspection == "yes" {
 		d.Set("inspection_enabled", true)

--- a/docs/data-sources/aviatrix_firenet.md
+++ b/docs/data-sources/aviatrix_firenet.md
@@ -35,6 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 * `inspection_enabled` - Enable/Disable traffic inspection.
 * `egress_enabled` - Enable/Disable egress through firewall.
 * `hashing_algorithm` - (Optional) Hashing algorithm to load balance traffic across the firewall.
+* `keep_alive_via_lan_interface_enabled` - (Optional) Enable Keep Alive via Firewall LAN Interface.
 * `firewall_instance_association` - List of firewall instances associated with fireNet.
   * `firenet_gw_name` - Name of the primary FireNet gateway.
   * `instance_id` - ID of Firewall instance.

--- a/docs/resources/aviatrix_firenet.md
+++ b/docs/resources/aviatrix_firenet.md
@@ -20,6 +20,7 @@ resource "aviatrix_firenet" "test_firenet" {
   vpc_id                               = "vpc-032005cc371"
   inspection_enabled                   = true
   egress_enabled                       = false
+  keep_alive_via_lan_interface_enabled = false
   manage_firewall_instance_association = false
 }
 ```
@@ -39,6 +40,7 @@ The following arguments are supported:
 -> **NOTE:** `egress_enabled` - Default value is false for associating firewall instance to FireNet. Only true is supported for associating FQDN gateway to FireNet.
 
 * `hashing_algorithm` - (Optional) Hashing algorithm to load balance traffic across the firewall. Valid values: "2-Tuple", "5-Tuple". Default value: "5-Tuple".
+* `keep_alive_via_lan_interface_enabled` - (Optional) Enable Keep Alive via Firewall LAN Interface. Valid values: true or false. Default value: false. Available as of provider version R2.18.1+.
 * `manage_firewall_instance_association` - (Optional) Enable this attribute to manage firewall associations in-line. If set to true, in-line `firewall_instance_association` blocks can be used. If set to false, all firewall associations must be managed via standalone `aviatrix_firewall_instance_association` resources. Default value: true. Valid values: true or false. Available in provider version R2.17.1+.
 
 ### Firewall Association


### PR DESCRIPTION
Add attribute to firenet resource and data source:
 - (Optional/Bool) `keep_alive_via_lan_interface_enabled`