### PR TITLE
Update module to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,32 +14,32 @@ Requirements
 Building The Provider (Terraform v0.12+)
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-aviatrix`
+Clone repository to: `$GOPATH/src/github.com/AviatrixSystems/terraform-provider-aviatrix`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers
-$ cd $GOPATH/src/github.com/terraform-providers
+$ mkdir -p $GOPATH/src/github.com/AviatrixSystems
+$ cd $GOPATH/src/github.com/AviatrixSystems
 $ git clone https://github.com/AviatrixSystems/terraform-provider-aviatrix.git
 ```
 
 To clone on windows
 ```sh
-mkdir %GOPATH%\src\github.com\terraform-providers
-cd %GOPATH%\src\github.com\terraform-providers
+mkdir %GOPATH%\src\github.com\AviatrixSystems
+cd %GOPATH%\src\github.com\AviatrixSystems
 git clone https://github.com/AviatrixSystems/terraform-provider-aviatrix.git
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-aviatrix
+$ cd $GOPATH/src/github.com/AviatrixSystems/terraform-provider-aviatrix
 $ make fmt
 $ make build
 ```
 
 To build on Windows
 ```sh
-cd %GOPATH%\src\github.com\terraform-providers\terraform-provider-aviatrix
+cd %GOPATH%\src\github.com\AviatrixSystems\terraform-provider-aviatrix
 go fmt
 go install
 ```

--- a/aviatrix/config.go
+++ b/aviatrix/config.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 )
 
 // Config contains the configuration for the Aviatrix provider

--- a/aviatrix/data_source_aviatrix_account.go
+++ b/aviatrix/data_source_aviatrix_account.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixAccount() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_caller_identity.go
+++ b/aviatrix/data_source_aviatrix_caller_identity.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixCallerIdentity() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_caller_identity_test.go
+++ b/aviatrix/data_source_aviatrix_caller_identity_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/aviatrix/data_source_aviatrix_firenet.go
+++ b/aviatrix/data_source_aviatrix_firenet.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixFireNet() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_firenet_vendor_integration.go
+++ b/aviatrix/data_source_aviatrix_firenet_vendor_integration.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixFireNetVendorIntegration() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_firewall.go
+++ b/aviatrix/data_source_aviatrix_firewall.go
@@ -3,8 +3,8 @@ package aviatrix
 import (
 	"fmt"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixFirewall() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_gateway.go
+++ b/aviatrix/data_source_aviatrix_gateway.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixGateway() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_spoke_gateway.go
+++ b/aviatrix/data_source_aviatrix_spoke_gateway.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixSpokeGateway() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_transit_gateway.go
+++ b/aviatrix/data_source_aviatrix_transit_gateway.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixTransitGateway() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_vpc.go
+++ b/aviatrix/data_source_aviatrix_vpc.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixVpc() *schema.Resource {

--- a/aviatrix/data_source_aviatrix_vpc_tracker.go
+++ b/aviatrix/data_source_aviatrix_vpc_tracker.go
@@ -3,9 +3,9 @@ package aviatrix
 import (
 	"fmt"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func dataSourceAviatrixVpcTracker() *schema.Resource {

--- a/aviatrix/resource_aviatrix_account.go
+++ b/aviatrix/resource_aviatrix_account.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAccount() *schema.Resource {

--- a/aviatrix/resource_aviatrix_account_test.go
+++ b/aviatrix/resource_aviatrix_account_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preAccountCheck(t *testing.T, msgEnd string) {

--- a/aviatrix/resource_aviatrix_account_user.go
+++ b/aviatrix/resource_aviatrix_account_user.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"unicode"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAccountUser() *schema.Resource {

--- a/aviatrix/resource_aviatrix_account_user_test.go
+++ b/aviatrix/resource_aviatrix_account_user_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAccountUser_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_arm_peer.go
+++ b/aviatrix/resource_aviatrix_arm_peer.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixARMPeer() *schema.Resource {

--- a/aviatrix/resource_aviatrix_arm_peer_test.go
+++ b/aviatrix/resource_aviatrix_arm_peer_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preARMPeerCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_aws_guard_duty.go
+++ b/aviatrix/resource_aviatrix_aws_guard_duty.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAwsGuardDuty() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_peer.go
+++ b/aviatrix/resource_aviatrix_aws_peer.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAWSPeer() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_peer_test.go
+++ b/aviatrix/resource_aviatrix_aws_peer_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preAWSPeerCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_aws_tgw.go
+++ b/aviatrix/resource_aviatrix_aws_tgw.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAWSTgw() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_connect.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_connect.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAwsTgwConnect() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_connect_peer.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_connect_peer.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAwsTgwConnectPeer() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_connect_peer_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_connect_peer_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAwsTgwConnectPeer_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_aws_tgw_connect_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_connect_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAwsTgwConnect_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_aws_tgw_directconnect.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_directconnect.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAWSTgwDirectConnect() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_directconnect_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_directconnect_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAwsTgwDirectConnect_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_aws_tgw_peering.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_peering.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAWSTgwPeering() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_peering_domain_conn.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_peering_domain_conn.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAWSTgwPeeringDomainConn() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_peering_domain_conn_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_peering_domain_conn_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAWSTgwPeeringDomainConn_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_aws_tgw_peering_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_peering_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAWSTgwPeering_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_aws_tgw_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAWSTgw_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_aws_tgw_transit_gateway_attachment.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_transit_gateway_attachment.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAwsTgwTransitGatewayAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_transit_gateway_attachment_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_transit_gateway_attachment_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAwsTgwTransitGatewayAttachment_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAwsTgwVpcAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAwsTgwVpcAttachment_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_aws_tgw_vpn_conn.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpn_conn.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAwsTgwVpnConn() *schema.Resource {

--- a/aviatrix/resource_aviatrix_aws_tgw_vpn_conn_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpn_conn_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAwsTgwVpnConn_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_azure_peer.go
+++ b/aviatrix/resource_aviatrix_azure_peer.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAzurePeer() *schema.Resource {

--- a/aviatrix/resource_aviatrix_azure_peer_test.go
+++ b/aviatrix/resource_aviatrix_azure_peer_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preAzurePeerCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_azure_spoke_native_peering.go
+++ b/aviatrix/resource_aviatrix_azure_spoke_native_peering.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAzureSpokeNativePeering() *schema.Resource {

--- a/aviatrix/resource_aviatrix_azure_spoke_native_peering_test.go
+++ b/aviatrix/resource_aviatrix_azure_spoke_native_peering_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preAzureSpokeNativePeeringCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_azure_vng_conn.go
+++ b/aviatrix/resource_aviatrix_azure_vng_conn.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixAzureVngConn() *schema.Resource {

--- a/aviatrix/resource_aviatrix_azure_vng_conn_test.go
+++ b/aviatrix/resource_aviatrix_azure_vng_conn_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixAzureVngConn_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_cloudwatch_agent.go
+++ b/aviatrix/resource_aviatrix_cloudwatch_agent.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/aviatrix/resource_aviatrix_cloudwatch_agent_test.go
+++ b/aviatrix/resource_aviatrix_cloudwatch_agent_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixCloudwatchAgent_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_controller_config.go
+++ b/aviatrix/resource_aviatrix_controller_config.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 const defaultAwsGuardDutyScanningInterval = 60

--- a/aviatrix/resource_aviatrix_controller_config_test.go
+++ b/aviatrix/resource_aviatrix_controller_config_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixControllerConfig_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_controller_private_oob.go
+++ b/aviatrix/resource_aviatrix_controller_private_oob.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixControllerPrivateOob() *schema.Resource {

--- a/aviatrix/resource_aviatrix_controller_private_oob_test.go
+++ b/aviatrix/resource_aviatrix_controller_private_oob_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixControllerPrivateOob_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_datadog_agent.go
+++ b/aviatrix/resource_aviatrix_datadog_agent.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixDatadogAgent() *schema.Resource {

--- a/aviatrix/resource_aviatrix_datadog_agent_test.go
+++ b/aviatrix/resource_aviatrix_datadog_agent_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixDatadogAgent_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_device_aws_tgw_attachment.go
+++ b/aviatrix/resource_aviatrix_device_aws_tgw_attachment.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixDeviceAwsTgwAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_device_aws_tgw_attachment_test.go
+++ b/aviatrix/resource_aviatrix_device_aws_tgw_attachment_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixDeviceAwsTgwAttachment_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_device_interface_config.go
+++ b/aviatrix/resource_aviatrix_device_interface_config.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixDeviceInterfaceConfig() *schema.Resource {

--- a/aviatrix/resource_aviatrix_device_interface_config_test.go
+++ b/aviatrix/resource_aviatrix_device_interface_config_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixDeviceInterfaceConfig_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_device_registration.go
+++ b/aviatrix/resource_aviatrix_device_registration.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixDeviceRegistration() *schema.Resource {

--- a/aviatrix/resource_aviatrix_device_registration_test.go
+++ b/aviatrix/resource_aviatrix_device_registration_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixDeviceRegistration_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_device_tag.go
+++ b/aviatrix/resource_aviatrix_device_tag.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixDeviceTag() *schema.Resource {

--- a/aviatrix/resource_aviatrix_device_tag_test.go
+++ b/aviatrix/resource_aviatrix_device_tag_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixDeviceTag_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_device_transit_gateway_attachment.go
+++ b/aviatrix/resource_aviatrix_device_transit_gateway_attachment.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixDeviceTransitGatewayAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_device_transit_gateway_attachment_test.go
+++ b/aviatrix/resource_aviatrix_device_transit_gateway_attachment_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixDeviceTransitGatewayAttachment_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_device_virtual_wan_attachment.go
+++ b/aviatrix/resource_aviatrix_device_virtual_wan_attachment.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixDeviceVirtualWanAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_device_virtual_wan_attachment_test.go
+++ b/aviatrix/resource_aviatrix_device_virtual_wan_attachment_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixDeviceVirtualWanAttachment_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_filebeat_forwarder.go
+++ b/aviatrix/resource_aviatrix_filebeat_forwarder.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFilebeatForwarder() *schema.Resource {

--- a/aviatrix/resource_aviatrix_filebeat_forwarder_test.go
+++ b/aviatrix/resource_aviatrix_filebeat_forwarder_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFilebeatForwarder_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFireNet() *schema.Resource {

--- a/aviatrix/resource_aviatrix_firenet_test.go
+++ b/aviatrix/resource_aviatrix_firenet_test.go
@@ -7,10 +7,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFireNet_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_firewall.go
+++ b/aviatrix/resource_aviatrix_firewall.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFirewall() *schema.Resource {

--- a/aviatrix/resource_aviatrix_firewall_instance.go
+++ b/aviatrix/resource_aviatrix_firewall_instance.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFirewallInstance() *schema.Resource {

--- a/aviatrix/resource_aviatrix_firewall_instance_association.go
+++ b/aviatrix/resource_aviatrix_firewall_instance_association.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFirewallInstanceAssociation() *schema.Resource {

--- a/aviatrix/resource_aviatrix_firewall_instance_association_test.go
+++ b/aviatrix/resource_aviatrix_firewall_instance_association_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFirewallInstanceAssociation_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_firewall_instance_test.go
+++ b/aviatrix/resource_aviatrix_firewall_instance_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFirewallInstance_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_firewall_management_access.go
+++ b/aviatrix/resource_aviatrix_firewall_management_access.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFirewallManagementAccess() *schema.Resource {

--- a/aviatrix/resource_aviatrix_firewall_management_access_test.go
+++ b/aviatrix/resource_aviatrix_firewall_management_access_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFirewallManagementAccess_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_firewall_policy.go
+++ b/aviatrix/resource_aviatrix_firewall_policy.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFirewallPolicy() *schema.Resource {

--- a/aviatrix/resource_aviatrix_firewall_policy_test.go
+++ b/aviatrix/resource_aviatrix_firewall_policy_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFirewallPolicy_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_firewall_tag.go
+++ b/aviatrix/resource_aviatrix_firewall_tag.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFirewallTag() *schema.Resource {

--- a/aviatrix/resource_aviatrix_firewall_tag_test.go
+++ b/aviatrix/resource_aviatrix_firewall_tag_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFirewallTag_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_firewall_test.go
+++ b/aviatrix/resource_aviatrix_firewall_test.go
@@ -7,10 +7,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFirewall_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_fqdn.go
+++ b/aviatrix/resource_aviatrix_fqdn.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFQDN() *schema.Resource {

--- a/aviatrix/resource_aviatrix_fqdn_pass_through.go
+++ b/aviatrix/resource_aviatrix_fqdn_pass_through.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFQDNPassThrough() *schema.Resource {

--- a/aviatrix/resource_aviatrix_fqdn_pass_through_test.go
+++ b/aviatrix/resource_aviatrix_fqdn_pass_through_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFQDNPassThrough_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_fqdn_tag_rule.go
+++ b/aviatrix/resource_aviatrix_fqdn_tag_rule.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixFQDNTagRule() *schema.Resource {

--- a/aviatrix/resource_aviatrix_fqdn_tag_rule_test.go
+++ b/aviatrix/resource_aviatrix_fqdn_tag_rule_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFQDNTagRule_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_fqdn_test.go
+++ b/aviatrix/resource_aviatrix_fqdn_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixFQDN_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixGateway() *schema.Resource {

--- a/aviatrix/resource_aviatrix_gateway_certificate_config.go
+++ b/aviatrix/resource_aviatrix_gateway_certificate_config.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixGatewayCertificateConfig() *schema.Resource {

--- a/aviatrix/resource_aviatrix_gateway_certificate_config_test.go
+++ b/aviatrix/resource_aviatrix_gateway_certificate_config_test.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixGatewayCertificateConfig_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_gateway_dnat.go
+++ b/aviatrix/resource_aviatrix_gateway_dnat.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixGatewayDNat() *schema.Resource {

--- a/aviatrix/resource_aviatrix_gateway_dnat_test.go
+++ b/aviatrix/resource_aviatrix_gateway_dnat_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixGatewayDNat_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_gateway_snat.go
+++ b/aviatrix/resource_aviatrix_gateway_snat.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixGatewaySNat() *schema.Resource {

--- a/aviatrix/resource_aviatrix_gateway_snat_test.go
+++ b/aviatrix/resource_aviatrix_gateway_snat_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixGatewaySNat_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_gateway_test.go
+++ b/aviatrix/resource_aviatrix_gateway_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preGatewayCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_geo_vpn.go
+++ b/aviatrix/resource_aviatrix_geo_vpn.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixGeoVPN() *schema.Resource {

--- a/aviatrix/resource_aviatrix_geo_vpn_test.go
+++ b/aviatrix/resource_aviatrix_geo_vpn_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixGeoVPN_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_netflow_agent.go
+++ b/aviatrix/resource_aviatrix_netflow_agent.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/aviatrix/resource_aviatrix_netflow_agent_test.go
+++ b/aviatrix/resource_aviatrix_netflow_agent_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixNetflowAgent_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_periodic_ping.go
+++ b/aviatrix/resource_aviatrix_periodic_ping.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixPeriodicPing() *schema.Resource {

--- a/aviatrix/resource_aviatrix_periodic_ping_test.go
+++ b/aviatrix/resource_aviatrix_periodic_ping_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixPeriodicPing_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_proxy_config.go
+++ b/aviatrix/resource_aviatrix_proxy_config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixProxyConfig() *schema.Resource {

--- a/aviatrix/resource_aviatrix_proxy_config_test.go
+++ b/aviatrix/resource_aviatrix_proxy_config_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixProxyConfig_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_rbac_group.go
+++ b/aviatrix/resource_aviatrix_rbac_group.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixRbacGroup() *schema.Resource {

--- a/aviatrix/resource_aviatrix_rbac_group_access_account_attachment.go
+++ b/aviatrix/resource_aviatrix_rbac_group_access_account_attachment.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixRbacGroupAccessAccountAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_rbac_group_access_account_attachment_test.go
+++ b/aviatrix/resource_aviatrix_rbac_group_access_account_attachment_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixRbacGroupAccessAccountAttachment_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_rbac_group_permission_attachment.go
+++ b/aviatrix/resource_aviatrix_rbac_group_permission_attachment.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixRbacGroupPermissionAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_rbac_group_permission_attachment_test.go
+++ b/aviatrix/resource_aviatrix_rbac_group_permission_attachment_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixRbacGroupPermissionAttachment_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_rbac_group_test.go
+++ b/aviatrix/resource_aviatrix_rbac_group_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixRbacGroup_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_rbac_group_user_attachment.go
+++ b/aviatrix/resource_aviatrix_rbac_group_user_attachment.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixRbacGroupUserAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_rbac_group_user_attachment_test.go
+++ b/aviatrix/resource_aviatrix_rbac_group_user_attachment_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixRbacGroupUserAttachment_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_remote_syslog.go
+++ b/aviatrix/resource_aviatrix_remote_syslog.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 var remoteSyslogMatcher = regexp.MustCompile(`\bremote_syslog_[0-9]\b`)

--- a/aviatrix/resource_aviatrix_remote_syslog_test.go
+++ b/aviatrix/resource_aviatrix_remote_syslog_test.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixRemoteSyslog_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_saml_endpoint.go
+++ b/aviatrix/resource_aviatrix_saml_endpoint.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSamlEndpoint() *schema.Resource {

--- a/aviatrix/resource_aviatrix_saml_endpoint_test.go
+++ b/aviatrix/resource_aviatrix_saml_endpoint_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preSamlEndpointCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_segmentation_security_domain.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSegmentationSecurityDomain() *schema.Resource {

--- a/aviatrix/resource_aviatrix_segmentation_security_domain_association.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain_association.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSegmentationSecurityDomainAssociation() *schema.Resource {

--- a/aviatrix/resource_aviatrix_segmentation_security_domain_association_test.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain_association_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixSegmentationSecurityDomainAssociation_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_segmentation_security_domain_connection_policy.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain_connection_policy.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSegmentationSecurityDomainConnectionPolicy() *schema.Resource {

--- a/aviatrix/resource_aviatrix_segmentation_security_domain_connection_policy_test.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain_connection_policy_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixSegmentationSecurityDomainConnectionPolicy_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_segmentation_security_domain_test.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixSegmentationSecurityDomain_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_site2cloud.go
+++ b/aviatrix/resource_aviatrix_site2cloud.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 var customMappedAttributeNames = []string{

--- a/aviatrix/resource_aviatrix_site2cloud_test.go
+++ b/aviatrix/resource_aviatrix_site2cloud_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixS2C_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_splunk_logging.go
+++ b/aviatrix/resource_aviatrix_splunk_logging.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSplunkLogging() *schema.Resource {

--- a/aviatrix/resource_aviatrix_splunk_logging_test.go
+++ b/aviatrix/resource_aviatrix_splunk_logging_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixSplunkLogging_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSpokeGateway() *schema.Resource {

--- a/aviatrix/resource_aviatrix_spoke_gateway_test.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixSpokeGateway_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSpokeTransitAttachment() *schema.Resource {

--- a/aviatrix/resource_aviatrix_spoke_vpc.go
+++ b/aviatrix/resource_aviatrix_spoke_vpc.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSpokeVpc() *schema.Resource {

--- a/aviatrix/resource_aviatrix_spoke_vpc_test.go
+++ b/aviatrix/resource_aviatrix_spoke_vpc_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preSpokeGatewayCheck(t *testing.T, msgCommon string) string {

--- a/aviatrix/resource_aviatrix_sumologic_forwarder.go
+++ b/aviatrix/resource_aviatrix_sumologic_forwarder.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixSumologicForwarder() *schema.Resource {

--- a/aviatrix/resource_aviatrix_sumologic_forwarder_test.go
+++ b/aviatrix/resource_aviatrix_sumologic_forwarder_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixSumologicForwarder_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_trans_peer.go
+++ b/aviatrix/resource_aviatrix_trans_peer.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixTransPeer() *schema.Resource {

--- a/aviatrix/resource_aviatrix_trans_peer_test.go
+++ b/aviatrix/resource_aviatrix_trans_peer_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preTransPeerCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {

--- a/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixTransitExternalDeviceConn_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_transit_firenet_policy.go
+++ b/aviatrix/resource_aviatrix_transit_firenet_policy.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixTransitFireNetPolicy() *schema.Resource {

--- a/aviatrix/resource_aviatrix_transit_firenet_policy_test.go
+++ b/aviatrix/resource_aviatrix_transit_firenet_policy_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixTransitFireNetPolicy_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 const defaultLearnedCidrApprovalMode = "gateway"

--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixTransitGatewayPeering() *schema.Resource {

--- a/aviatrix/resource_aviatrix_transit_gateway_peering_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preAvxTransitGatewayPeeringCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixTransitGateway_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_transit_vpc.go
+++ b/aviatrix/resource_aviatrix_transit_vpc.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixTransitVpc() *schema.Resource {

--- a/aviatrix/resource_aviatrix_transit_vpc_test.go
+++ b/aviatrix/resource_aviatrix_transit_vpc_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixTransitGw_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_tunnel.go
+++ b/aviatrix/resource_aviatrix_tunnel.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixTunnel() *schema.Resource {

--- a/aviatrix/resource_aviatrix_tunnel_test.go
+++ b/aviatrix/resource_aviatrix_tunnel_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preGateway2Check(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_vgw_conn.go
+++ b/aviatrix/resource_aviatrix_vgw_conn.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixVGWConn() *schema.Resource {

--- a/aviatrix/resource_aviatrix_vgw_conn_test.go
+++ b/aviatrix/resource_aviatrix_vgw_conn_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preVGWConnCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_vpc.go
+++ b/aviatrix/resource_aviatrix_vpc.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixVpc() *schema.Resource {

--- a/aviatrix/resource_aviatrix_vpc_test.go
+++ b/aviatrix/resource_aviatrix_vpc_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixVpc_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_vpn_cert_download.go
+++ b/aviatrix/resource_aviatrix_vpn_cert_download.go
@@ -3,8 +3,8 @@ package aviatrix
 import (
 	"fmt"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixVPNCertDownload() *schema.Resource {

--- a/aviatrix/resource_aviatrix_vpn_cert_download_test.go
+++ b/aviatrix/resource_aviatrix_vpn_cert_download_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func preVPNCertDownloadCheck(t *testing.T, msgCommon string) {

--- a/aviatrix/resource_aviatrix_vpn_profile.go
+++ b/aviatrix/resource_aviatrix_vpn_profile.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixProfile() *schema.Resource {

--- a/aviatrix/resource_aviatrix_vpn_profile_test.go
+++ b/aviatrix/resource_aviatrix_vpn_profile_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixVPNProfile_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_vpn_user.go
+++ b/aviatrix/resource_aviatrix_vpn_user.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixVPNUser() *schema.Resource {

--- a/aviatrix/resource_aviatrix_vpn_user_accelerator.go
+++ b/aviatrix/resource_aviatrix_vpn_user_accelerator.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func resourceAviatrixVPNUserAccelerator() *schema.Resource {

--- a/aviatrix/resource_aviatrix_vpn_user_accelerator_test.go
+++ b/aviatrix/resource_aviatrix_vpn_user_accelerator_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixVPNUserAccelerator_basic(t *testing.T) {

--- a/aviatrix/resource_aviatrix_vpn_user_test.go
+++ b/aviatrix/resource_aviatrix_vpn_user_test.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 func TestAccAviatrixVPNUser_basic(t *testing.T) {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
 )
 
 // validateAzureAZ is a SchemaValidateFunc for Azure Availability Zone

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-aviatrix
+module github.com/AviatrixSystems/terraform-provider-aviatrix/v2
 
 go 1.14
 

--- a/goaviatrix/README.md
+++ b/goaviatrix/README.md
@@ -22,7 +22,7 @@ import (
     "log"
     "crypto/tls"
     "net/http"
-    "github.com/terraform-providers/terraform-provider-aviatrix/goaviatrix"
+    "github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/aviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/terraform-providers/terraform-provider-aviatrix/aviatrix"
 )
 
 func main() {


### PR DESCRIPTION
This solves two issues that inhibit others from using the goaviatrix
SDK pacakge in their own projects:

1) The module name is no longer correct since we moved the repository
under the AviatrixSystems account.

2) The module is at v0/v1 so Go will only pull the latest version
less than v2.0.0, which in our case is v1.16.20

We solve these issues by:

1) Update the module name in go.mod to the correct repository path

2) Append /v2 to the module name and update all import paths