### PR TITLE
20462: use transport_vpc_id argument name instead of attachment_name

### DIFF
--- a/aviatrix/resource_aviatrix_aws_tgw_connect.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_connect.go
@@ -32,7 +32,7 @@ func resourceAviatrixAwsTgwConnect() *schema.Resource {
 				ForceNew:    true,
 				Description: "Connection Name.",
 			},
-			"attachment_name": {
+			"transport_vpc_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -62,8 +62,8 @@ func marshalAwsTgwConnectInput(d *schema.ResourceData) *goaviatrix.AwsTgwConnect
 	return &goaviatrix.AwsTgwConnect{
 		TgwName:               d.Get("tgw_name").(string),
 		ConnectionName:        d.Get("connection_name").(string),
-		TransportAttachmentID: d.Get("attachment_name").(string),
-		RouteDomainName:       d.Get("security_domain_name").(string),
+		TransportAttachmentID: d.Get("transport_vpc_id").(string),
+		SecurityDomainName:    d.Get("security_domain_name").(string),
 	}
 }
 
@@ -111,8 +111,8 @@ func resourceAviatrixAwsTgwConnectRead(ctx context.Context, d *schema.ResourceDa
 
 	d.Set("tgw_name", connect.TgwName)
 	d.Set("connection_name", connect.ConnectionName)
-	d.Set("attachment_name", connect.TransportAttachmentName)
-	d.Set("security_domain_name", connect.RouteDomainName)
+	d.Set("transport_vpc_id", connect.TransportAttachmentName)
+	d.Set("security_domain_name", connect.SecurityDomainName)
 	d.Set("connect_attachment_id", connect.ConnectAttachmentID)
 	d.Set("transport_attachment_id", connect.TransportAttachmentID)
 	d.SetId(connect.ID())

--- a/aviatrix/resource_aviatrix_aws_tgw_connect_peer_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_connect_peer_test.go
@@ -108,7 +108,7 @@ resource "aviatrix_aws_tgw_vpc_attachment" "aws_tgw_vpc_attachment" {
 resource "aviatrix_aws_tgw_connect" "test_aws_tgw_connect" {
   tgw_name             = aviatrix_aws_tgw.test_aws_tgw.tgw_name
   connection_name      = "aws-tgw-connect-%[2]s"
-  attachment_name      = aviatrix_aws_tgw_vpc_attachment.aws_tgw_vpc_attachment.vpc_id
+  transport_vpc_id     = aviatrix_aws_tgw_vpc_attachment.aws_tgw_vpc_attachment.vpc_id
   security_domain_name = aviatrix_aws_tgw_vpc_attachment.aws_tgw_vpc_attachment.security_domain_name
 }
 

--- a/aviatrix/resource_aviatrix_aws_tgw_connect_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_connect_test.go
@@ -108,7 +108,7 @@ resource "aviatrix_aws_tgw_vpc_attachment" "aws_tgw_vpc_attachment" {
 resource "aviatrix_aws_tgw_connect" "test_aws_tgw_connect" {
 	tgw_name             = aviatrix_aws_tgw.test_aws_tgw.tgw_name
 	connection_name      = "aws-tgw-connect-%[2]s"
-	attachment_name      = aviatrix_aws_tgw_vpc_attachment.aws_tgw_vpc_attachment.vpc_id
+	transport_vpc_id     = aviatrix_aws_tgw_vpc_attachment.aws_tgw_vpc_attachment.vpc_id
 	security_domain_name = aviatrix_aws_tgw_vpc_attachment.aws_tgw_vpc_attachment.security_domain_name
 }
 `, testAccAccountConfigAWS(acctest.RandInt()), rName, os.Getenv("AWS_REGION"))

--- a/docs/resources/aviatrix_aws_tgw_connect.md
+++ b/docs/resources/aviatrix_aws_tgw_connect.md
@@ -23,7 +23,7 @@ the `aviatrix_aws_tgw` `cidrs` attribute.
 resource "aviatrix_aws_tgw_connect" "test_aws_tgw_connect" {
   tgw_name             = aviatrix_aws_tgw.test_aws_tgw.tgw_name
   connection_name      = "aws-tgw-connect"
-  attachment_name      = aviatrix_aws_tgw_vpc_attachment.test_aws_tgw_vpc_attachment.vpc_id
+  transport_vpc_id     = aviatrix_aws_tgw_vpc_attachment.test_aws_tgw_vpc_attachment.vpc_id
   security_domain_name = aviatrix_aws_tgw_vpc_attachment.test_aws_tgw_vpc_attachment.security_domain_name
 }
 ```
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `tgw_name` - (Required) AWS TGW name.
 * `connection_name` - (Required) Connection name.
-* `attachment_name` - (Required) Transport Attachment VPC ID.
+* `transport_vpc_id` - (Required) Transport Attachment VPC ID.
 * `security_domain_name` - (Required) Security Domain name.
 
 ## Attribute Reference

--- a/goaviatrix/aws_tgw_connect.go
+++ b/goaviatrix/aws_tgw_connect.go
@@ -11,10 +11,10 @@ type AwsTgwConnect struct {
 	CID                     string `form:"CID"`
 	TgwName                 string `form:"tgw_name" json:"tgw_name"`
 	ConnectionName          string `form:"connection_name" json:"connection_name"`
-	TransportAttachmentID   string `form:"transport_attachment_id" json:"transport_attachment_id"`
+	TransportAttachmentID   string `form:"transport_vpc_id" json:"transport_attachment_id"`
 	TransportAttachmentName string `json:"transport_attachment_name"`
 	TransportVpcName        string `json:"transport_vpc_name"`
-	RouteDomainName         string `form:"route_domain_name" json:"route_domain_name"`
+	SecurityDomainName      string `form:"security_domain_name" json:"route_domain_name"`
 	ConnectAttachmentID     string `form:"connect_attachment_id" json:"connect_attachment_id"`
 }
 


### PR DESCRIPTION
Due to naming confusion around the attachment_name
attribute, it will be renamed in TF/UI/API to
transport_vpc_id.