### PR TITLE
20703: Fix issue where the order of the cidrs for local_tunnel_cidr and other three attributes should matter

### DIFF
--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -109,7 +109,7 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				ForceNew:         true,
-				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceInString,
+				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceOnlyInString,
 				Description:      "Source CIDR for the tunnel from the Aviatrix transit gateway.",
 			},
 			"remote_tunnel_cidr": {
@@ -117,7 +117,7 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				ForceNew:         true,
-				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceInString,
+				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceOnlyInString,
 				Description:      "Destination CIDR for the tunnel to the external device.",
 			},
 			"custom_algorithms": {
@@ -220,7 +220,7 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				ForceNew:         true,
-				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceInString,
+				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceOnlyInString,
 				Description:      "Source CIDR for the tunnel from the backup Aviatrix transit gateway.",
 			},
 			"backup_remote_tunnel_cidr": {
@@ -228,7 +228,7 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				ForceNew:         true,
-				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceInString,
+				DiffSuppressFunc: DiffSuppressFuncIgnoreSpaceOnlyInString,
 				Description:      "Destination CIDR for the tunnel to the backup external device.",
 			},
 			"backup_direct_connect": {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -61,29 +61,25 @@ func DiffSuppressFuncIgnoreSpaceInString(k, old, new string, d *schema.ResourceD
 }
 
 func DiffSuppressFuncIgnoreSpaceOnlyInString(k, old, new string, d *schema.ResourceData) bool {
-	var oldValue []string
-	var newValue []string
-
 	oldValueList := strings.Split(old, ",")
 	newValueList := strings.Split(new, ",")
-
-	if len(oldValue) != len(newValue) {
+	if len(oldValueList) != len(newValueList) {
 		return false
 	}
 
+	var oldValue []string
+	var newValue []string
 	for i := range oldValueList {
 		oldValue = append(oldValue, strings.TrimSpace(oldValueList[i]))
 	}
 	for i := range newValueList {
 		newValue = append(newValue, strings.TrimSpace(newValueList[i]))
 	}
-
 	for i := range oldValueList {
 		if oldValue[i] != newValue[i] {
 			return false
 		}
 	}
-
 	return true
 }
 

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -65,17 +65,17 @@ func DiffSuppressFuncIgnoreSpaceOnlyInString(k, old, new string, d *schema.Resou
 	var newValue []string
 
 	oldValueList := strings.Split(old, ",")
-	for i := range oldValueList {
-		oldValue = append(oldValue, strings.TrimSpace(oldValueList[i]))
-	}
-
 	newValueList := strings.Split(new, ",")
-	for i := range newValueList {
-		newValue = append(newValue, strings.TrimSpace(newValueList[i]))
-	}
 
 	if len(oldValue) != len(newValue) {
 		return false
+	}
+
+	for i := range oldValueList {
+		oldValue = append(oldValue, strings.TrimSpace(oldValueList[i]))
+	}
+	for i := range newValueList {
+		newValue = append(newValue, strings.TrimSpace(newValueList[i]))
 	}
 
 	for i := range oldValueList {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -60,6 +60,33 @@ func DiffSuppressFuncIgnoreSpaceInString(k, old, new string, d *schema.ResourceD
 	return goaviatrix.Equivalent(oldValue, newValue)
 }
 
+func DiffSuppressFuncIgnoreSpaceOnlyInString(k, old, new string, d *schema.ResourceData) bool {
+	var oldValue []string
+	var newValue []string
+
+	oldValueList := strings.Split(old, ",")
+	for i := range oldValueList {
+		oldValue = append(oldValue, strings.TrimSpace(oldValueList[i]))
+	}
+
+	newValueList := strings.Split(new, ",")
+	for i := range newValueList {
+		newValue = append(newValue, strings.TrimSpace(newValueList[i]))
+	}
+
+	if len(oldValue) != len(newValue) {
+		return false
+	}
+
+	for i := range oldValueList {
+		if oldValue[i] != newValue[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 func setConfigValueIfEquivalent(d *schema.ResourceData, k string, fromConfig, fromAPI []string) error {
 	if goaviatrix.Equivalent(fromConfig, fromAPI) {
 		return d.Set(k, fromConfig)

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -67,16 +67,8 @@ func DiffSuppressFuncIgnoreSpaceOnlyInString(k, old, new string, d *schema.Resou
 		return false
 	}
 
-	var oldValue []string
-	var newValue []string
 	for i := range oldValueList {
-		oldValue = append(oldValue, strings.TrimSpace(oldValueList[i]))
-	}
-	for i := range newValueList {
-		newValue = append(newValue, strings.TrimSpace(newValueList[i]))
-	}
-	for i := range oldValueList {
-		if oldValue[i] != newValue[i] {
+		if strings.TrimSpace(oldValueList[i]) != strings.TrimSpace(newValueList[i]) {
 			return false
 		}
 	}


### PR DESCRIPTION
Solution: for following four attributes, only ignore white spaces in their value. If there are two cidrs for any of them, the sequence of the two cidrs will matter.
  - local_tunnel_cidr
  - remote_tunnel_cidr
  - backup_local_tunnel_cidr
  - backup_remote_tunnel_cidr
  