### PR TITLE
20122: [Deprecation] Add deprecation flag and descriptors for resources using "manage_xxx"

### DIFF
--- a/aviatrix/resource_aviatrix_aws_tgw.go
+++ b/aviatrix/resource_aviatrix_aws_tgw.go
@@ -76,6 +76,7 @@ func resourceAviatrixAWSTgw() *schema.Resource {
 						"attached_vpc": {
 							Type:        schema.TypeList,
 							Optional:    true,
+							Deprecated:  "Please use the standalone aviatrix_aws_tgw_vpc_attachment resource instead, and set `manage_vpc_attachment` to false.",
 							Description: "A list of VPCs attached to the domain.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -161,6 +162,7 @@ func resourceAviatrixAWSTgw() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional:    true,
+				Deprecated:  "Please use the standalone aviatrix_aws_tgw_transit_gateway_attachment resource instead, and set `manage_transit_gateway_attachment` to false.",
 				Description: "A list of Names of Aviatrix Transit Gateway to attach to one of the three default domains.",
 			},
 			"manage_vpc_attachment": {

--- a/aviatrix/resource_aviatrix_aws_tgw.go
+++ b/aviatrix/resource_aviatrix_aws_tgw.go
@@ -76,7 +76,7 @@ func resourceAviatrixAWSTgw() *schema.Resource {
 						"attached_vpc": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Deprecated:  "Please use the standalone aviatrix_aws_tgw_vpc_attachment resource instead, and set `manage_vpc_attachment` to false.",
+							Deprecated:  "Please set `manage_vpc_attachment` to false, and use the standalone aviatrix_aws_tgw_vpc_attachment resource instead.",
 							Description: "A list of VPCs attached to the domain.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -162,7 +162,7 @@ func resourceAviatrixAWSTgw() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional:    true,
-				Deprecated:  "Please use the standalone aviatrix_aws_tgw_transit_gateway_attachment resource instead, and set `manage_transit_gateway_attachment` to false.",
+				Deprecated:  "Please set `manage_transit_gateway_attachment` to false, and use the standalone aviatrix_aws_tgw_transit_gateway_attachment resource instead.",
 				Description: "A list of Names of Aviatrix Transit Gateway to attach to one of the three default domains.",
 			},
 			"manage_vpc_attachment": {

--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -39,7 +39,7 @@ func resourceAviatrixFireNet() *schema.Resource {
 			"firewall_instance_association": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "Please use the standalone aviatrix_firewall_instance_association resource instead, and set `manage_firewall_instance_association` to false.",
+				Deprecated:  "Please set `manage_firewall_instance_association` to false, and use the standalone aviatrix_firewall_instance_association resource instead.",
 				Description: "List of firewall instances to be associated with fireNet.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -39,7 +39,7 @@ func resourceAviatrixFireNet() *schema.Resource {
 			"firewall_instance_association": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "Please use the standalone aviatrix_firewall_instance_association resource instead.",
+				Deprecated:  "Please use the standalone aviatrix_firewall_instance_association resource instead, and set `manage_firewall_instance_association` to false.",
 				Description: "List of firewall instances to be associated with fireNet.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aviatrix/resource_aviatrix_firewall.go
+++ b/aviatrix/resource_aviatrix_firewall.go
@@ -55,7 +55,7 @@ func resourceAviatrixFirewall() *schema.Resource {
 			"policy": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "Please use the standalone aviatrix_firewall_policy resource instead, and set `manage_firewall_policies` to false.",
+				Deprecated:  "Please set `manage_firewall_policies` to false, and use the standalone aviatrix_firewall_policy resource instead.",
 				Description: "New access policy for the gateway.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aviatrix/resource_aviatrix_firewall.go
+++ b/aviatrix/resource_aviatrix_firewall.go
@@ -55,6 +55,7 @@ func resourceAviatrixFirewall() *schema.Resource {
 			"policy": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Deprecated:  "Please use the standalone aviatrix_firewall_policy resource instead, and set `manage_firewall_policies` to false.",
 				Description: "New access policy for the gateway.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aviatrix/resource_aviatrix_fqdn.go
+++ b/aviatrix/resource_aviatrix_fqdn.go
@@ -69,7 +69,7 @@ func resourceAviatrixFQDN() *schema.Resource {
 			"domain_names": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Deprecated:  "Please use the standalone aviatrix_fqdn_tag_rule resource instead, and set `manage_domain_names` to false.",
+				Deprecated:  "Please set `manage_domain_names` to false, and use the standalone aviatrix_fqdn_tag_rule resource instead.",
 				Description: "A list of one or more domain names.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aviatrix/resource_aviatrix_fqdn.go
+++ b/aviatrix/resource_aviatrix_fqdn.go
@@ -69,6 +69,7 @@ func resourceAviatrixFQDN() *schema.Resource {
 			"domain_names": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				Deprecated:  "Please use the standalone aviatrix_fqdn_tag_rule resource instead, and set `manage_domain_names` to false.",
 				Description: "A list of one or more domain names.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -141,7 +141,7 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
-				Deprecated:  "Please use the standalone aviatrix_spoke_transit_attachment resource instead, and set `manage_transit_gateway_attachment` to false.",
+				Deprecated:  "Please set `manage_transit_gateway_attachment` to false, and use the standalone aviatrix_spoke_transit_attachment resource instead.",
 				Description: "Specify the transit Gateways to attach to this spoke. Format is a comma-separated list of transit gateway names. For example, 'transit-gw1,transit-gw2'.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldGws := strings.Split(old, ",")

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -141,6 +141,7 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "",
+				Deprecated:  "Please use the standalone aviatrix_spoke_transit_attachment resource instead, and set `manage_transit_gateway_attachment` to false.",
 				Description: "Specify the transit Gateways to attach to this spoke. Format is a comma-separated list of transit gateway names. For example, 'transit-gw1,transit-gw2'.",
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					oldGws := strings.Split(old, ",")

--- a/docs/resources/aviatrix_aws_tgw.md
+++ b/docs/resources/aviatrix_aws_tgw.md
@@ -138,7 +138,7 @@ The following arguments are supported:
 
 ### VPC Attachments
 
-!> **WARNING:** Attribute `attached_vpc` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_aws_tgw_vpc_attachment` resource instead, and set `manage_vpc_attachment` to false.
+!> **WARNING:** Attribute `attached_vpc` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please set `manage_vpc_attachment` to false, and use the standalone `aviatrix_aws_tgw_vpc_attachment` resource instead. 
 
 -> **NOTE:** The `attached_vpc` code block is to be nested under the `security_domains` block. Please see the code examples above for more information.
 
@@ -154,7 +154,7 @@ The following arguments are supported:
 
 ### Misc.
 
-!> **WARNING:** Attribute `attached_aviatrix_transit_gateway` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_aws_tgw_transit_gateway_attachment` resource instead, and set `manage_transit_gateway_attachment` to false.
+!> **WARNING:** Attribute `attached_aviatrix_transit_gateway` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please set `manage_transit_gateway_attachment` to false, and use the standalone `aviatrix_aws_tgw_transit_gateway_attachment` resource instead.
 
 * `attached_aviatrix_transit_gateway` - (Optional) A list of names of Aviatrix Transit Gateway(s) (transit VPCs) to attach to the Aviatrix_Edge_Domain.
 * `cloud_type` - (Optional) Type of cloud service provider, requires an integer value. Supported for AWS (1) and AWS GOV (256). Default value: 1.

--- a/docs/resources/aviatrix_aws_tgw.md
+++ b/docs/resources/aviatrix_aws_tgw.md
@@ -18,12 +18,9 @@ The **aviatrix_aws_tgw** resource allows the creation and management of Aviatrix
 # Create an Aviatrix AWS TGW
 resource "aviatrix_aws_tgw" "test_aws_tgw" {
   account_name                      = "devops"
-  attached_aviatrix_transit_gateway = [
-     "avx-transit-gw"
-  ]
   aws_side_as_number                = "64512"
-  manage_vpc_attachment             = true
-  manage_transit_gateway_attachment = true
+  manage_vpc_attachment             = false
+  manage_transit_gateway_attachment = false
   region                            = "us-east-1"
   tgw_name                          = "test-AWS-TGW"
 
@@ -57,36 +54,10 @@ resource "aviatrix_aws_tgw" "test_aws_tgw" {
       "Aviatrix_Edge_Domain"
     ]
     security_domain_name = "SDN1"
-
-    attached_vpc {
-      vpc_account_name = "devops2"
-      vpc_id           = "vpc-0e2fac2b91"
-      vpc_region       = "us-east-1"
-    }
-
-    attached_vpc {
-      vpc_account_name = "devops2"
-      vpc_id           = "vpc-0c63660a16"
-      vpc_region       = "us-east-1"
-    }
-
-    attached_vpc {
-      vpc_account_name = "devops"
-      vpc_id           = "vpc-032005cc444"
-      vpc_region       = "us-east-1"
-    }
   }
 
   security_domains {
     security_domain_name = "mysdn2"
-
-    attached_vpc {
-      vpc_region                      = "us-east-1"
-      vpc_account_name                = "devops"
-      vpc_id                          = "vpc-03200566666"
-      customized_routes               = "10.8.0.0/16,10.9.0.0/16"
-      disable_local_route_propagation = true
-    }
   }
 
   security_domains {
@@ -100,12 +71,9 @@ resource "aviatrix_aws_tgw" "test_aws_tgw" {
 resource "aviatrix_aws_tgw" "test_aws_gov_tgw" {
   account_name                      = "devops"
   cloud_type                        = 256
-  attached_aviatrix_transit_gateway = [
-     "avx-transit-gw"
-  ]
   aws_side_as_number                = "64512"
-  manage_vpc_attachment             = true
-  manage_transit_gateway_attachment = true
+  manage_vpc_attachment             = false
+  manage_transit_gateway_attachment = false
   region                            = "us-gov-east-1"
   tgw_name                          = "test-AWS-GOV-TGW"
 
@@ -139,36 +107,10 @@ resource "aviatrix_aws_tgw" "test_aws_gov_tgw" {
       "Aviatrix_Edge_Domain"
     ]
     security_domain_name = "SDN1"
-
-    attached_vpc {
-      vpc_account_name = "devops2"
-      vpc_id           = "vpc-0e2fac2b91"
-      vpc_region       = "us-gov-east-1"
-    }
-
-    attached_vpc {
-      vpc_account_name = "devops2"
-      vpc_id           = "vpc-0c63660a16"
-      vpc_region       = "us-gov-east-1"
-    }
-
-    attached_vpc {
-      vpc_account_name = "devops"
-      vpc_id           = "vpc-032005cc444"
-      vpc_region       = "us-gov-east-1"
-    }
   }
 
   security_domains {
     security_domain_name = "mysdn2"
-
-    attached_vpc {
-      vpc_region                      = "us-gov-east-1"
-      vpc_account_name                = "devops"
-      vpc_id                          = "vpc-03200566666"
-      customized_routes               = "10.8.0.0/16,10.9.0.0/16"
-      disable_local_route_propagation = true
-    }
   }
 
   security_domains {
@@ -196,6 +138,8 @@ The following arguments are supported:
 
 ### VPC Attachments
 
+!> **WARNING:** Attribute `attached_vpc` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_aws_tgw_vpc_attachment` resource instead, and set `manage_vpc_attachment` to false.
+
 -> **NOTE:** The `attached_vpc` code block is to be nested under the `security_domains` block. Please see the code examples above for more information.
 
 * `attached_vpc` - (Optional) A list of VPCs attached to the domain (name: `security_domain_name`) together with its creation. This list needs to be null for "Aviatrix_Edge_Domain".
@@ -209,6 +153,9 @@ The following arguments are supported:
   * `disable_local_route_propagation` - (Optional) Advanced option. If set to true, it disables automatic route propagation of this VPC to other VPCs within the same security domain. Valid values: true, false. Default value: false.
 
 ### Misc.
+
+!> **WARNING:** Attribute `attached_aviatrix_transit_gateway` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_aws_tgw_transit_gateway_attachment` resource instead, and set `manage_transit_gateway_attachment` to false.
+
 * `attached_aviatrix_transit_gateway` - (Optional) A list of names of Aviatrix Transit Gateway(s) (transit VPCs) to attach to the Aviatrix_Edge_Domain.
 * `cloud_type` - (Optional) Type of cloud service provider, requires an integer value. Supported for AWS (1) and AWS GOV (256). Default value: 1.
 * `manage_transit_gateway_attachment` - (Optional) This parameter is a switch used to determine whether or not to manage transit gateway attachments to the TGW using the **aviatrix_aws_tgw** resource. If this is set to false, attachment of transit gateways must be done using the **aviatrix_aws_tgw_transit_gateway_attachment** resource. Valid values: true, false. Default value: true.

--- a/docs/resources/aviatrix_firenet.md
+++ b/docs/resources/aviatrix_firenet.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 ### Firewall Association
 
-!> **WARNING:** Attribute `firewall_instance_association` has been deprecated as of provider version R2.18+ and will not receive further updates. Please use the standalone `aviatrix_firewall_instance_association` resource instead.
+!> **WARNING:** Attribute `firewall_instance_association` has been deprecated as of provider version R2.18+ and will not receive further updates. Please use the standalone `aviatrix_firewall_instance_association` resource instead, and set `manage_firewall_instance_association` to false.
 
 -> **NOTE:** `firewall_instance_association` - Associating a firewall instance with a Native GWLB enabled VPC is not supported in the in-line `firewall_instance_association` attribute. Please use the standalone `aviatrix_firewall_instance_association` resource instead.
 

--- a/docs/resources/aviatrix_firenet.md
+++ b/docs/resources/aviatrix_firenet.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 ### Firewall Association
 
-!> **WARNING:** Attribute `firewall_instance_association` has been deprecated as of provider version R2.18+ and will not receive further updates. Please use the standalone `aviatrix_firewall_instance_association` resource instead, and set `manage_firewall_instance_association` to false.
+!> **WARNING:** Attribute `firewall_instance_association` has been deprecated as of provider version R2.18+ and will not receive further updates. Please set `manage_firewall_instance_association` to false, and use the standalone `aviatrix_firewall_instance_association` resource instead.
 
 -> **NOTE:** `firewall_instance_association` - Associating a firewall instance with a Native GWLB enabled VPC is not supported in the in-line `firewall_instance_association` attribute. Please use the standalone `aviatrix_firewall_instance_association` resource instead.
 

--- a/docs/resources/aviatrix_firewall.md
+++ b/docs/resources/aviatrix_firewall.md
@@ -17,43 +17,16 @@ The **aviatrix_firewall** resource allows the creation and management of [Aviatr
 ```hcl
 # Create an Aviatrix Firewall
 resource "aviatrix_firewall" "stateful_firewall_1" {
-  gw_name          = "gateway-1"
-  base_policy      = "allow-all"
-  base_log_enabled = true
-
-  policy {
-    protocol    = "tcp"
-    src_ip      = "10.15.0.224/32"
-    log_enabled = false
-    dst_ip      = "10.12.0.172/32"
-    action      = "allow"
-    port        = "0:65535"
-    description = "This is policy no.1"
-  }
-
-  policy {
-    protocol    = "tcp"
-    src_ip      = "10.15.1.224/32"
-    log_enabled = false
-    dst_ip      = "10.12.1.172/32"
-    action      = "deny"
-    port        = "0:65535"
-    description = "This is policy no.2"
-  }
-
-  policy {
-    protocol    = "tcp"
-    src_ip      = "10.15.2.224/32"
-    log_enabled = false
-    dst_ip      = "10.12.3.172/32"
-    action      = "force-drop"
-    port        = "0:65535"
-    description = "This is policy no.3"
-  }
+  gw_name                  = "gateway-1"
+  base_policy              = "allow-all"
+  base_log_enabled         = true
+  manage_firewall_policies = false
 }
 ```
 
 ## Argument Reference
+
+!> **WARNING:** Attribute `policy` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_firewall_policy` resource instead, and set `manage_firewall_policies` to false.
 
 The following arguments are supported:
 

--- a/docs/resources/aviatrix_firewall.md
+++ b/docs/resources/aviatrix_firewall.md
@@ -26,7 +26,7 @@ resource "aviatrix_firewall" "stateful_firewall_1" {
 
 ## Argument Reference
 
-!> **WARNING:** Attribute `policy` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_firewall_policy` resource instead, and set `manage_firewall_policies` to false.
+!> **WARNING:** Attribute `policy` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please set `manage_firewall_policies` to false, and use the standalone `aviatrix_firewall_policy` resource instead.
 
 The following arguments are supported:
 

--- a/docs/resources/aviatrix_fqdn.md
+++ b/docs/resources/aviatrix_fqdn.md
@@ -39,23 +39,12 @@ resource "aviatrix_fqdn" "test_fqdn" {
       "30.0.0.0/16"
     ]
   }
-
-  domain_names {
-    fqdn  = "facebook.com"
-    proto = "tcp"
-    port  = "443"
-    action = "Allow"
-  }
-
-  domain_names {
-    fqdn  = "reddit.com"
-    proto = "tcp"
-    port  = "443"
-  }
 }
 ```
 
 ## Argument Reference
+
+!> **WARNING:** Attribute `domain_names` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_fqdn_tag_rule` resource instead, and set `manage_domain_names` to false.
 
 The following arguments are supported:
 

--- a/docs/resources/aviatrix_fqdn.md
+++ b/docs/resources/aviatrix_fqdn.md
@@ -44,7 +44,7 @@ resource "aviatrix_fqdn" "test_fqdn" {
 
 ## Argument Reference
 
-!> **WARNING:** Attribute `domain_names` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_fqdn_tag_rule` resource instead, and set `manage_domain_names` to false.
+!> **WARNING:** Attribute `domain_names` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please set `manage_domain_names` to false, and use the standalone `aviatrix_fqdn_tag_rule` resource instead.
 
 The following arguments are supported:
 

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -15,16 +15,17 @@ The **aviatrix_spoke_gateway** resource allows the creation and management of Av
 ```hcl
 # Create an Aviatrix AWS Spoke Gateway
 resource "aviatrix_spoke_gateway" "test_spoke_gateway_aws" {
-  cloud_type         = 1
-  account_name       = "my-aws"
-  gw_name            = "spoke-gw-aws"
-  vpc_id             = "vpc-abcd123"
-  vpc_reg            = "us-west-1"
-  gw_size            = "t2.micro"
-  subnet             = "10.11.0.0/24"
-  enable_snat        = false
-  enable_active_mesh = true
-  tag_list           = [
+  cloud_type                        = 1
+  account_name                      = "my-aws"
+  gw_name                           = "spoke-gw-aws"
+  vpc_id                            = "vpc-abcd123"
+  vpc_reg                           = "us-west-1"
+  gw_size                           = "t2.micro"
+  subnet                            = "10.11.0.0/24"
+  enable_snat                       = false
+  enable_active_mesh                = true
+  manage_transit_gateway_attachment = false
+  tag_list                          = [
     "k1:v1",
     "k2:v2",
   ]
@@ -33,58 +34,62 @@ resource "aviatrix_spoke_gateway" "test_spoke_gateway_aws" {
 ```hcl
 # Create an Aviatrix GCP Spoke Gateway
 resource "aviatrix_spoke_gateway" "test_spoke_gateway_gcp" {
-  cloud_type         = 4
-  account_name       = "my-gcp"
-  gw_name            = "spoke-gw-gcp"
-  vpc_id             = "gcp-spoke-vpc"
-  vpc_reg            = "us-west1-b"
-  gw_size            = "n1-standard-1"
-  subnet             = "10.12.0.0/24"
-  enable_snat        = false
-  enable_active_mesh = true
+  cloud_type                        = 4
+  account_name                      = "my-gcp"
+  gw_name                           = "spoke-gw-gcp"
+  vpc_id                            = "gcp-spoke-vpc"
+  vpc_reg                           = "us-west1-b"
+  gw_size                           = "n1-standard-1"
+  subnet                            = "10.12.0.0/24"
+  enable_snat                       = false
+  enable_active_mesh                = true
+  manage_transit_gateway_attachment = false
 }
 ```
 ```hcl
 # Create an Aviatrix Azure Spoke Gateway
 resource "aviatrix_spoke_gateway" "test_spoke_gateway_azure" {
-  cloud_type         = 8
-  account_name       = "my-azure"
-  gw_name            = "spoke-gw-01"
-  vpc_id             = "spoke:test-spoke-gw-123"
-  vpc_reg            = "West US"
-  gw_size            = "Standard_B1ms"
-  subnet             = "10.13.0.0/24"
-  zone               = "az-1"
-  enable_snat        = false
-  enable_active_mesh = true
+  cloud_type                        = 8
+  account_name                      = "my-azure"
+  gw_name                           = "spoke-gw-01"
+  vpc_id                            = "spoke:test-spoke-gw-123"
+  vpc_reg                           = "West US"
+  gw_size                           = "Standard_B1ms"
+  subnet                            = "10.13.0.0/24"
+  zone                              = "az-1"
+  enable_snat                       = false
+  enable_active_mesh                = true
+  manage_transit_gateway_attachment = false
 }
 ```
 ```hcl
 # Create an Aviatrix OCI Spoke Gateway
 resource "aviatrix_spoke_gateway" "test_spoke_gateway_oracle" {
-  cloud_type         = 16
-  account_name       = "my-oracle"
-  gw_name            = "avtxgw-oracle"
-  vpc_id             = "vpc-oracle-test"
-  vpc_reg            = "us-ashburn-1"
-  gw_size            = "VM.Standard2.2"
-  subnet             = "10.7.0.0/16"
-  enable_active_mesh = true
+  cloud_type                        = 16
+  account_name                      = "my-oracle"
+  gw_name                           = "avtxgw-oracle"
+  vpc_id                            = "vpc-oracle-test"
+  vpc_reg                           = "us-ashburn-1"
+  gw_size                           = "VM.Standard2.2"
+  subnet                            = "10.7.0.0/16"
+  enable_active_mesh                = true
+  manage_transit_gateway_attachment = false
 }
 ```
 ```hcl
 # Create an Aviatrix AWSGOV Spoke Gateway
 resource "aviatrix_spoke_gateway" "test_spoke_gateway_awsgov" {
-  cloud_type         = 256
-  account_name       = "my-awsgov"
-  gw_name            = "spoke-gw-awsgov"
-  vpc_id             = "vpc-abcd123"
-  vpc_reg            = "us-gov-west-1"
-  gw_size            = "t2.micro"
-  subnet             = "10.11.0.0/24"
-  enable_snat        = false
-  enable_active_mesh = true
-  tag_list           = [
+  cloud_type                        = 256
+  account_name                      = "my-awsgov"
+  gw_name                           = "spoke-gw-awsgov"
+  vpc_id                            = "vpc-abcd123"
+  vpc_reg                           = "us-gov-west-1"
+  gw_size                           = "t2.micro"
+  subnet                            = "10.11.0.0/24"
+  enable_snat                       = false
+  enable_active_mesh                = true
+  manage_transit_gateway_attachment = false
+  tag_list                          = [
     "k1:v1",
     "k2:v2",
   ]
@@ -139,6 +144,9 @@ The following arguments are supported:
 * `monitor_exclude_list` - (Optional) Set of monitored instance ids. Only valid when 'enable_monitor_gateway_subnets' = true. Available in provider version R2.18+.
 
 ### Misc.
+
+!> **WARNING:** Attribute `transit_gw` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_spoke_transit_attachment` resource instead, and set `manage_transit_gateway_attachment` to false.
+
 * `allocate_new_eip` - (Optional) When value is false, reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway. Available in Controller 4.7+. Valid values: true, false. Default: true. Option not available for AZURE and OCI gateways, they will automatically allocate new EIPs.
 * `eip` - (Optional) Required when `allocate_new_eip` is false. It uses the specified EIP for this gateway. Available in Controller 4.7+. Only available for AWS, GCP and AWSGOV.
 * `tag_list` - (Optional) Instance tag of cloud provider. Only supported for AWS, AWSGOV and Azure. Example: ["key1:value1", "key2:value2"].

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -145,7 +145,7 @@ The following arguments are supported:
 
 ### Misc.
 
-!> **WARNING:** Attribute `transit_gw` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please use the standalone `aviatrix_spoke_transit_attachment` resource instead, and set `manage_transit_gateway_attachment` to false.
+!> **WARNING:** Attribute `transit_gw` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please set `manage_transit_gateway_attachment` to false, and use the standalone `aviatrix_spoke_transit_attachment` resource instead.
 
 * `allocate_new_eip` - (Optional) When value is false, reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway. Available in Controller 4.7+. Valid values: true, false. Default: true. Option not available for AZURE and OCI gateways, they will automatically allocate new EIPs.
 * `eip` - (Optional) Required when `allocate_new_eip` is false. It uses the specified EIP for this gateway. Available in Controller 4.7+. Only available for AWS, GCP and AWSGOV.


### PR DESCRIPTION
1. "attached_vpc" and "attached_aviatrix_transit_gateway" in aviatrix_aws_tgw;
2. "transit_gw" in aviatrix_spoke_gateway;
3. "policy" in aviatrix_firewall;
4. "domain_names" in aviatrix_fqdn.