### PR TITLE
21150: Fix issue where terraform apply to reorder security domains inside aviatrix_aws_tgw does do something sometimes

### DIFF
--- a/aviatrix/resource_aviatrix_aws_tgw.go
+++ b/aviatrix/resource_aviatrix_aws_tgw.go
@@ -1171,11 +1171,11 @@ func resourceAviatrixAWSTgwUpdate(d *schema.ResourceData, meta interface{}) erro
 			domainsToCreate = goaviatrix.Difference(domainsToCreateNew, domainsToCreateOld)
 			domainsToRemove = goaviatrix.Difference(domainsToCreateOld, domainsToCreateNew)
 
-			domainConnPolicy = goaviatrix.DifferenceSlice(domainConnPolicyNew, domainConnPolicyOld)
-			domainConnRemove = goaviatrix.DifferenceSlice(domainConnPolicyOld, domainConnPolicyNew)
+			domainConnPolicy = goaviatrix.DifferencePairSlice(domainConnPolicyNew, domainConnPolicyOld)
+			domainConnRemove = goaviatrix.DifferencePairSlice(domainConnPolicyOld, domainConnPolicyNew)
 
-			domainConnPolicy1 := goaviatrix.DifferenceSlice(domainConnRemoveOld, domainConnRemoveNew)
-			domainConnRemove1 := goaviatrix.DifferenceSlice(domainConnRemoveNew, domainConnRemoveOld)
+			domainConnPolicy1 := goaviatrix.DifferencePairSlice(domainConnRemoveOld, domainConnRemoveNew)
+			domainConnRemove1 := goaviatrix.DifferencePairSlice(domainConnRemoveNew, domainConnRemoveOld)
 
 			toAttachVPCs = goaviatrix.DifferenceSliceAttachedVPC(attachedVPCNew, attachedVPCOld)
 			toDetachVPCs = goaviatrix.DifferenceSliceAttachedVPC(attachedVPCOld, attachedVPCNew)
@@ -1625,11 +1625,11 @@ func resourceAviatrixAWSTgwUpdate(d *schema.ResourceData, meta interface{}) erro
 				domainsToCreate = goaviatrix.Difference(domainsToCreateNew, domainsToCreateOld)
 				domainsToRemove = goaviatrix.Difference(domainsToCreateOld, domainsToCreateNew)
 
-				domainConnPolicy = goaviatrix.DifferenceSlice(domainConnPolicyNew, domainConnPolicyOld)
-				domainConnRemove = goaviatrix.DifferenceSlice(domainConnPolicyOld, domainConnPolicyNew)
+				domainConnPolicy = goaviatrix.DifferencePairSlice(domainConnPolicyNew, domainConnPolicyOld)
+				domainConnRemove = goaviatrix.DifferencePairSlice(domainConnPolicyOld, domainConnPolicyNew)
 
-				domainConnPolicy1 := goaviatrix.DifferenceSlice(domainConnRemoveOld, domainConnRemoveNew)
-				domainConnRemove1 := goaviatrix.DifferenceSlice(domainConnRemoveNew, domainConnRemoveOld)
+				domainConnPolicy1 := goaviatrix.DifferencePairSlice(domainConnRemoveOld, domainConnRemoveNew)
+				domainConnRemove1 := goaviatrix.DifferencePairSlice(domainConnRemoveNew, domainConnRemoveOld)
 
 				toAttachVPCs = goaviatrix.DifferenceSliceAttachedVPC(attachedVPCNew, attachedVPCOld)
 				toDetachVPCs = goaviatrix.DifferenceSliceAttachedVPC(attachedVPCOld, attachedVPCNew)

--- a/goaviatrix/utils.go
+++ b/goaviatrix/utils.go
@@ -51,35 +51,26 @@ func DifferenceSlice(a, b [][]string) [][]string {
 		return a
 	}
 
-	aa := make([]string, 0)
-	for i := range a {
-		temp := ""
-		for j := range a[i] {
-			temp += a[i][j]
-		}
-		aa = append(aa, temp)
-	}
-
-	bb := make([]string, 0)
-	for t := range b {
-		temp := ""
-		for m := range b[t] {
-			temp += b[t][m]
-		}
-		bb = append(bb, temp)
-	}
-
 	mb := map[string]bool{}
-	for x := range bb {
-		mb[bb[x]] = true
+	for i := range b {
+		if len(b[i]) != 2 {
+			return a
+		}
+		mb[b[i][0]+b[i][1]] = true
+		mb[b[i][1]+b[i][0]] = true
 	}
-	ab := make([][]string, 0)
-	for x := range aa {
-		if _, ok := mb[aa[x]]; !ok {
-			ab = append(ab, a[x])
+
+	result := make([][]string, 0)
+	for i := range a {
+		if len(a[i]) != 2 {
+			return a
+		}
+		if _, ok := mb[a[i][0]+a[i][1]]; !ok {
+			result = append(result, a[i])
 		}
 	}
-	return ab
+
+	return result
 }
 
 // DifferenceSliceAttachedVPC returns the one-dimension elements in two-dimension slice a that aren't in two-dimension b.

--- a/goaviatrix/utils.go
+++ b/goaviatrix/utils.go
@@ -45,8 +45,8 @@ func Equivalent(a, b []string) bool {
 	return len(Difference(a, b)) == 0 && len(Difference(b, a)) == 0
 }
 
-// DifferenceSlice returns the one-dimension elements in two-dimension slice a that aren't in two-dimension b
-func DifferenceSlice(a, b [][]string) [][]string {
+// DifferencePairs returns all pairs in a that are not in b. If b contains any elements that are non-pairs (len != 2) then a is returned
+func DifferencePairSlice(a, b [][]string) [][]string {
 	if len(a) == 0 || len(b) == 0 {
 		return a
 	}


### PR DESCRIPTION
DifferenceSlice is used to find the difference between two list of connection policy pairs.
"connection policy" for aviatrix_aws_tgw is symmetric meaning if a is connected to b, b is also connected to a.
Example: a is [[domain1, domain2][domain3, domain4]], and b is [[domain1, domain2][domain4, domain3]]. There is no diff between a and b because domain1 and domain2, domain3 and domain4 are connected for both a and b.