### PR TITLE
20476: Transit Gateway Advanced Config: BGP Hold Time

### DIFF
--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -175,6 +175,7 @@ The following arguments are supported:
 
 * `enable_gateway_load_balancer` - (Optional) Enable FireNet interfaces with AWS Gateway Load Balancer. Only valid when `enable_firenet` or `enable_transit_firenet` are set to true and `cloud_type` = 1 (AWS). Currently, AWS Gateway Load Balancer is only supported in AWS regions: us-west-2, us-east-1, eu-west-1, ap-southeast-2 and sa-east-1. Valid values: true or false. Default value: false. Available as of provider version R2.18+.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: "50".
+* `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `prepend_as_path` - (Optional) List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
 * `local_as_number` - (Optional) Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations.
 * `bgp_ecmp` - (Optional) Enable Equal Cost Multi Path (ECMP) routing for the next hop. Default value: false.

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -67,6 +67,7 @@ type TransitGatewayAdvancedConfig struct {
 	TunnelAddrLocal                   string
 	TunnelAddrLocalBackup             string
 	PeerVnetId                        []string
+	BgpHoldTime                       int
 }
 
 type StandbyConnection struct {
@@ -86,6 +87,7 @@ type TransitGatewayAdvancedConfigRespResult struct {
 	TunnelAddrLocal                   string                    `json:"tunnel_addr_local"`
 	TunnelAddrLocalBackup             string                    `json:"tunnel_addr_local_backup"`
 	PeerVnetId                        []string                  `json:"peer_vnet_id"`
+	BgpHoldTime                       int                       `json:"bgp_hold_time"`
 }
 
 type LearnedCIDRApprovalInfo struct {
@@ -671,6 +673,7 @@ func (c *Client) GetTransitGatewayAdvancedConfig(transitGateway *TransitVpc) (*T
 		TunnelAddrLocal:                   data.Results.TunnelAddrLocal,
 		TunnelAddrLocalBackup:             data.Results.TunnelAddrLocalBackup,
 		PeerVnetId:                        data.Results.PeerVnetId,
+		BgpHoldTime:                       data.Results.BgpHoldTime,
 	}, nil
 }
 
@@ -711,6 +714,16 @@ func (c *Client) EditTransitConnectionBGPManualAdvertiseCIDRs(gwName, connName s
 		"gateway_name":                          gwName,
 		"connection_name":                       connName,
 		"connection_bgp_manual_advertise_cidrs": strings.Join(cidrs, ","),
+	}
+	return c.PostAPI(data["action"], data, BasicCheck)
+}
+
+func (c *Client) ChangeBgpHoldTime(gwName string, holdTime int) error {
+	data := map[string]string{
+		"action":        "change_bgp_hold_time",
+		"gateway_name":  gwName,
+		"bgp_hold_time": strconv.Itoa(holdTime),
+		"CID":           c.CID,
 	}
 	return c.PostAPI(data["action"], data, BasicCheck)
 }


### PR DESCRIPTION
Added Optional Integer attribute on aviatrix_transit_gateway, `bgp_hold_time`, default value: 180, valid range: 12-360

### Unit Test:
Create Transit Gateway with bgp_hold_time set to non-default value
PASS

Update bgp_hold_time
PASS

Delete transit gateway with bgp_hold_time set
PASS

Import Transit Gateway
PASS