### PR TITLE
20375: Site2Cloud event triggered HA

### DIFF
--- a/docs/resources/aviatrix_device_transit_gateway_attachment.md
+++ b/docs/resources/aviatrix_device_transit_gateway_attachment.md
@@ -51,6 +51,13 @@ The following arguments are supported:
 * `remote_tunnel_ip` - Remote tunnel IP.
 * `enable_learned_cidrs_approval` - (Optional) Enable learned CIDRs approval for the connection. Requires the transit_gateway's 'learned_cidrs_approval_mode' attribute be set to 'connection'. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
 * `manual_bgp_advertised_cidrs` - (Optional) Configure manual BGP advertised CIDRs for this connection. Available as of provider version R2.18+.
+* `enable_event_triggered_ha` - (Optional) Enable Event Triggered HA. Default value: false. Valid values: true or false. Available as of provider version R2.19+.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `vpc_id` - VPC ID.
 
 
 ## Import

--- a/docs/resources/aviatrix_site2cloud.md
+++ b/docs/resources/aviatrix_site2cloud.md
@@ -109,6 +109,7 @@ The following arguments are supported:
 * `enable_active_active` - (Optional) Enable/disable active active HA for an existing site2cloud connection. Valid values: true, false. Default value: false.
 * `enable_ikev2` - (Optional) Switch to enable IKEv2. Valid values: true, false. Default value: false.
 * `forward_traffic_to_transit` - (Optional) Enable spoke gateway with mapped site2cloud configurations to forward traffic from site2cloud connection to Aviatrix Transit Gateway. Default value: false. Valid values: true or false. Available in provider version 2.17.2+.
+* `enable_event_triggered_ha` - (Optional) Enable Event Triggered HA. Default value: false. Valid values: true or false. Available as of provider version R2.19+.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_transit_external_device_conn.md
+++ b/docs/resources/aviatrix_transit_external_device_conn.md
@@ -118,6 +118,7 @@ The following arguments are supported:
 * `enable_learned_cidrs_approval` - (Optional) Enable learned CIDRs approval for the connection. Only valid with 'connection_type' = 'bgp'. Requires the transit_gateway's 'learned_cidrs_approval_mode' attribute be set to 'connection'. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
 * `enable_ikev2` - (Optional) Set as true to enable IKEv2 protocol.
 * `manual_bgp_advertised_cidrs` - (Optional) Configure manual BGP advertised CIDRs for this connection. Only valid with 'connection_type'= 'bgp'. Available as of provider version R2.18+.
+* `enable_event_triggered_ha` - (Optional) Enable Event Triggered HA. Default value: false. Valid values: true or false. Available as of provider version R2.19+.
 
 ## Import
 

--- a/docs/resources/aviatrix_vgw_conn.md
+++ b/docs/resources/aviatrix_vgw_conn.md
@@ -41,6 +41,7 @@ The following arguments are supported:
 ### Optional
 * `enable_learned_cidrs_approval` - (Optional) Enable learned CIDRs approval for the connection. Requires the transit_gateway's 'learned_cidrs_approval_mode' attribute be set to 'connection'. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
 * `manual_bgp_advertised_cidrs` - (Optional) Configure manual BGP advertised CIDRs for this connection. Available as of provider version R2.18+.
+* `enable_event_triggered_ha` - (Optional) Enable Event Triggered HA. Default value: false. Valid values: true or false. Available as of provider version R2.19+.
 
 The following arguments are deprecated:
 

--- a/goaviatrix/device_transit_gateway_attachment.go
+++ b/goaviatrix/device_transit_gateway_attachment.go
@@ -26,6 +26,8 @@ type DeviceTransitGatewayAttachment struct {
 	PreSharedKey            string `form:"pre_shared_key,omitempty"`
 	LocalTunnelIP           string `form:"local_tunnel_ip,omitempty"`
 	RemoteTunnelIP          string `form:"remote_tunnel_ip,omitempty"`
+	VpcID                   string
+	EventTriggeredHA        bool
 	ManualBGPCidrs          []string
 	Action                  string `form:"action"`
 	CID                     string `form:"CID"`
@@ -121,6 +123,8 @@ func (c *Client) GetDeviceTransitGatewayAttachment(attachment *DeviceTransitGate
 		LocalTunnelIP:           data.Results.Connections.BgpLocalIP,
 		RemoteTunnelIP:          data.Results.Connections.BgpRemoteIP,
 		ManualBGPCidrs:          data.Results.Connections.ManualBGPCidrs,
+		EventTriggeredHA:        data.Results.Connections.EventTriggeredHA == "enabled",
+		VpcID:                   vpcID,
 	}, nil
 }
 

--- a/goaviatrix/site2cloud.go
+++ b/goaviatrix/site2cloud.go
@@ -63,6 +63,7 @@ type Site2Cloud struct {
 	DeadPeerDetection             bool
 	EnableActiveActive            bool
 	ForwardToTransit              bool
+	EventTriggeredHA              bool
 	CustomMap                     bool   `form:"custom_map,omitempty"`
 	RemoteSourceRealCIDRs         string `form:"remote_src_real_cidrs,omitempty"`
 	RemoteSourceVirtualCIDRs      string `form:"remote_src_virt_cidrs,omitempty"`
@@ -143,6 +144,7 @@ type EditSite2CloudConnDetail struct {
 	LocalDestinationRealCIDRs     string        `json:"local_dst_real_cidrs"`
 	LocalDestinationVirtualCIDRs  string        `json:"local_dst_virt_cidrs"`
 	ManualBGPCidrs                []string      `json:"conn_bgp_manual_advertise_cidrs"`
+	EventTriggeredHA              string        `json:"event_triggered_ha"`
 }
 
 type Site2CloudConnDetailResp struct {
@@ -409,6 +411,7 @@ func (c *Client) GetSite2CloudConnDetail(site2cloud *Site2Cloud) (*Site2Cloud, e
 		if s2cConnDetail.EnableIKEv2 == "2" {
 			site2cloud.EnableIKEv2 = "true"
 		}
+		site2cloud.EventTriggeredHA = s2cConnDetail.EventTriggeredHA == "enabled"
 		site2cloud.RemoteSourceRealCIDRs = s2cConnDetail.RemoteSourceRealCIDRs
 		site2cloud.RemoteSourceVirtualCIDRs = s2cConnDetail.RemoteSourceVirtualCIDRs
 		site2cloud.RemoteDestinationRealCIDRs = s2cConnDetail.RemoteDestinationRealCIDRs
@@ -618,6 +621,26 @@ func (c *Client) DisableSpokeMappedSite2CloudForwarding(site2cloud *Site2Cloud) 
 		"action":          "disable_spoke_mapped_site2cloud_forwarding",
 		"vpc_id":          site2cloud.VpcID,
 		"connection_name": site2cloud.TunnelName,
+	}
+	return c.PostAPI(data["action"], data, BasicCheck)
+}
+
+func (c *Client) EnableSite2CloudEventTriggeredHA(vpcID, connectionName string) error {
+	data := map[string]string{
+		"CID":             c.CID,
+		"action":          "enable_site2cloud_event_triggered_ha",
+		"vpc_id":          vpcID,
+		"connection_name": connectionName,
+	}
+	return c.PostAPI(data["action"], data, BasicCheck)
+}
+
+func (c *Client) DisableSite2CloudEventTriggeredHA(vpcID, connectionName string) error {
+	data := map[string]string{
+		"CID":             c.CID,
+		"action":          "disable_site2cloud_event_triggered_ha",
+		"vpc_id":          vpcID,
+		"connection_name": connectionName,
 	}
 	return c.PostAPI(data["action"], data, BasicCheck)
 }

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -47,6 +47,7 @@ type ExternalDeviceConn struct {
 	LocalLanIP             string `form:"local_lan_ip,omitempty"`
 	BackupRemoteLanIP      string `form:"backup_remote_lan_ip,omitempty"`
 	BackupLocalLanIP       string `form:"backup_local_lan_ip,omitempty"`
+	EventTriggeredHA       bool
 }
 
 type EditExternalDeviceConnDetail struct {
@@ -80,6 +81,7 @@ type EditExternalDeviceConnDetail struct {
 	LocalLanIP             string `json:"local_lan_ip"`
 	BackupRemoteLanIP      string `json:"backup_remote_lan_ip"`
 	BackupLocalLanIP       string `json:"backup_local_lan_ip"`
+	EventTriggeredHA       string `json:"event_triggered_ha"`
 }
 
 type ExternalDeviceConnDetailResp struct {
@@ -267,6 +269,7 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 		} else {
 			externalDeviceConn.EnableIkev2 = "disabled"
 		}
+		externalDeviceConn.EventTriggeredHA = externalDeviceConnDetail.EventTriggeredHA == "enabled"
 		externalDeviceConn.PeerVnetId = externalDeviceConnDetail.PeerVnetId
 		externalDeviceConn.RemoteLanIP = externalDeviceConnDetail.RemoteLanIP
 		externalDeviceConn.LocalLanIP = externalDeviceConnDetail.LocalLanIP

--- a/goaviatrix/vgw_connection.go
+++ b/goaviatrix/vgw_connection.go
@@ -10,16 +10,17 @@ import (
 
 // VGWConn simple struct to hold VGW Connection details
 type VGWConn struct {
-	Action         string `form:"action,omitempty"`
-	BgpLocalAsNum  string `form:"bgp_local_asn_num,omitempty" json:"bgp_local_asn_num,omitempty"`
-	BgpVGWId       string `form:"vgw_id,omitempty" json:"bgp_vgw_id,omitempty"`
-	BgpVGWAccount  string `form:"bgp_vgw_account_name,omitempty" json:"bgp_vgw_account,omitempty"`
-	BgpVGWRegion   string `form:"bgp_vgw_region,omitempty" json:"bgp_vgw_region,omitempty"`
-	CID            string `form:"CID,omitempty"`
-	ConnName       string `form:"connection_name,omitempty" json:"name,omitempty"`
-	GwName         string `form:"gw_name,omitempty" json:"gw_name,omitempty"`
-	VPCId          string `form:"vpc_id,omitempty" json:"vpc_id,omitempty"`
-	ManualBGPCidrs []string
+	Action           string `form:"action,omitempty"`
+	BgpLocalAsNum    string `form:"bgp_local_asn_num,omitempty" json:"bgp_local_asn_num,omitempty"`
+	BgpVGWId         string `form:"vgw_id,omitempty" json:"bgp_vgw_id,omitempty"`
+	BgpVGWAccount    string `form:"bgp_vgw_account_name,omitempty" json:"bgp_vgw_account,omitempty"`
+	BgpVGWRegion     string `form:"bgp_vgw_region,omitempty" json:"bgp_vgw_region,omitempty"`
+	CID              string `form:"CID,omitempty"`
+	ConnName         string `form:"connection_name,omitempty" json:"name,omitempty"`
+	GwName           string `form:"gw_name,omitempty" json:"gw_name,omitempty"`
+	VPCId            string `form:"vpc_id,omitempty" json:"vpc_id,omitempty"`
+	ManualBGPCidrs   []string
+	EventTriggeredHA bool
 }
 
 type VGWConnListResp struct {
@@ -45,14 +46,15 @@ type VGWConnDetail struct {
 }
 
 type ConnectionDetail struct {
-	ConnName       []string `json:"name"`
-	GwName         string   `json:"gw_name"`
-	VPCId          []string `json:"vpc_id"`
-	BgpVGWId       string   `json:"bgp_vgw_id"`
-	BgpVGWAccount  string   `json:"bgp_vgw_account"`
-	BgpVGWRegion   string   `json:"bgp_vgw_region"`
-	BgpLocalAsNum  string   `json:"bgp_local_asn_number"`
-	ManualBGPCidrs []string `json:"conn_bgp_manual_advertise_cidrs"`
+	ConnName         []string `json:"name"`
+	GwName           string   `json:"gw_name"`
+	VPCId            []string `json:"vpc_id"`
+	BgpVGWId         string   `json:"bgp_vgw_id"`
+	BgpVGWAccount    string   `json:"bgp_vgw_account"`
+	BgpVGWRegion     string   `json:"bgp_vgw_region"`
+	BgpLocalAsNum    string   `json:"bgp_local_asn_number"`
+	ManualBGPCidrs   []string `json:"conn_bgp_manual_advertise_cidrs"`
+	EventTriggeredHA string   `json:"event_triggered_ha"`
 }
 
 type VGWConnEnableAdvertiseTransitCidrResp struct {
@@ -195,6 +197,7 @@ func (c *Client) GetVGWConnDetail(vgwConn *VGWConn) (*VGWConn, error) {
 		vgwConn.BgpVGWRegion = data.Results.Connections.BgpVGWRegion
 		vgwConn.BgpLocalAsNum = data.Results.Connections.BgpLocalAsNum
 		vgwConn.ManualBGPCidrs = data.Results.Connections.ManualBGPCidrs
+		vgwConn.EventTriggeredHA = data.Results.Connections.EventTriggeredHA == "enabled"
 		return vgwConn, nil
 	}
 	return nil, ErrNotFound


### PR DESCRIPTION
Add Event Triggered HA option to all site2cloud/IPSec
based connections.

Updated these resources:
- site2cloud
- transit_external_device_conn
- vgw_conn
- device_transit_gateway_attachment

Later I need to also add to
- device_virtual_wan_attachment (currently not working on 6.4)
- cloudn_transit_gateway_attachment (not implemented yet)