### PR TITLE
20432: Update firenet doc

### DIFF
--- a/docs/resources/aviatrix_firenet.md
+++ b/docs/resources/aviatrix_firenet.md
@@ -10,7 +10,7 @@ description: |-
 
 The **aviatrix_firenet** resource allows the creation and management of [Aviatrix Firewall Networks](https://docs.aviatrix.com/HowTos/firewall_network_faq.html).
 
-~> **NOTE:** This resource is used in conjunction with multiple other resources that may include, and are not limited to: **firewall_instance**, **aws_tgw**, and **transit_gateway** resources or even **aviatrix_fqdn**, under the Aviatrix FireNet solution. Explicit dependencies may be set using `depends_on`. For more information on proper FireNet configuration, please see the workflow [here](https://docs.aviatrix.com/HowTos/firewall_network_workflow.html).
+~> **NOTE:** This resource is used in conjunction with multiple other resources that may include, and are not limited to: **firewall_instance**, **firewall_instance_association**, **aws_tgw**, and **transit_gateway** resources or even **aviatrix_fqdn**, under the Aviatrix FireNet solution. Explicit dependencies may be set using `depends_on`. For more information on proper FireNet configuration, please see the workflow [here](https://docs.aviatrix.com/HowTos/firewall_network_workflow.html).
 
 ## Example Usage
 
@@ -22,6 +22,8 @@ resource "aviatrix_firenet" "test_firenet" {
   egress_enabled                       = false
   keep_alive_via_lan_interface_enabled = false
   manage_firewall_instance_association = false
+  
+  depends_on = [aviatrix_firewall_instance_association.association_1]
 }
 ```
 


### PR DESCRIPTION
Update the firenet documentation to inform users
that an explicit depends_on needs to be set on any
of their firewall_instance_association resources.

Also added an example of the depends_on to the example
since users often copy/paste directly from the example.

Note that I specifically did not include examples of
setting depends on for transit_gateway or firewall_instance
resources because the firewall_instance_association should
cover the dependency on those resources.