### PR TITLE
20061: add metrics_only to datadog and fix bugs

### DIFF
--- a/aviatrix/resource_aviatrix_cloudwatch_agent.go
+++ b/aviatrix/resource_aviatrix_cloudwatch_agent.go
@@ -111,7 +111,9 @@ func resourceAviatrixCloudwatchAgentRead(d *schema.ResourceData, meta interface{
 	d.Set("cloudwatch_role_arn", cloudwatchAgentStatus.RoleArn)
 	d.Set("region", cloudwatchAgentStatus.Region)
 	d.Set("log_group_name", cloudwatchAgentStatus.LogGroupName)
-	d.Set("excluded_gateways", cloudwatchAgentStatus.ExcludedGateways)
+	if len(cloudwatchAgentStatus.ExcludedGateways) != 0 {
+		d.Set("excluded_gateways", cloudwatchAgentStatus.ExcludedGateways)
+	}
 	d.Set("status", cloudwatchAgentStatus.Status)
 
 	d.SetId("cloudwatch_agent")

--- a/aviatrix/resource_aviatrix_datadog_agent.go
+++ b/aviatrix/resource_aviatrix_datadog_agent.go
@@ -44,6 +44,13 @@ func resourceAviatrixDatadogAgent() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"metrics_only": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Default:     false,
+				Description: "Only export metrics without exporting logs.",
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -55,8 +62,9 @@ func resourceAviatrixDatadogAgent() *schema.Resource {
 
 func marshalDatadogAgentInput(d *schema.ResourceData) *goaviatrix.DatadogAgent {
 	datadogAgent := &goaviatrix.DatadogAgent{
-		ApiKey: d.Get("api_key").(string),
-		Site:   d.Get("site").(string),
+		ApiKey:      d.Get("api_key").(string),
+		Site:        d.Get("site").(string),
+		MetricsOnly: d.Get("metrics_only").(bool),
 	}
 
 	var excludedGateways []string
@@ -104,7 +112,10 @@ func resourceAviatrixDatadogAgentRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("site", datadogAgentStatus.Site)
-	d.Set("excluded_gateways", datadogAgentStatus.ExcludedGateways)
+	if len(datadogAgentStatus.ExcludedGateways) != 0 {
+		d.Set("excluded_gateways", datadogAgentStatus.ExcludedGateways)
+	}
+	d.Set("metrics_only", datadogAgentStatus.MetricsOnly)
 	d.Set("status", datadogAgentStatus.Status)
 
 	d.SetId("datadog_agent")

--- a/aviatrix/resource_aviatrix_filebeat_forwarder.go
+++ b/aviatrix/resource_aviatrix_filebeat_forwarder.go
@@ -123,13 +123,8 @@ func resourceAviatrixFilebeatForwarderRead(d *schema.ResourceData, meta interfac
 	port, _ := strconv.Atoi(filebeatForwarderStatus.Port)
 	d.Set("port", port)
 	d.Set("status", filebeatForwarderStatus.Status)
-
-	var excludedGateways []interface{}
-	for _, v := range filebeatForwarderStatus.ExcludedGateways {
-		excludedGateways = append(excludedGateways, v)
-	}
-	if err := d.Set("excluded_gateways", excludedGateways); err != nil {
-		return fmt.Errorf("could not set excluded_gateway: %v", err)
+	if len(filebeatForwarderStatus.ExcludedGateways) != 0 {
+		d.Set("excluded_gateways", filebeatForwarderStatus.ExcludedGateways)
 	}
 
 	d.SetId("filebeat_forwarder")

--- a/aviatrix/resource_aviatrix_netflow_agent.go
+++ b/aviatrix/resource_aviatrix_netflow_agent.go
@@ -115,7 +115,9 @@ func resourceAviatrixNetflowAgentRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("port", port)
 	version, _ := strconv.Atoi(netflowAgentStatus.Version)
 	d.Set("version", version)
-	d.Set("excluded_gateways", netflowAgentStatus.ExcludedGateways)
+	if len(netflowAgentStatus.ExcludedGateways) != 0 {
+		d.Set("excluded_gateways", netflowAgentStatus.ExcludedGateways)
+	}
 	d.Set("status", netflowAgentStatus.Status)
 
 	d.SetId("netflow_agent")

--- a/aviatrix/resource_aviatrix_remote_syslog.go
+++ b/aviatrix/resource_aviatrix_remote_syslog.go
@@ -195,7 +195,9 @@ func resourceAviatrixRemoteSyslogRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("template", remoteSyslogStatus.Template)
 	d.Set("notls", remoteSyslogStatus.Notls)
 	d.Set("status", remoteSyslogStatus.Status)
-	d.Set("excluded_gateways", remoteSyslogStatus.ExcludedGateways)
+	if len(remoteSyslogStatus.ExcludedGateways) != 0 {
+		d.Set("excluded_gateways", remoteSyslogStatus.ExcludedGateways)
+	}
 
 	d.SetId("remote_syslog_" + remoteSyslogStatus.Index)
 	return nil

--- a/aviatrix/resource_aviatrix_splunk_logging.go
+++ b/aviatrix/resource_aviatrix_splunk_logging.go
@@ -143,7 +143,9 @@ func resourceAviatrixSplunkLoggingRead(d *schema.ResourceData, meta interface{})
 	d.Set("port", port)
 	d.Set("custom_input_config", splunkLoggingStatus.CustomConfig)
 	d.Set("status", splunkLoggingStatus.Status)
-	d.Set("excluded_gateways", splunkLoggingStatus.ExcludedGateways)
+	if len(splunkLoggingStatus.ExcludedGateways) != 0 {
+		d.Set("excluded_gateways", splunkLoggingStatus.ExcludedGateways)
+	}
 
 	d.SetId("splunk_logging")
 	return nil

--- a/aviatrix/resource_aviatrix_sumologic_forwarder.go
+++ b/aviatrix/resource_aviatrix_sumologic_forwarder.go
@@ -120,7 +120,9 @@ func resourceAviatrixSumologicForwarderRead(d *schema.ResourceData, meta interfa
 	d.Set("access_id", sumologicForwarderStatus.AccessID)
 	d.Set("source_category", sumologicForwarderStatus.SourceCategory)
 	d.Set("custom_configuration", sumologicForwarderStatus.CustomConfig)
-	d.Set("excluded_gateways", sumologicForwarderStatus.ExcludedGateways)
+	if len(sumologicForwarderStatus.ExcludedGateways) != 0 {
+		d.Set("excluded_gateways", sumologicForwarderStatus.ExcludedGateways)
+	}
 	d.Set("status", sumologicForwarderStatus.Status)
 
 	d.SetId("sumologic_forwarder")

--- a/docs/resources/aviatrix_datadog_agent.md
+++ b/docs/resources/aviatrix_datadog_agent.md
@@ -30,6 +30,7 @@ The following arguments are supported:
 * `site` (Optional) Site preference ("datadoghq.com" or" datadoghq.eu"). "datadoghq.com" by default.
 
 ### Optional
+* `metrics_only` (Optional) Only export metrics without exporting logs. False by default.
 * `excluded_gateways` (Optional) List of gateways to be excluded from logging. e.g.: ["gateway01", "gateway02", "gateway01-hagw"].
 
 ## Attribute Reference

--- a/goaviatrix/datadog_agent.go
+++ b/goaviatrix/datadog_agent.go
@@ -1,16 +1,20 @@
 package goaviatrix
 
+import "strconv"
+
 type DatadogAgent struct {
 	CID                   string
 	ApiKey                string
 	Site                  string
 	ExcludedGatewaysInput string
+	MetricsOnly           bool
 }
 
 type DatadogAgentResp struct {
 	ApiKey           string   `json:"api_key"`
 	Site             string   `json:"site"`
 	ExcludedGateways []string `json:"excluded_gateway"`
+	MetricsOnly      bool     `json:"metrics_only"`
 	Status           string   `json:"status"`
 }
 
@@ -21,6 +25,7 @@ func (c *Client) EnableDatadogAgent(r *DatadogAgent) error {
 		"api_key":              r.ApiKey,
 		"site":                 r.Site,
 		"exclude_gateway_list": r.ExcludedGatewaysInput,
+		"metrics_only":         strconv.FormatBool(r.MetricsOnly),
 	}
 
 	return c.PostAPI(params["action"], params, BasicCheck)


### PR DESCRIPTION
1. add `metrics_only` to datadog_agent
2. fix the bug: when an attribute is list/set and is not set by user, Read() sets it to []. This triggers a diff ([] -> null) in this case: create resource -> remove state -> import resource -> plan 