### PR TITLE
20242: add support for deploying oob ha in different az

### DIFF
--- a/aviatrix/data_source_aviatrix_spoke_gateway.go
+++ b/aviatrix/data_source_aviatrix_spoke_gateway.go
@@ -195,6 +195,16 @@ func dataSourceAviatrixSpokeGateway() *schema.Resource {
 				Computed:    true,
 				Description: "OOB subnet availability zone.",
 			},
+			"ha_oob_management_subnet": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "OOB HA management subnet.",
+			},
+			"ha_oob_availability_zone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "OOB HA availability zone.",
+			},
 		},
 	}
 }
@@ -257,7 +267,7 @@ func dataSourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}
 
 		d.Set("enable_private_oob", gw.EnablePrivateOob)
 		if gw.EnablePrivateOob {
-			d.Set("oob_management_subnet", gw.OobManagementSubnet)
+			d.Set("oob_management_subnet", strings.Split(gw.OobManagementSubnet, "~~")[0])
 			d.Set("oob_availability_zone", gw.GatewayZone)
 		}
 
@@ -351,6 +361,11 @@ func dataSourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}
 				d.Set("ha_insane_mode_az", haGw.GatewayZone)
 			} else {
 				d.Set("ha_insane_mode_az", "")
+			}
+
+			if haGw.EnablePrivateOob {
+				d.Set("ha_oob_management_subnet", strings.Split(haGw.OobManagementSubnet, "~~")[0])
+				d.Set("ha_oob_availability_zone", haGw.GatewayZone)
 			}
 		}
 

--- a/aviatrix/data_source_aviatrix_transit_gateway.go
+++ b/aviatrix/data_source_aviatrix_transit_gateway.go
@@ -239,6 +239,16 @@ func dataSourceAviatrixTransitGateway() *schema.Resource {
 				Computed:    true,
 				Description: "OOB subnet availability zone.",
 			},
+			"ha_oob_management_subnet": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "OOB HA management subnet.",
+			},
+			"ha_oob_availability_zone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "OOB HA availability zone.",
+			},
 		},
 	}
 }
@@ -295,7 +305,7 @@ func dataSourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface
 
 		d.Set("enable_private_oob", gw.EnablePrivateOob)
 		if gw.EnablePrivateOob {
-			d.Set("oob_management_subnet", gw.OobManagementSubnet)
+			d.Set("oob_management_subnet", strings.Split(gw.OobManagementSubnet, "~~")[0])
 			d.Set("oob_availability_zone", gw.GatewayZone)
 		}
 
@@ -431,6 +441,11 @@ func dataSourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface
 			d.Set("ha_insane_mode_az", haGw.GatewayZone)
 		} else {
 			d.Set("ha_insane_mode_az", "")
+		}
+
+		if haGw.EnablePrivateOob {
+			d.Set("ha_oob_management_subnet", strings.Split(haGw.OobManagementSubnet, "~~")[0])
+			d.Set("ha_oob_availability_zone", haGw.GatewayZone)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -257,16 +257,18 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description: "Enable jumbo frame support for spoke gateway. Valid values: true or false. Default value: true.",
 			},
 			"eip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Required when allocate_new_eip is false. It uses specified EIP for this gateway.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPAddress,
+				Description:  "Required when allocate_new_eip is false. It uses specified EIP for this gateway.",
 			},
 			"ha_eip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Public IP address that you want assigned to the HA Spoke Gateway.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPAddress,
+				Description:  "Public IP address that you want assigned to the HA Spoke Gateway.",
 			},
 			"security_group_id": {
 				Type:        schema.TypeString,
@@ -1128,7 +1130,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 
 	if !enablePrivateOob {
 		if d.HasChange("ha_oob_management_subnet") {
-			return fmt.Errorf("updating ha_oob_manage_subnet is not allowed if private oob is disabled")
+			return fmt.Errorf("updating ha_oob_management_subnet is not allowed if private oob is disabled")
 		}
 
 		if d.HasChange("ha_oob_availability_zone") {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -64,9 +64,10 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description: "Size of the gateway instance.",
 			},
 			"subnet": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Public Subnet Info.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsCIDR,
+				Description:  "Public Subnet Info.",
 			},
 			"zone": {
 				Type:         schema.TypeString,
@@ -97,9 +98,10 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 					"Otherwise, allocate a new Elastic IP and use it for this gateway.",
 			},
 			"ha_subnet": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "HA Subnet. Required if enabling HA for AWS/AZURE. Optional if enabling HA for GCP.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsCIDR,
+				Description:  "HA Subnet. Required if enabling HA for AWS/AZURE. Optional if enabling HA for GCP.",
 			},
 			"ha_zone": {
 				Type:        schema.TypeString,
@@ -227,9 +229,10 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description: "Enable private OOB.",
 			},
 			"oob_management_subnet": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "OOB management subnet.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsCIDR,
+				Description:  "OOB management subnet.",
 			},
 			"oob_availability_zone": {
 				Type:        schema.TypeString,
@@ -237,9 +240,10 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description: "OOB subnet availability zone.",
 			},
 			"ha_oob_management_subnet": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "OOB HA management subnet.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsCIDR,
+				Description:  "OOB HA management subnet.",
 			},
 			"ha_oob_availability_zone": {
 				Type:        schema.TypeString,
@@ -457,14 +461,6 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("\"oob_management_subnet\" is required if \"enable_private_oob\" is true")
 		}
 
-		if _, err := validation.IsCIDR(oobManagementSubnet, "oob_management_subnet"); err != nil {
-			return fmt.Errorf("\"oob_management_subnet\" must be a CIDR if \"enable_private_oob\" is true")
-		}
-
-		if _, err := validation.IsCIDR(gateway.Subnet, "subnet"); err != nil {
-			return fmt.Errorf("\"subnet\" must be a CIDR if \"enable_private_oob\" is true")
-		}
-
 		if haSubnet != "" {
 			if haOobAvailabilityZone == "" {
 				return fmt.Errorf("\"ha_oob_availability_zone\" is required if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
@@ -472,14 +468,6 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 
 			if haOobManagementSubnet == "" {
 				return fmt.Errorf("\"ha_oob_management_subnet\" is required if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
-			}
-
-			if _, err := validation.IsCIDR(haSubnet, "ha_subnet"); err != nil {
-				return fmt.Errorf("\"ha_subnet\" must be a CIDR if \"enable_private_oob\" is true")
-			}
-
-			if _, err := validation.IsCIDR(haOobManagementSubnet, "ha_oob_management_subnet"); err != nil {
-				return fmt.Errorf("\"ha_oob_management_subnet\" must be a CIDR if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
 			}
 		} else {
 			if haOobAvailabilityZone != "" {
@@ -1333,14 +1321,6 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 
 				if haOobManagementSubnet == "" {
 					return fmt.Errorf("\"ha_oob_management_subnet\" is required if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
-				}
-
-				if _, err := validation.IsCIDR(spokeGw.HASubnet, "ha_subnet"); err != nil {
-					return fmt.Errorf("\"ha_subnet\" must be a CIDR if \"enable_private_oob\" is true")
-				}
-
-				if _, err := validation.IsCIDR(haOobManagementSubnet, "ha_oob_management_subnet"); err != nil {
-					return fmt.Errorf("\"ha_oob_management_subnet\" must be a CIDR if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
 				}
 
 				spokeGw.HASubnet = spokeGw.HASubnet + "~~" + haOobAvailabilityZone

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -670,6 +670,14 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			if _, err := validation.IsCIDR(haOobManagementSubnet, "ha_oob_management_subnet"); err != nil {
 				return fmt.Errorf("\"ha_oob_management_subnet\" must be a CIDR if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
 			}
+		} else {
+			if haOobAvailabilityZone != "" {
+				return fmt.Errorf("\"ha_oob_availability_zone\" must be empty if \"ha_subnet\" is empty")
+			}
+
+			if haOobManagementSubnet != "" {
+				return fmt.Errorf("\"ha_oob_mangeemnt_sbunet\" must be empty if \"ha_subnet\" is empty")
+			}
 		}
 
 		gateway.EnablePrivateOob = "on"
@@ -1546,6 +1554,18 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("updating oob_availability_zone is not allowed")
 	}
 
+	enablePrivateOob := d.Get("enable_private_oob").(bool)
+
+	if !enablePrivateOob {
+		if d.HasChange("ha_oob_management_subnet") {
+			return fmt.Errorf("updating ha_oob_manage_subnet is not allowed if private oob is disabled")
+		}
+
+		if d.HasChange("ha_oob_availability_zone") {
+			return fmt.Errorf("updating ha_oob_availability_zone is not allowed if private oob is disabled")
+		}
+	}
+
 	if d.HasChange("single_az_ha") {
 		singleAZGateway := &goaviatrix.Gateway{
 			GwName: d.Get("gw_name").(string),
@@ -1587,7 +1607,8 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 	}
 
 	newHaGwEnabled := false
-	if d.HasChange("ha_subnet") || d.HasChange("ha_zone") || d.HasChange("ha_insane_mode_az") {
+	if d.HasChange("ha_subnet") || d.HasChange("ha_zone") || d.HasChange("ha_insane_mode_az") ||
+		(enablePrivateOob && (d.HasChange("ha_oob_management_subnet") || d.HasChange("ha_oob_availability_zone"))) {
 		transitGw := &goaviatrix.TransitVpc{
 			GwName:    d.Get("gw_name").(string),
 			CloudType: d.Get("cloud_type").(int),
@@ -1619,14 +1640,24 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if transitGw.CloudType == goaviatrix.AZURE && d.Get("ha_zone").(string) != "" {
 				transitGw.HASubnet = fmt.Sprintf("%s~~%s~~", d.Get("ha_subnet").(string), d.Get("ha_zone").(string))
 			}
-			if oldSubnet == "" && newSubnet != "" {
-				newHaGwEnabled = true
-			} else if oldSubnet != "" && newSubnet == "" {
-				deleteHaGw = true
-			} else if oldSubnet != "" && newSubnet != "" {
-				changeHaGw = true
-			} else if d.HasChange("ha_zone") {
-				changeHaGw = true
+			if !enablePrivateOob {
+				if oldSubnet == "" && newSubnet != "" {
+					newHaGwEnabled = true
+				} else if oldSubnet != "" && newSubnet == "" {
+					deleteHaGw = true
+				} else if oldSubnet != "" && newSubnet != "" {
+					changeHaGw = true
+				} else if d.HasChange("ha_zone") {
+					changeHaGw = true
+				}
+			} else {
+				if oldSubnet == "" && newSubnet != "" {
+					newHaGwEnabled = true
+				} else if newSubnet == "" {
+					deleteHaGw = true
+				} else if oldSubnet != newSubnet || (oldSubnet == newSubnet && (d.HasChange("ha_oob_management_subnet") || d.HasChange("ha_oob_availability_zone"))) {
+					changeHaGw = true
+				}
 			}
 		} else if transitGw.CloudType == goaviatrix.GCP {
 			transitGw.HAZone = d.Get("ha_zone").(string)
@@ -1643,25 +1674,35 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		haOobManagementSubnet := d.Get("ha_oob_management_subnet").(string)
 		haOobAvailabilityZone := d.Get("ha_oob_availability_zone").(string)
 
-		if (newHaGwEnabled || changeHaGw) && d.Get("enable_private_oob").(bool) {
-			if haOobAvailabilityZone == "" {
-				return fmt.Errorf("\"ha_oob_availability_zone\" is required if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
-			}
+		if enablePrivateOob {
+			if newHaGwEnabled || changeHaGw {
+				if haOobAvailabilityZone == "" {
+					return fmt.Errorf("\"ha_oob_availability_zone\" is required if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
+				}
 
-			if haOobManagementSubnet == "" {
-				return fmt.Errorf("\"ha_oob_management_subnet\" is required if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
-			}
+				if haOobManagementSubnet == "" {
+					return fmt.Errorf("\"ha_oob_management_subnet\" is required if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
+				}
 
-			if _, err := validation.IsCIDR(transitGw.HASubnet, "ha_subnet"); err != nil {
-				return fmt.Errorf("\"ha_subnet\" must be a CIDR if \"enable_private_oob\" is true")
-			}
+				if _, err := validation.IsCIDR(transitGw.HASubnet, "ha_subnet"); err != nil {
+					return fmt.Errorf("\"ha_subnet\" must be a CIDR if \"enable_private_oob\" is true")
+				}
 
-			if _, err := validation.IsCIDR(haOobManagementSubnet, "ha_oob_management_subnet"); err != nil {
-				return fmt.Errorf("\"ha_oob_management_subnet\" must be a CIDR if \"enable_private_oob\" is true")
-			}
+				if _, err := validation.IsCIDR(haOobManagementSubnet, "ha_oob_management_subnet"); err != nil {
+					return fmt.Errorf("\"ha_oob_management_subnet\" must be a CIDR if \"enable_private_oob\" is true and \"ha_subnet\" is provided")
+				}
 
-			transitGw.HASubnet = transitGw.HASubnet + "~~" + haOobAvailabilityZone
-			transitGw.HAOobManagementSubnet = haOobManagementSubnet + "~~" + haOobAvailabilityZone
+				transitGw.HASubnet = transitGw.HASubnet + "~~" + haOobAvailabilityZone
+				transitGw.HAOobManagementSubnet = haOobManagementSubnet + "~~" + haOobAvailabilityZone
+			} else if deleteHaGw {
+				if haOobAvailabilityZone != "" {
+					return fmt.Errorf("\"ha_oob_availability_zone\" must be empty if \"ha_subnet\" is empty")
+				}
+
+				if haOobManagementSubnet != "" {
+					return fmt.Errorf("\"ha_oob_mangeemnt_sbunet\" must be empty if \"ha_subnet\" is empty")
+				}
+			}
 		}
 
 		if newHaGwEnabled {
@@ -1678,6 +1719,10 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			newHaGwEnabled = true
 		} else if deleteHaGw {
+			if d.Get("ha_gw_size").(string) != "" {
+				return fmt.Errorf("\"ha_gw_size\" must be empty if spoke HA gateway is deleted")
+			}
+
 			err := client.DeleteGateway(haGateway)
 			if err != nil {
 				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %s", err)

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -368,16 +368,18 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Description: "Enable jumbo frame support for transit gateway. Valid values: true or false. Default value: true.",
 			},
 			"eip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Required when allocate_new_eip is false. It uses specified EIP for this gateway.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPAddress,
+				Description:  "Required when allocate_new_eip is false. It uses specified EIP for this gateway.",
 			},
 			"ha_eip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Public IP address that you want assigned to the HA Transit Gateway.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IsIPAddress,
+				Description:  "Public IP address that you want assigned to the HA Transit Gateway.",
 			},
 			"security_group_id": {
 				Type:        schema.TypeString,
@@ -664,7 +666,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			}
 
 			if haOobManagementSubnet != "" {
-				return fmt.Errorf("\"ha_oob_mangeemnt_sbunet\" must be empty if \"ha_subnet\" is empty")
+				return fmt.Errorf("\"ha_oob_management_sbunet\" must be empty if \"ha_subnet\" is empty")
 			}
 		}
 
@@ -685,7 +687,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		}
 
 		if haOobManagementSubnet != "" {
-			return fmt.Errorf("\"ha_oob_mangeemnt_sbunet\" must be empty if \"enable_private_oob\" is false")
+			return fmt.Errorf("\"ha_oob_management_sbunet\" must be empty if \"enable_private_oob\" is false")
 		}
 	}
 

--- a/docs/data-sources/aviatrix_spoke_gateway.md
+++ b/docs/data-sources/aviatrix_spoke_gateway.md
@@ -66,3 +66,5 @@ In addition to all arguments above, the following attributes are exported:
 * `enable_private_oob` - Status of private OOB for the spoke gateway.
 * `oob_management_subnet` - OOB management subnet.
 * `oob_availability_zone` - OOB availability zone.
+* `ha_oob_management_subnet` - HA OOB management subnet.
+* `ha_oob_availability_zone` - HA OOB availability zone.

--- a/docs/data-sources/aviatrix_transit_gateway.md
+++ b/docs/data-sources/aviatrix_transit_gateway.md
@@ -74,3 +74,5 @@ In addition to all arguments above, the following attributes are exported:
 * `enable_private_oob` - Status of private OOB for the transit gateway.
 * `oob_management_subnet` - OOB management subnet.
 * `oob_availability_zone` - OOB availability zone.
+* `ha_oob_management_subnet` - HA OOB management subnet.
+* `ha_oob_availability_zone` - HA OOB availability zone.

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -143,6 +143,13 @@ The following arguments are supported:
 * `enable_monitor_gateway_subnets` - (Optional) If set to true, the [Monitor Gateway Subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet) feature is enabled. Default value is false. Available in provider version R2.18+.
 * `monitor_exclude_list` - (Optional) Set of monitored instance ids. Only valid when 'enable_monitor_gateway_subnets' = true. Available in provider version R2.18+.
 
+### OOB
+* `enable_private_oob` - (Optional) Enable private OOB. Only available for AWS and AWSGOV. Valid values: true, false. Default value: false.
+* `oob_management_subnet` - (Optional) OOB management subnet. Required if enabling private OOB. Example: "11.0.2.0/24".
+* `oob_availability_zone` - (Optional) OOB availability zone. Required if enabling private OOB. Example: "us-west-1a".
+* `ha_oob_management_subnet` - (Optional) HA OOB management subnet. Required if enabling private OOB and HA. Example: "11.0.0.48/28".
+* `ha_oob_availability_zone` - (Optional) HA OOB availability zone. Required if enabling private OOB and HA. Example: "us-west-1b".
+
 ### Misc.
 
 !> **WARNING:** Attribute `transit_gw` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please set `manage_transit_gateway_attachment` to false, and use the standalone `aviatrix_spoke_transit_attachment` resource instead.
@@ -155,9 +162,6 @@ The following arguments are supported:
 * `zone` - (Optional) Availability Zone. Only available for cloud_type = 8 (AZURE). Must be in the form 'az-n', for example, 'az-2'. Available in provider version R2.17+.
 * `manage_transit_gateway_attachment` - (Optional) Enable to manage spoke-to-Aviatrix transit gateway attachments using the **aviatrix_spoke_gateway** resource with the below `transit_gw` attribute. If this is set to false, attaching this spoke to transit gateways must be done using the **aviatrix_spoke_transit_attachment** resource. Valid values: true, false. Default value: true. Available in provider R2.17+.
 * `transit_gw` - (Optional) Specify the Aviatrix transit gateways to attach this spoke gateway to. Format is a comma separated list of transit gateway names. For example: "transit-gw1,transit-gw2".
-* `enable_private_oob` - (Optional) Enable private OOB.
-* `oob_management_subnet` - (Optional) OOB management subnet. Required if `enable_private_oob` is true.
-* `oob_availability_zone` - (Optional) OOB availability zone. Required if `enable_private_oob` is true.
 * `enable_jumbo_frame` - (Optional) Enable jumbo frames for this spoke gateway. Default value is true.
 
 -> **NOTE:** `manage_transit_gateway_attachment` - If you are using/upgraded to Aviatrix Terraform Provider R2.17+, and an **aviatrix_spoke_gateway** resource was originally created with a provider version <R2.17, you must do 'terraform refresh' to update and apply the attribute's default value (true) into the state file.

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -95,6 +95,28 @@ resource "aviatrix_spoke_gateway" "test_spoke_gateway_awsgov" {
   ]
 }
 ```
+```hcl
+# Create an OOB Aviatrix AWS Spoke Gateway
+resource "aviatrix_spoke_gateway" "test_oob_spoke" {
+  cloud_type   = 1
+  account_name = "devops-aws"
+  gw_name      = "oob-spoke"
+  vpc_id       = "vpc-abcd1234"
+  vpc_reg      = "us-west-1"
+  gw_size      = "c5.xlarge"
+  enable_active_mesh = true
+
+  enable_private_oob = true
+  subnet = "11.0.0.128/26"
+  oob_management_subnet = "11.0.2.0/24"
+  oob_availability_zone = "us-west-1a"
+
+  ha_subnet = "11.0.3.64/26"
+  ha_gw_size = "c5.xlarge"
+  ha_oob_management_subnet = "11.0.0.48/28"
+  ha_oob_availability_zone = "us-west-1b"
+}
+```
 
 ## Argument Reference
 

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -181,6 +181,13 @@ The following arguments are supported:
 * `enable_monitor_gateway_subnets` - (Optional) If set to true, the [Monitor Gateway Subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet) feature is enabled. Default value is false. Available in provider version R2.18+.
 * `monitor_exclude_list` - (Optional) Set of monitored instance ids. Only valid when 'enable_monitor_gateway_subnets' = true. Available in provider version R2.18+.
 
+### OOB
+* `enable_private_oob` - (Optional) Enable private OOB. Only available for AWS and AWSGOV. Valid values: true, false. Default value: false.
+* `oob_management_subnet` - (Optional) OOB management subnet. Required if enabling private OOB. Example: "11.0.2.0/24".
+* `oob_availability_zone` - (Optional) OOB availability zone. Required if enabling private OOB. Example: "us-west-1a".
+* `ha_oob_management_subnet` - (Optional) HA OOB management subnet. Required if enabling private OOB and HA. Example: "11.0.0.48/28".
+* `ha_oob_availability_zone` - (Optional) HA OOB availability zone. Required if enabling private OOB and HA. Example: "us-west-1b".
+
 ### Misc.
 * `allocate_new_eip` - (Optional) When value is false, reuse an idle address in Elastic IP pool for this gateway. Otherwise, allocate a new Elastic IP and use it for this gateway. Available in Controller 4.7+. Valid values: true, false. Default: true. Option not available for Azure and OCI gateways, they will automatically allocate new EIPs.
 * `eip` - (Optional) Required when `allocate_new_eip` is false. It uses the specified EIP for this gateway. Available in Controller version 4.7+. Only available for AWS and GCP.
@@ -189,9 +196,6 @@ The following arguments are supported:
 * `enable_vpc_dns_server` - (Optional) Enable VPC DNS Server for Gateway. Currently only supports AWS and AWSGOV. Valid values: true, false. Default value: false.
 * `zone` - (Optional) Availability Zone. Only available for cloud_type = 8 (AZURE). Must be in the form 'az-n', for example, 'az-2'. Available in provider version R2.17+.
 * `enable_active_standby` - (Optional) Enables [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby). Available only with Active Mesh Mode enabled and HA enabled. Valid values: true, false. Default value: false. Available in provider version R2.17.1+.
-* `enable_private_oob` - (Optional) Enable private OOB.
-* `oob_management_subnet` - (Optional) OOB management subnet. Required if `enable_private_oob` is true.
-* `oob_availability_zone` - (Optional) OOB availability zone. Required if `enable_private_oob` is true.
 * `enable_jumbo_frame` - (Optional) Enable jumbo frames for this transit gateway. Default value is true.
 
 ## Attribute Reference

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -103,6 +103,28 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_awsgov" {
   connected_transit        = true
 }
 ```
+```hcl
+# Create an OOB Aviatrix AWS Transit Network Gateway
+resource "aviatrix_transit_gateway" "test_oob_transit" {
+  cloud_type   = 1
+  account_name = "devops-aws"
+  gw_name      = "oob-transit"
+  vpc_id       = "vpc-abcd1234"
+  vpc_reg      = "us-west-1"
+  gw_size      = "c5.xlarge"
+  enable_active_mesh = true
+
+  enable_private_oob = true
+  subnet = "11.0.0.128/26"
+  oob_management_subnet = "11.0.2.0/24"
+  oob_availability_zone = "us-west-1a"
+
+  ha_subnet = "11.0.3.64/26"
+  ha_gw_size = "c5.xlarge"
+  ha_oob_management_subnet = "11.0.0.48/28"
+  ha_oob_availability_zone = "us-west-1b"
+}
+```
 
 ## Argument Reference
 

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -41,6 +41,7 @@ type SpokeVpc struct {
 	EncVolume             string `form:"enc_volume,omitempty"`
 	EnablePrivateOob      string `form:"private_oob,omitempty"`
 	OobManagementSubnet   string `form:"oob_mgmt_subnet,omitempty"`
+	HAOobManagementSubnet string
 }
 
 func (c *Client) LaunchSpokeVpc(spoke *SpokeVpc) error {
@@ -149,7 +150,7 @@ func (c *Client) EnableHaSpokeVpc(spoke *SpokeVpc) error {
 
 	if spoke.CloudType == AWS || spoke.CloudType == AZURE || spoke.CloudType == OCI || spoke.CloudType == AWSGOV {
 		enableSpokeHa.Add("public_subnet", spoke.HASubnet)
-		enableSpokeHa.Add("oob_mgmt_subnet", spoke.OobManagementSubnet)
+		enableSpokeHa.Add("oob_mgmt_subnet", spoke.HAOobManagementSubnet)
 	} else if spoke.CloudType == GCP {
 		enableSpokeHa.Add("new_zone", spoke.HAZone)
 	} else {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -52,6 +52,7 @@ type TransitVpc struct {
 	BgpOverLan                   string `form:"bgp_over_lan,omitempty"`
 	EnablePrivateOob             string `form:"private_oob,omitempty"`
 	OobManagementSubnet          string `form:"oob_mgmt_subnet,omitempty"`
+	HAOobManagementSubnet        string
 }
 
 type TransitGatewayAdvancedConfig struct {
@@ -169,7 +170,7 @@ func (c *Client) EnableHaTransitVpc(gateway *TransitVpc) error {
 		enableTransitHa.Add("new_zone", gateway.HAZone)
 	} else {
 		enableTransitHa.Add("public_subnet", gateway.HASubnet)
-		enableTransitHa.Add("oob_mgmt_subnet", gateway.OobManagementSubnet)
+		enableTransitHa.Add("oob_mgmt_subnet", gateway.HAOobManagementSubnet)
 	}
 
 	Url.RawQuery = enableTransitHa.Encode()


### PR DESCRIPTION
- added support for deploying oob ha in a different az
- reordered the attributes
- refactored the code
- reorganized the doc
- add additional checks
```
In Create():
If oob enabled:
	If not AWS or AWSGOV -> error
	If oob_az or oob_mgmt_subnet is empty -> error
	If subnet or oob_mgmt_subnet is not CIDR -> error
	If ha_subnet is provided (to enable HA):
		If ha_oob_az or ha_oob_mgmt_subnet is empty -> error
		If ha_subnet or ha_oob_mgmt_subnet is not CIDR -> error
	Else:
		If ha_oob_az or ha_oob_mgmt_subnet is not empty -> error
Else:
	If oob_az, oob_mgmt_subnet, ha_oob_az or ha_oob_mgmt_subnet is not empty -> error

In Update():
If enable_private_oob, oob_mgmt_subnet or oob_az is changed -> error
If oob disabled:
	If ha_oob_mgmt_subnet or ha_oob_az is changed -> error
If oob enabled:
	If create new ha or change ha:
		If ha_oob_az or ha_oob_mgmt_subnet is empty -> error
		If ha_subnet or ha_oob_mgmt_subnet is not CIDR -> error	
	Else if delete ha:
		If ha_oob_az or ha_oob_mgmt_subnet is not empty -> error
```
- unit tests:
    - Create oob transit/spoke gw without ha -> remove state, import, plan -> no diff
    - Add ha -> remove state, import, plan -> no diff
    - Destroy
    - Create oob transit/spoke gw with ha -> remove state, import, plan -> no diff
    - Delete ha -> remove state, import, plan -> no diff
    - Add ha -> remove state, import, plan -> no diff
    - Destroy
    - Create normal spoke gw -> remove state, import, plan -> no diff
    - try some invalid input -> error
    - make changes to ha gateway
