### PR TITLE
17261: add support for management access from onprem

### DIFF
--- a/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
@@ -113,7 +113,7 @@ func resourceAviatrixAwsTgwVpcAttachmentCreate(d *schema.ResourceData, meta inte
 		if err == goaviatrix.ErrNotFound {
 			return fmt.Errorf("could not find Security Domain: " + awsTgwVpcAttachment.SecurityDomainName)
 		}
-		return fmt.Errorf(("could not find Security Domain due to: ") + err.Error())
+		return fmt.Errorf("could not find Security Domain due to: %v", err)
 	}
 
 	log.Printf("[INFO] Attaching vpc: %s to tgw %s", awsTgwVpcAttachment.VpcID, awsTgwVpcAttachment.TgwName)
@@ -294,7 +294,7 @@ func resourceAviatrixAwsTgwVpcAttachmentUpdate(d *schema.ResourceData, meta inte
 			if err == goaviatrix.ErrNotFound {
 				return fmt.Errorf("could not find Security Domain: " + awsTgwVpcAttachment.SecurityDomainName)
 			}
-			return fmt.Errorf(("could not find Security Domain due to: ") + err.Error())
+			return fmt.Errorf("could not find Security Domain due to: %v", err)
 		}
 
 		oldEA, newEA := d.GetChange("edge_attachment")

--- a/docs/resources/aviatrix_aws_tgw_vpc_attachment.md
+++ b/docs/resources/aviatrix_aws_tgw_vpc_attachment.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `customized_routes` - (Optional) Advanced option. Customized Spoke VPC Routes. It allows the admin to enter non-RFC1918 routes in the VPC route table targeting the TGW. Example: "10.8.0.0/16,10.9.0.0/16,10.10.0.0/16".
 * `customized_route_advertisement` - (Optional and ForeNew) Advanced option. Customized route(s) to be advertised to other VPCs that are connected to the same TGW. Example: "10.8.0.0/16,10.9.0.0/16,10.10.0.0/16".
 * `disable_local_route_propagation` - (Optional and ForceNew) Advanced option. If set to true, it disables automatic route propagation of this VPC to other VPCs within the same security domain. Valid values: true, false. Default value: false.
-
+* `edge_attachment` - (Optional) Advanced option. To allow access to the private IP of the MGMT interface of the Firewalls, set this attribute to enable Management Access From Onprem. This feature advertises the Firewalls private MGMT subnet to your Edge domain. Example: "vpn-0068bb31917ff2289".
 
 ## Import
 

--- a/goaviatrix/aws_tgw_vpc_attachment.go
+++ b/goaviatrix/aws_tgw_vpc_attachment.go
@@ -173,7 +173,7 @@ func (c *Client) GetAwsTgwVpcAttachment(awsTgwVpcAttachment *AwsTgwVpcAttachment
 
 	firenetManagementDetails, err := c.GetFirenetManagementDetails(awsTgwVpcAttachment)
 	if err != nil {
-		return nil, errors.New("could not get firenet management details: " + err.Error())
+		return nil, fmt.Errorf("could not get firenet management details: %s", err)
 	}
 	if len(firenetManagementDetails) != 0 {
 		aTVA.EdgeAttachment = firenetManagementDetails[1]
@@ -420,9 +420,7 @@ func (c *Client) GetFirenetManagementDetails(awsTgwVpcAttachment *AwsTgwVpcAttac
 	}
 
 	type Resp struct {
-		Return  bool             `json:"return"`
-		Results []AccessFromEdge `json:"results"`
-		Reason  string           `json:"reason"`
+		Results []AccessFromEdge
 	}
 
 	var data Resp

--- a/goaviatrix/aws_tgw_vpc_attachment.go
+++ b/goaviatrix/aws_tgw_vpc_attachment.go
@@ -22,6 +22,7 @@ type AwsTgwVpcAttachment struct {
 	RouteTables                  string
 	CustomizedRouteAdvertisement string
 	DisableLocalRoutePropagation bool `form:"disable_local_route_propagation,omitempty" json:"disable_local_route_propagation,omitempty"`
+	EdgeAttachment               string
 }
 
 type DomainListResp struct {
@@ -168,6 +169,14 @@ func (c *Client) GetAwsTgwVpcAttachment(awsTgwVpcAttachment *AwsTgwVpcAttachment
 		aTVA.Subnets = ""
 		aTVA.RouteTables = ""
 		aTVA.CustomizedRouteAdvertisement = ""
+	}
+
+	firenetManagementDetails, err := c.GetFirenetManagementDetails(awsTgwVpcAttachment)
+	if err != nil {
+		return nil, errors.New("could not get firenet management details: " + err.Error())
+	}
+	if len(firenetManagementDetails) != 0 {
+		aTVA.EdgeAttachment = firenetManagementDetails[1]
 	}
 
 	return aTVA, nil
@@ -380,4 +389,48 @@ func (c *Client) EditTgwSpokeVpcCustomizedRouteAdvertisement(awsTgwVpcAttachment
 		return errors.New("Rest API 'update_customized_route_advertisement' Get failed: " + data.Reason)
 	}
 	return nil
+}
+
+func (c *Client) UpdateFirewallAttachmentAccessFromOnprem(awsTgwVpcAttachment *AwsTgwVpcAttachment) error {
+	params := map[string]string{
+		"action":          "update_firewall_attachment_access_from_onprem",
+		"CID":             c.CID,
+		"tgw_name":        awsTgwVpcAttachment.TgwName,
+		"attachment_name": awsTgwVpcAttachment.VpcID,
+		"edge_attachment": awsTgwVpcAttachment.EdgeAttachment,
+	}
+
+	if awsTgwVpcAttachment.EdgeAttachment == "" {
+		params["edge_attachment"] = "no"
+	}
+
+	return c.PostAPI(params["action"], params, BasicCheck)
+}
+
+func (c *Client) GetFirenetManagementDetails(awsTgwVpcAttachment *AwsTgwVpcAttachment) ([]string, error) {
+	params := map[string]string{
+		"action":          "get_tgw_attachment_details",
+		"CID":             c.CID,
+		"tgw_name":        awsTgwVpcAttachment.TgwName,
+		"attachment_name": awsTgwVpcAttachment.VpcID,
+	}
+
+	type AccessFromEdge struct {
+		AccessFromEdge []string `json:"access_from_edge"`
+	}
+
+	type Resp struct {
+		Return  bool             `json:"return"`
+		Results []AccessFromEdge `json:"results"`
+		Reason  string           `json:"reason"`
+	}
+
+	var data Resp
+
+	err := c.GetAPI(&data, params["action"], params, BasicCheck)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.Results[0].AccessFromEdge, nil
 }


### PR DESCRIPTION
- create vpc attachment with edge_attachment -> remove, import, plan -> no diff
- change edge attachment -> remove, import, plan -> no diff
- delete edge attachment -> remove, import, plan -> no diff
- create vpc attachment without edge_attachment -> remove, import, plan -> no diff
- add edge attachment -> remove, import, plan -> no diff
- destroy
- try a non firenet domain -> error