### PR TITLE
Fix gateway Read nil pointer crash

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1088,7 +1088,7 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("couldn't find Aviatrix Gateway: %s", gw.GwName)
+		return fmt.Errorf("couldn't find Aviatrix Gateway: %s", gwName)
 	}
 
 	log.Printf("[TRACE] reading gateway %s: %#v", d.Get("gw_name").(string), gw)


### PR DESCRIPTION
```
	return fmt.Errorf("couldn't find Aviatrix Gateway: %s", gw.GwName)
```
If we hit this line, then `gw` is definitely a nil pointer. Instead, we will use a local gateway name variable.