### PR TITLE
20043: remove egress+connected_transit check

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1421,9 +1421,6 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 	if d.Get("enable_egress_transit_firenet").(bool) && !d.Get("enable_transit_firenet").(bool) {
 		return fmt.Errorf("'enable_egress_transit_firenet' requires 'enable_transit_firenet' to be set to true")
 	}
-	if d.Get("enable_egress_transit_firenet").(bool) && d.Get("connected_transit").(bool) {
-		return fmt.Errorf("'enable_egress_transit_firenet' requires 'connected_transit' to be set to false")
-	}
 	if d.Get("enable_egress_transit_firenet").(bool) && gateway.CloudType != goaviatrix.AZURE && gateway.CloudType != goaviatrix.AWS && gateway.CloudType != goaviatrix.AWSGOV {
 		return fmt.Errorf("'enable_egress_transit_firenet' is currently only supported on AWS, AZURE and AWSGOV cloud providers")
 	}


### PR DESCRIPTION
Prior to 6.3 having egress+connected_transit was allowed so there exists customer with egress+connected_transit already deployed. When those customers try to do any update to their transit_gateway they will hit this block, however, if they try to set their connected_transit=false and apply, they get the error `[AVXERR-TRANSIT-0018] Transit edit is not supported on Egress Transit gateway` so that leaves them with an unusable Terraform.

Instead we should not have this provider-side check at all in the Update function, if there is any issue with having egress+connected_transit then backend is responsible for returning an error.