### PR TITLE
19016: GCP transit gateway firenet

### DIFF
--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -93,3 +93,13 @@ func stringInSlice(needle string, haystack []string) bool {
 	}
 	return false
 }
+
+// intInSlice checks if the needle is in the haystack
+func intInSlice(needle int, haystack []int) bool {
+	for _, element := range haystack {
+		if element == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -145,6 +145,8 @@ The following arguments are supported:
 -> **NOTE:** Enabling FireNet will automatically enable hybrid connection. If `enable_firenet` is set to true, please set `enable_hybrid_connection` to true in the respective **aviatrix_transit_gateway** as well.
 
 * `enable_transit_firenet` - (Optional) Sign of readiness for [Transit FireNet](https://docs.aviatrix.com/HowTos/transit_firenet_faq.html) connection. Valid values: true, false. Default value: false. Available in provider version R2.12+.
+* `lan_vpc_id` - (Optional) LAN VPC ID. Only valid when enabling Transit FireNet on GCP. Available as of provider version R2.18.1+.
+* `lan_private_subnet` - (Optional) LAN Private Subnet. Only valid when enabling Transit FireNet on GCP. Available as of provider version R2.18.1+.
 * `enable_egress_transit_firenet` - (Optional) Enable [Egress Transit FireNet](https://docs.aviatrix.com/HowTos/transit_firenet_workflow.html#b-enable-transit-firenet-on-aviatrix-egress-transit-gateway). Valid values: true, false. Default value: false. Available in provider version R2.16.3+.
 
 -> **NOTE:** Enabling or disabling `enable_gateway_load_balancer` requires that the FireNet interfaces also be disabled or enabled. For example, if the transit gateway currently has `enable_firenet` = true and `enable_gateway_load_balancer` = false, to enable `enable_gateway_load_balancer` you would first set `enable_firenet` = false and apply to disable the FireNet interfaces. Then you would set `enable_firenet` = true and `enable_gateway_load_balancer` = true and apply to reach the desired configuration.

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -165,28 +165,38 @@ type PolicyRule struct {
 }
 
 type GatewayDetail struct {
-	AccountName                  string       `form:"account_name,omitempty" json:"account_name,omitempty"`
-	Action                       string       `form:"action,omitempty"`
-	GwName                       string       `form:"gw_name,omitempty" json:"vpc_name,omitempty"`
-	DMZEnabled                   bool         `json:"dmz_enabled,omitempty"`
-	EnableAdvertiseTransitCidr   string       `json:"advertise_transit_cidr,omitempty"`
-	BgpManualSpokeAdvertiseCidrs []string     `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
-	VpnNat                       bool         `json:"vpn_nat,omitempty"`
-	SnatPolicy                   []PolicyRule `json:"snat_ip_port_list,omitempty"`
-	DnatPolicy                   []PolicyRule `json:"dnat_ip_port_list,omitempty"`
-	Elb                          ElbDetail    `json:"elb,omitempty"`
-	EnableEgressTransitFireNet   bool         `json:"egress_transit,omitempty"`
-	EnableFireNet                bool         `json:"firenet_enabled,omitempty"`
-	EnabledGatewayLoadBalancer   bool         `json:"gwlb_enabled,omitempty"`
-	EnableTransitFireNet         bool         `json:"transit_firenet_enabled,omitempty"`
-	LearnedCidrsApproval         string       `json:"learned_cidrs_approval,omitempty"`
-	SyncSNATToHA                 bool         `json:"sync_snat_to_ha,omitempty"`
-	SyncDNATToHA                 bool         `json:"sync_dnat_to_ha,omitempty"`
-	GwZone                       string       `json:"gw_zone,omitempty"`
-	TransitGwName                string       `json:"transit_gw_name,omitempty"`
-	EgressTransitGwName          string       `json:"egress_transit_gw_name,omitempty"`
-	RouteTables                  []string     `json:"spoke_rtb_list,omitempty"`
-	CustomizedTransitVpcRoutes   []string     `json:"customized_transit_vpc_cidrs"`
+	AccountName                  string        `form:"account_name,omitempty" json:"account_name,omitempty"`
+	Action                       string        `form:"action,omitempty"`
+	GwName                       string        `form:"gw_name,omitempty" json:"vpc_name,omitempty"`
+	DMZEnabled                   bool          `json:"dmz_enabled,omitempty"`
+	EnableAdvertiseTransitCidr   string        `json:"advertise_transit_cidr,omitempty"`
+	BgpManualSpokeAdvertiseCidrs []string      `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
+	VpnNat                       bool          `json:"vpn_nat,omitempty"`
+	SnatPolicy                   []PolicyRule  `json:"snat_ip_port_list,omitempty"`
+	DnatPolicy                   []PolicyRule  `json:"dnat_ip_port_list,omitempty"`
+	Elb                          ElbDetail     `json:"elb,omitempty"`
+	EnableEgressTransitFireNet   bool          `json:"egress_transit,omitempty"`
+	EnableFireNet                bool          `json:"firenet_enabled,omitempty"`
+	EnabledGatewayLoadBalancer   bool          `json:"gwlb_enabled,omitempty"`
+	EnableTransitFireNet         bool          `json:"transit_firenet_enabled,omitempty"`
+	LearnedCidrsApproval         string        `json:"learned_cidrs_approval,omitempty"`
+	SyncSNATToHA                 bool          `json:"sync_snat_to_ha,omitempty"`
+	SyncDNATToHA                 bool          `json:"sync_dnat_to_ha,omitempty"`
+	GwZone                       string        `json:"gw_zone,omitempty"`
+	TransitGwName                string        `json:"transit_gw_name,omitempty"`
+	EgressTransitGwName          string        `json:"egress_transit_gw_name,omitempty"`
+	RouteTables                  []string      `json:"spoke_rtb_list,omitempty"`
+	CustomizedTransitVpcRoutes   []string      `json:"customized_transit_vpc_cidrs"`
+	BundleVpcInfo                BundleVpcInfo `json:"bundle_vpc_info"`
+}
+
+type BundleVpcInfo struct {
+	LAN BundleVpcLanInfo
+}
+
+type BundleVpcLanInfo struct {
+	VpcID  string `json:"vpc_id"`
+	Subnet string
 }
 
 type ElbDetail struct {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -45,6 +45,8 @@ type TransitVpc struct {
 	EnableAdvertiseTransitCidr   bool
 	BgpManualSpokeAdvertiseCidrs string `form:"bgp_manual_spoke,omitempty"`
 	EnableTransitFireNet         string `form:"enable_transit_firenet,omitempty"`
+	LanVpcID                     string `form:"lan_vpc_id,omitempty"`
+	LanPrivateSubnet             string `form:"lan_private_subnet,omitempty"`
 	LearnedCidrsApproval         string `form:"learned_cidrs_approval,omitempty"`
 	EncVolume                    string `form:"enc_volume,omitempty"`
 	BgpOverLan                   string `form:"bgp_over_lan,omitempty"`


### PR DESCRIPTION
Allows for enabling of transit firenet on GCP transit gateways. Enabling transit firenet on a GCP transit gateway also requires 2 additional new attributes lan_vpc_id and lan_private_subnet.

## Unit Test:
Create GCP non-HA Transit Gateway with Transit FireNet
PASS

Update GCP non-HA -> HA Transit Gateway with Transit FireNet
PASS

Delete GCP non-HA Transit Gateway with Transit FireNet
PASS

Create GCP non-HA Transit Gateway without Transit FireNet
PASS

Update GCP  enable_transit_firenet
Get error: editing 'enable_transit_firenet' in GCP and AZURE is not supported
PASS

Update lan_vpc_id or lan_private_subnet
Get error: updating lan_vpc_id/lan_private_subnet is not allowed

Invalid configuration (enable_transit_firenet = true and lan_vpc_id or lan_private_subnet is not set)
Got error: 'lan_vpc_id' and 'lan_private_subnet' are required when 'cloud_type' = 4 (GCP) and 'enable_transit_firenet' = true
PASS

Invalid configuration (enable_transit_firenet = false and lan_vpc_id or lan_private_subnet are set)
Got error: 'lan_vpc_id' and 'lan_private_subnet' are only valid when 'cloud_type' = 4 (GCP) and 'enable_transit_firenet' = true
PASS

Create AWS non-HA Transit Gateway with Transit Firenet
PASS