### PR TITLE
Update cisco-csr module to use unique names

### DIFF
--- a/test-infra/cisco-csr/00-vpc.tf
+++ b/test-infra/cisco-csr/00-vpc.tf
@@ -26,7 +26,7 @@ resource aws_subnet csr_vpc_subnet_1 {
   map_public_ip_on_launch = true
 
   tags = {
-    Name    = "csr-vpc-subnet-1"
+    Name    = "csr-vpc-subnet-${random_integer.csr_vpc_int[0].result}"
     Purpose = "Terraform Acceptance"
   }
 }
@@ -37,14 +37,14 @@ resource aws_network_interface csr_aws_netw_interface_1 {
     aws_security_group.csr_sec_group.id]
 
   tags = {
-    Name    = "csr-aws-netw-interface-1"
+    Name    = "csr-aws-netw-interface-${random_integer.csr_vpc_int[0].result}"
     Purpose = "Terraform Acceptance"
   }
 }
 
 resource aws_eip csr_eip_1 {
   tags = {
-    Name    = "csr-eip-1"
+    Name    = "csr-eip-${random_integer.csr_vpc_int[0].result}"
     Purpose = "Terraform Acceptance"
   }
 

--- a/test-infra/cisco-csr/01-network.tf
+++ b/test-infra/cisco-csr/01-network.tf
@@ -1,7 +1,7 @@
 resource aws_internet_gateway csr_vpc_igw {
   vpc_id = aws_vpc.csr_vpc.id
   tags   = {
-    Name    = "csr-igw"
+    Name    = "csr-igw-${random_integer.csr_vpc_int[0].result}"
     Purpose = "Terraform Regression"
   }
 }
@@ -14,7 +14,7 @@ resource aws_route_table csr_vpc_rtb {
     gateway_id = aws_internet_gateway.csr_vpc_igw.id
   }
   tags = {
-    Name    = "csr-vpc-rtb"
+    Name    = "csr-vpc-rtb-${random_integer.csr_vpc_int[0].result}"
     Purpose = "Terraform Regression"
   }
 }
@@ -25,12 +25,12 @@ resource aws_route_table_association csr_vpc_subnet_rtb_1 {
 }
 
 resource aws_security_group csr_sec_group {
-  name        = "csr-sec-group"
+  name        = "csr-sec-group-${random_integer.csr_vpc_int[0].result}"
   description = "Aviatrix - Controller Security Group"
   vpc_id      = aws_vpc.csr_vpc.id
 
   tags = {
-    Name    = "csr-aws-sec-group"
+    Name    = "csr-aws-sec-group-${random_integer.csr_vpc_int[0].result}"
     Purpose = "Terraform Acceptance"
   }
 }

--- a/test-infra/cisco-csr/02-csr.tf
+++ b/test-infra/cisco-csr/02-csr.tf
@@ -17,12 +17,12 @@ resource "tls_private_key" "key_pair_material" {
 }
 
 resource "aws_key_pair" "csr_key_pair" {
-  key_name = "csr-kp"
+  key_name = "csr-kp-${random_integer.csr_vpc_int[0].result}"
   public_key = tls_private_key.key_pair_material.public_key_openssh
 }
 
 locals {
-  key_file_path = "/tmp/csr-kp.pem"
+  key_file_path = "/tmp/csr-kp-${random_integer.csr_vpc_int[0].result}.pem"
 }
 
 resource "null_resource" "key_pair_file" {
@@ -43,7 +43,7 @@ resource aws_instance csr_instance_1 {
   }
 
   tags = {
-    Name    = "csr-instance-1"
+    Name    = "csr-instance-1-${random_integer.csr_vpc_int[0].result}"
     Purpose = "Terraform Acceptance"
   }
 }


### PR DESCRIPTION
Without unique names for the key file then
you cannot bring up the cisco-csr module more
than once on a single machine.