### PR TITLE
19914: Fix firewall_instance.key_name import

### DIFF
--- a/aviatrix/resource_aviatrix_firewall_instance.go
+++ b/aviatrix/resource_aviatrix_firewall_instance.go
@@ -385,9 +385,9 @@ func resourceAviatrixFirewallInstanceRead(d *schema.ResourceData, meta interface
 		d.Set("management_subnet", fI.ManagementSubnet)
 	}
 
-	if (d.Get("zone").(string) != "" || isImport) && fI.AvailabilityZone != "AvailabilitySet" && fI.AvailabilityZone != "" && fI.CloudVendor == "Azure ARM" {
+	if (d.Get("zone").(string) != "" || isImport) && fI.AvailabilityZone != "AvailabilitySet" && fI.AvailabilityZone != "" && stringInSlice(fI.CloudVendor, goaviatrix.AzureArmRelatedVendorNames) {
 		d.Set("zone", "az-"+fI.AvailabilityZone)
-	} else if fI.AvailabilityZone != "" && fI.CloudVendor == "AWS" && fI.GwName == "" {
+	} else if fI.AvailabilityZone != "" && stringInSlice(fI.CloudVendor, goaviatrix.AWSRelatedVendorNames) && fI.GwName == "" {
 		d.Set("zone", fI.AvailabilityZone)
 	}
 
@@ -399,7 +399,7 @@ func resourceAviatrixFirewallInstanceRead(d *schema.ResourceData, meta interface
 	if fI.FirewallImageVersion != "" {
 		d.Set("firewall_image_version", fI.FirewallImageVersion)
 	}
-	if fI.KeyFile == "" {
+	if fI.KeyFile == "" && stringInSlice(fI.CloudVendor, goaviatrix.AWSRelatedVendorNames) {
 		d.Set("key_name", fI.KeyName)
 	}
 	if fI.IamRole != "" {

--- a/aviatrix/resource_aviatrix_firewall_instance.go
+++ b/aviatrix/resource_aviatrix_firewall_instance.go
@@ -399,7 +399,7 @@ func resourceAviatrixFirewallInstanceRead(d *schema.ResourceData, meta interface
 	if fI.FirewallImageVersion != "" {
 		d.Set("firewall_image_version", fI.FirewallImageVersion)
 	}
-	if d.Get("key_name") != "" {
+	if fI.KeyFile == "" {
 		d.Set("key_name", fI.KeyName)
 	}
 	if fI.IamRole != "" {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -83,3 +83,13 @@ func getStringSet(d *schema.ResourceData, k string) []string {
 	}
 	return sl
 }
+
+// stringInSlice checks if the needle is in the haystack
+func stringInSlice(needle string, haystack []string) bool {
+	for _, element := range haystack {
+		if element == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/resources/aviatrix_firewall_instance.md
+++ b/docs/resources/aviatrix_firewall_instance.md
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `zone` - (Optional) Availability Zone. Required if creating a Firewall Instance with a Native AWS GWLB enabled VPC. Applicable to Azure and AWS only. Available as of provider version R2.17+.
 
 ### Authentication method
-* `key_name`- (Optional) Applicable to AWS deployment only. The **.pem** filename for SSH access to the firewall instance.
+* `key_name`- (Optional) Applicable to AWS deployment only. AWS Key Pair name. If not provided a Key Pair will be generated.
 * `username`- (Optional) Applicable to Azure deployment only. "admin" as a username is not accepted.
 * `password`- (Optional) Applicable to Azure deployment only.
 * `ssh_public_key` - (Optional) Applicable to Azure deployment only.

--- a/goaviatrix/const.go
+++ b/goaviatrix/const.go
@@ -12,6 +12,12 @@ const (
 	AWSGOV = 256
 )
 
+// Cloud vendor names
+var (
+	AWSRelatedVendorNames = []string{"AWS", "AWS GOV", "AWS CHINA"}
+	AzureArmRelatedVendorNames = []string{"Azure ARM", "ARM CHINA", "ARM GOV"}
+)
+
 // GetSupportedClouds returns the list of currently supported cloud IDs
 // Example usage to validate a cloud_type attribute in a schema:
 // "cloud_type": {

--- a/goaviatrix/const.go
+++ b/goaviatrix/const.go
@@ -14,7 +14,7 @@ const (
 
 // Cloud vendor names
 var (
-	AWSRelatedVendorNames = []string{"AWS", "AWS GOV", "AWS CHINA"}
+	AWSRelatedVendorNames      = []string{"AWS", "AWS GOV", "AWS CHINA"}
 	AzureArmRelatedVendorNames = []string{"Azure ARM", "ARM CHINA", "ARM GOV"}
 )
 

--- a/goaviatrix/firewall_instance.go
+++ b/goaviatrix/firewall_instance.go
@@ -21,6 +21,7 @@ type FirewallInstance struct {
 	EgressSubnet         string `form:"egress_subnet,omitempty" json:"egress_subnet,omitempty"`
 	ManagementSubnet     string `form:"management_subnet,omitempty" json:"management_subnet,omitempty"`
 	KeyName              string `form:"key_name,omitempty" json:"key_name,omitempty"`
+	KeyFile              string `json:"key_file"`
 	IamRole              string `form:"iam_role,omitempty" json:"iam_role,omitempty"`
 	BootstrapBucketName  string `form:"bootstrap_bucket_name,omitempty" json:"bootstrap_bucket_name,omitempty"`
 	InstanceID           string `form:"firewall_id,omitempty" json:"instance_id,omitempty"`


### PR DESCRIPTION
Due to a bug in export we would not export
the key_name field. Then if a user imported
the resource while the key_name field was
blank then the key_name was not read into state.

From then on the key_name would never be read into
state, even if user added the key_name to the config
because of the blank value in the state file.

Also update the documentation as it is not clear that
the key_name is actually an AWS KeyPair name.