### PR TITLE
20531: change local_as_number to optional and computed

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -297,6 +297,7 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 			"local_as_number": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				Description:  "Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations.",
 				ValidateFunc: goaviatrix.ValidateASN,
 			},
@@ -1375,11 +1376,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return fmt.Errorf("could not set prepend_as_path: %v", err)
 	}
-	if _, ok := d.GetOk("local_as_number"); ok || isImport {
-		if advancedConfig.LocalASNumber != "" {
-			d.Set("local_as_number", advancedConfig.LocalASNumber)
-		}
-	}
+	d.Set("local_as_number", advancedConfig.LocalASNumber)
 	d.Set("bgp_ecmp", advancedConfig.BgpEcmpEnabled)
 	d.Set("enable_active_standby", advancedConfig.ActiveStandbyEnabled)
 	if gw.CloudType == goaviatrix.AZURE {
@@ -2310,7 +2307,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	if d.HasChange("local_as_number") && d.Get("local_as_number").(string) != "" {
+	if d.HasChange("local_as_number") {
 		localAsNumber := d.Get("local_as_number").(string)
 		gateway := &goaviatrix.TransitVpc{
 			GwName: d.Get("gw_name").(string),


### PR DESCRIPTION
`local_as_number` is now optional and computed

- asn not set in .tf, asn set in controller -> plan -> no diff -> refresh -> asn in state
- asn set in .tf, asn not changed in controller -> plan -> no diff	
- asn set in .tf, asn changed in controller -> plan -> diff