### PR TITLE
20408: gw/tgw/sgw change some attributes to ForceNew

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -51,11 +51,13 @@ func resourceAviatrixGateway() *schema.Resource {
 			"vpc_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "ID of legacy VPC/Vnet to be connected.",
 			},
 			"vpc_reg": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Region where this gateway will be launched.",
 			},
 			"gw_size": {
@@ -66,11 +68,13 @@ func resourceAviatrixGateway() *schema.Resource {
 			"subnet": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "A VPC Network address range selected from one of the available network ranges.",
 			},
 			"zone": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 				Description: "Availability Zone. Only available for Azure and Public Subnet Filtering gateway",
 			},
 			"insane_mode_az": {
@@ -1469,18 +1473,6 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 	if d.HasChange("gw_name") {
 		return fmt.Errorf("updating gw_name is not allowed")
-	}
-	if d.HasChange("vpc_id") {
-		return fmt.Errorf("updating vpc_id is not allowed")
-	}
-	if d.HasChange("vpc_reg") {
-		return fmt.Errorf("updating vpc_reg is not allowed")
-	}
-	if d.HasChange("subnet") {
-		return fmt.Errorf("updating subnet is not allowed")
-	}
-	if d.HasChange("zone") {
-		return fmt.Errorf("updating zone is not allowed")
 	}
 	if d.HasChange("vpn_access") {
 		return fmt.Errorf("updating vpn_access is not allowed")

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -51,11 +51,13 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 			"vpc_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "VPC-ID/VNet-Name of cloud provider.",
 			},
 			"vpc_reg": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Region of cloud provider.",
 			},
 			"gw_size": {
@@ -66,12 +68,14 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 			"subnet": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.IsCIDR,
 				Description:  "Public Subnet Info.",
 			},
 			"zone": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: validateAzureAZ,
 				Description:  "Availability Zone. Only available for cloud_type = 8 (AZURE). Must be in the form 'az-n', for example, 'az-2'.",
 			},
@@ -231,12 +235,14 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 			"oob_management_subnet": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.IsCIDR,
 				Description:  "OOB management subnet.",
 			},
 			"oob_availability_zone": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 				Description: "OOB subnet availability zone.",
 			},
 			"ha_oob_management_subnet": {
@@ -1083,18 +1089,6 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChange("gw_name") {
 		return fmt.Errorf("updating gw_name is not allowed")
 	}
-	if d.HasChange("vpc_id") {
-		return fmt.Errorf("updating vpc_id is not allowed")
-	}
-	if d.HasChange("vpc_reg") {
-		return fmt.Errorf("updating vpc_reg is not allowed")
-	}
-	if d.HasChange("subnet") {
-		return fmt.Errorf("updating subnet is not allowed")
-	}
-	if d.HasChange("zone") {
-		return fmt.Errorf("updating zone is not allowed")
-	}
 	if d.HasChange("insane_mode") {
 		return fmt.Errorf("updating insane_mode is not allowed")
 	}
@@ -1116,14 +1110,6 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 
 	if d.HasChange("enable_private_oob") {
 		return fmt.Errorf("updating enable_private_oob is not allowed")
-	}
-
-	if d.HasChange("oob_management_subnet") {
-		return fmt.Errorf("updating oob_manage_subnet is not allowed")
-	}
-
-	if d.HasChange("oob_availability_zone") {
-		return fmt.Errorf("updating oob_availability_zone is not allowed")
 	}
 
 	enablePrivateOob := d.Get("enable_private_oob").(bool)

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -46,11 +46,13 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 			"vpc_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "VPC-ID/VNet-Name of cloud provider.",
 			},
 			"vpc_reg": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Region of cloud provider.",
 			},
 			"gw_size": {
@@ -61,12 +63,14 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 			"subnet": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.IsCIDR,
 				Description:  "Public Subnet Name.",
 			},
 			"zone": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: validateAzureAZ,
 				Description:  "Availability Zone. Only available for cloud_type = 8 (AZURE). Must be in the form 'az-n', for example, 'az-2'.",
 			},
@@ -342,12 +346,14 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 			"oob_management_subnet": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.IsCIDR,
 				Description:  "OOB management subnet.",
 			},
 			"oob_availability_zone": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 				Description: "OOB subnet availability zone.",
 			},
 			"ha_oob_management_subnet": {
@@ -1481,18 +1487,6 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 	if d.HasChange("gw_name") {
 		return fmt.Errorf("updating gw_name is not allowed")
 	}
-	if d.HasChange("vpc_id") {
-		return fmt.Errorf("updating vpc_id is not allowed")
-	}
-	if d.HasChange("vpc_reg") {
-		return fmt.Errorf("updating vpc_reg is not allowed")
-	}
-	if d.HasChange("subnet") {
-		return fmt.Errorf("updating subnet is not allowed")
-	}
-	if d.HasChange("zone") {
-		return fmt.Errorf("updating zone is not allowed")
-	}
 	if d.HasChange("insane_mode") {
 		return fmt.Errorf("updating insane_mode is not allowed")
 	}
@@ -1534,14 +1528,6 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChange("enable_private_oob") {
 		return fmt.Errorf("updating enable_private_oob is not allowed")
-	}
-
-	if d.HasChange("oob_management_subnet") {
-		return fmt.Errorf("updating oob_manage_subnet is not allowed")
-	}
-
-	if d.HasChange("oob_availability_zone") {
-		return fmt.Errorf("updating oob_availability_zone is not allowed")
 	}
 
 	enablePrivateOob := d.Get("enable_private_oob").(bool)


### PR DESCRIPTION
In gateway, transit_gateway and spoke_gateway, `vpc_id`, `vpc_reg`, `subnet`, `zone`, `oob_management_subnet` and `oob_availability_zone` are set to ForceNew now. 

Two special cases for `zone`, `oob_management_subnet` and `oob_availability_zone`:
1. `zone` only works for Azure now. If user accidentally changes `zone` for gateways of other cloud types, there's no way to stop Terraform from deleting the resource, but an error will be returned in Create().
2. Similarly, for non-oob gateways, if user accidentally changes `oob_management_subnet` or `oob_availability_zone`, there's no way to stop the ForceNew process, but an error will be returned in Create().
