### PR TITLE
19867: Fix issue where terrafrom refresh/destroy does not work if vgw conn has been removed from UI

### DIFF
--- a/goaviatrix/vgw_connection.go
+++ b/goaviatrix/vgw_connection.go
@@ -182,6 +182,9 @@ func (c *Client) GetVGWConnDetail(vgwConn *VGWConn) (*VGWConn, error) {
 	var data VGWConnDetailResp
 	err := c.GetAPI(&data, params["action"], params, BasicCheck)
 	if err != nil {
+		if strings.Contains(data.Reason, "does not exist") {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	if data.Results.Connections.ConnName[0] != "" {


### PR DESCRIPTION
If connection does not exist, do not return error. To be consistent with aviatrix_site2cloud, aviatrix_transit_external_device_conn, and aviatrix_device_transit_gateway_attachment, and aviatrix_device_virtual_wan_attachment. 