### PR TITLE
20458: Fix issue where gateway creation with customer_managed_keys to enable encrption volume fails

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -340,10 +340,11 @@ func resourceAviatrixGateway() *schema.Resource {
 				Description: "Enable encrypt gateway EBS volume. Only supported for AWS provider. Valid values: true, false. Default value: false.",
 			},
 			"customer_managed_keys": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "Customer managed key ID.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				Description:  "Customer managed key ID.",
 			},
 			"elb_dns_name": {
 				Type:        schema.TypeString,

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -729,8 +729,11 @@ func resourceAviatrixGatewayCreate(d *schema.ResourceData, meta interface{}) err
 	if enableEncryptVolume && d.Get("cloud_type").(int) != goaviatrix.AWS && d.Get("cloud_type").(int) != goaviatrix.AWSGOV {
 		return fmt.Errorf("'enable_encrypt_volume' is only supported for AWS and AWSGOV provider")
 	}
-	if !enableEncryptVolume && customerManagedKeys != "" {
-		return fmt.Errorf("'customer_managed_keys' should be empty since Encrypt Volume is not enabled")
+	if customerManagedKeys != "" {
+		if !enableEncryptVolume {
+			return fmt.Errorf("'customer_managed_keys' should be empty since Encrypt Volume is not enabled")
+		}
+		gateway.EncVolume = "no"
 	}
 	if !enableEncryptVolume && (gateway.CloudType == goaviatrix.AWS || gateway.CloudType == goaviatrix.AWSGOV) {
 		gateway.EncVolume = "no"
@@ -774,6 +777,17 @@ func resourceAviatrixGatewayCreate(d *schema.ResourceData, meta interface{}) err
 
 	flag := false
 	defer resourceAviatrixGatewayReadIfRequired(d, meta, &flag)
+
+	if customerManagedKeys != "" && enableEncryptVolume {
+		gwEncVolume := &goaviatrix.Gateway{
+			GwName:              d.Get("gw_name").(string),
+			CustomerManagedKeys: d.Get("customer_managed_keys").(string),
+		}
+		err := client.EnableEncryptVolume(gwEncVolume)
+		if err != nil {
+			return fmt.Errorf("failed to enable encrypt gateway volume when creating gateway: %s due to %s", gwEncVolume.GwName, err)
+		}
+	}
 
 	enableVpnNat := d.Get("enable_vpn_nat").(bool)
 	if vpnStatus {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -432,8 +432,11 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 	if enableEncryptVolume && d.Get("cloud_type").(int) != goaviatrix.AWS && d.Get("cloud_type").(int) != goaviatrix.AWSGOV {
 		return fmt.Errorf("'enable_encrypt_volume' is only supported for AWS and AWSGOV provider")
 	}
-	if !enableEncryptVolume && customerManagedKeys != "" {
-		return fmt.Errorf("'customer_managed_keys' should be empty since Encrypt Volume is not enabled")
+	if customerManagedKeys != "" {
+		if !enableEncryptVolume {
+			return fmt.Errorf("'customer_managed_keys' should be empty since Encrypt Volume is not enabled")
+		}
+		gateway.EncVolume = "no"
 	}
 	if !enableEncryptVolume && (gateway.CloudType == goaviatrix.AWS || gateway.CloudType == goaviatrix.AWSGOV) {
 		gateway.EncVolume = "no"
@@ -519,6 +522,17 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 
 	flag := false
 	defer resourceAviatrixSpokeGatewayReadIfRequired(d, meta, &flag)
+
+	if customerManagedKeys != "" && enableEncryptVolume {
+		gwEncVolume := &goaviatrix.Gateway{
+			GwName:              d.Get("gw_name").(string),
+			CustomerManagedKeys: d.Get("customer_managed_keys").(string),
+		}
+		err := client.EnableEncryptVolume(gwEncVolume)
+		if err != nil {
+			return fmt.Errorf("failed to enable encrypt gateway volume when creating spoke gateway: %s due to %s", gwEncVolume.GwName, err)
+		}
+	}
 
 	if enableActiveMesh := d.Get("enable_active_mesh").(bool); !enableActiveMesh {
 		gw := &goaviatrix.Gateway{


### PR DESCRIPTION
Solution: 
If "enable_encrypt_volume = true" and "customer_managed_keys" is given (non-empty, validation fails for empty string):
  - Create the gateway/spoke/transit without enabling encrypt volume;
  - Enable encrypt volume with given customer_managed_keys after above gateway is created in create function. 