### PR TITLE
21183: Max_hop_limit: single configuration for rfc1918 and non-rfc1918 cidr

### DIFF
--- a/aviatrix/resource_aviatrix_controller_bgp_max_as_limit_config.go
+++ b/aviatrix/resource_aviatrix_controller_bgp_max_as_limit_config.go
@@ -23,15 +23,9 @@ func resourceAviatrixControllerBgpMaxAsLimitConfig() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"max_as_limit": {
 				Type:         schema.TypeInt,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validation.IntBetween(1, 254),
-				Description:  "The maximum AS path limit allowed by transit gateways when handling BGP/Peering route propagation for RFC 1918 CIDRs.",
-			},
-			"max_as_limit_non_rfc1918": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(1, 254),
-				Description:  "The maximum AS path limit allowed by transit gateways when handling BGP/Peering route propagation for non-RFC 1918 CIDRs.",
+				Description:  "The maximum AS path limit allowed by transit gateways when handling BGP/Peering route propagation.",
 			},
 		},
 	}
@@ -40,25 +34,10 @@ func resourceAviatrixControllerBgpMaxAsLimitConfig() *schema.Resource {
 func resourceAviatrixControllerBgpMaxAsLimitConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*goaviatrix.Client)
 
-	maxAsLimit, maxAsLimitOk := d.GetOk("max_as_limit")
-	maxAsLimitNonRfc1918, maxAsLimitNonRfc1918Ok := d.GetOk("max_as_limit_non_rfc1918")
-
-	if !maxAsLimitOk && !maxAsLimitNonRfc1918Ok {
-		return diag.Errorf("error creating controller BGP max AS limit config: at least one of max_as_limit and max_as_limit_non_rfc1918 must be provided")
-	}
-
-	if maxAsLimitOk {
-		err := client.SetControllerBgpMaxAsLimit(ctx, maxAsLimit.(int))
-		if err != nil {
-			return diag.Errorf("failed to create controller BGP max AS limit config for RGC 1918 CIDRs: %v", err)
-		}
-	}
-
-	if maxAsLimitNonRfc1918Ok {
-		err := client.SetControllerBgpMaxAsLimitNonRfc1918(ctx, maxAsLimitNonRfc1918.(int))
-		if err != nil {
-			return diag.Errorf("failed to create controller BGP max AS limit config for non-RFC 1918 CIDRs: %v", err)
-		}
+	maxAsLimit := d.Get("max_as_limit").(int)
+	err := client.SetControllerBgpMaxAsLimit(ctx, maxAsLimit)
+	if err != nil {
+		return diag.Errorf("failed to create controller BGP max AS limit config: %v", err)
 	}
 
 	d.SetId(strings.Replace(client.ControllerIP, ".", "-", -1))
@@ -72,7 +51,7 @@ func resourceAviatrixControllerBgpMaxAsLimitConfigRead(ctx context.Context, d *s
 		return diag.Errorf("ID: %s does not match controller IP. Please provide correct ID for importing", d.Id())
 	}
 
-	maxAsLimit, maxAsLimitNonRfc1918, err := client.GetControllerBgpMaxAsLimit(ctx)
+	maxAsLimit, err := client.GetControllerBgpMaxAsLimit(ctx)
 	if err != nil {
 		if err == goaviatrix.ErrNotFound {
 			d.SetId("")
@@ -82,7 +61,6 @@ func resourceAviatrixControllerBgpMaxAsLimitConfigRead(ctx context.Context, d *s
 	}
 
 	d.Set("max_as_limit", maxAsLimit)
-	d.Set("max_as_limit_non_rfc1918", maxAsLimitNonRfc1918)
 	d.SetId(strings.Replace(client.ControllerIP, ".", "-", -1))
 	return nil
 }
@@ -90,38 +68,11 @@ func resourceAviatrixControllerBgpMaxAsLimitConfigRead(ctx context.Context, d *s
 func resourceAviatrixControllerBgpMaxAsLimitConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*goaviatrix.Client)
 
-	maxAsLimit, maxAsLimitOk := d.GetOk("max_as_limit")
-	maxAsLimitNonRfc1918, maxAsLimitNonRfc1918Ok := d.GetOk("max_as_limit_non_rfc1918")
-
-	if !maxAsLimitOk && !maxAsLimitNonRfc1918Ok {
-		return diag.Errorf("error updating controller BGP max AS limit config: at least one of max_as_limit and max_as_limit_non_rfc1918 must be provided")
-	}
-
 	if d.HasChange("max_as_limit") {
-		if maxAsLimitOk {
-			err := client.SetControllerBgpMaxAsLimit(ctx, maxAsLimit.(int))
-			if err != nil {
-				return diag.Errorf("failed to update BGP max AS limit for RFC 1918 CIDRs: %v", err)
-			}
-		} else {
-			err := client.DisableControllerBgpMaxAsLimit(ctx)
-			if err != nil {
-				return diag.Errorf("failed to disable BGP max AS limit for RFC 1918 CIDRs: %v", err)
-			}
-		}
-	}
-
-	if d.HasChange("max_as_limit_non_rfc1918") {
-		if maxAsLimitNonRfc1918Ok {
-			err := client.SetControllerBgpMaxAsLimitNonRfc1918(ctx, maxAsLimitNonRfc1918.(int))
-			if err != nil {
-				return diag.Errorf("failed to update BGP max AS limit for non-RFC 1918 CIDRs: %v", err)
-			}
-		} else {
-			err := client.DisableControllerBgpMaxAsLimitNonRfc1918(ctx)
-			if err != nil {
-				return diag.Errorf("failed to disable BGP max AS limit for non-RFC 1918 CDIRs: %v", err)
-			}
+		maxAsLimit := d.Get("max_as_limit").(int)
+		err := client.SetControllerBgpMaxAsLimit(ctx, maxAsLimit)
+		if err != nil {
+			return diag.Errorf("failed to update controller BGP max AS limit config: %v", err)
 		}
 	}
 
@@ -134,11 +85,6 @@ func resourceAviatrixControllerBgpMaxAsLimitConfigDelete(ctx context.Context, d 
 	err := client.DisableControllerBgpMaxAsLimit(ctx)
 	if err != nil {
 		return diag.Errorf("failed to delete controller BGP max AS limit config: %v", err)
-	}
-
-	err = client.DisableControllerBgpMaxAsLimitNonRfc1918(ctx)
-	if err != nil {
-		return diag.Errorf("failed to delete controller BGP max AS limit config for non-RFC 1918 CIDRs: %v", err)
 	}
 
 	return nil

--- a/aviatrix/resource_aviatrix_controller_bgp_max_as_limit_config.go
+++ b/aviatrix/resource_aviatrix_controller_bgp_max_as_limit_config.go
@@ -57,7 +57,7 @@ func resourceAviatrixControllerBgpMaxAsLimitConfigRead(ctx context.Context, d *s
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("failed to get controller BGP max AS limit config: %v", err)
+		return diag.Errorf("could not get controller BGP max AS limit config: %v", err)
 	}
 
 	d.Set("max_as_limit", maxAsLimit)

--- a/aviatrix/resource_aviatrix_controller_bgp_max_as_limit_config_test.go
+++ b/aviatrix/resource_aviatrix_controller_bgp_max_as_limit_config_test.go
@@ -31,7 +31,6 @@ func TestAccAviatrixControllerBgpMaxAsLimitConfig_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckControllerBgpMaxAsLimitConfigExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "max_as_limit", "1"),
-					resource.TestCheckResourceAttr(resourceName, "max_as_limit_non_rfc1918", "2"),
 				),
 			},
 			{
@@ -46,8 +45,7 @@ func TestAccAviatrixControllerBgpMaxAsLimitConfig_basic(t *testing.T) {
 func testAccControllerBgpMaxAsLimitConfigBasic() string {
 	return `
 resource "aviatrix_controller_bgp_max_as_limit_config" "test_bgp_max_as_limit" {
-  max_as_limit                = 1
-  max_as_limit_non_rfc1918    = 2
+	max_as_limit = 1
 }
 `
 }
@@ -64,7 +62,7 @@ func testAccCheckControllerBgpMaxAsLimitConfigExists(n string) resource.TestChec
 
 		client := testAccProviderVersionValidation.Meta().(*goaviatrix.Client)
 
-		_, _, err := client.GetControllerBgpMaxAsLimit(context.Background())
+		_, err := client.GetControllerBgpMaxAsLimit(context.Background())
 		if err != nil {
 			return fmt.Errorf("failed to get controller bgp max as limit config status: %v", err)
 		}
@@ -85,7 +83,7 @@ func testAccCheckControllerBgpMaxAsLimitConfigDestroy(s *terraform.State) error 
 			continue
 		}
 
-		_, _, err := client.GetControllerBgpMaxAsLimit(context.Background())
+		_, err := client.GetControllerBgpMaxAsLimit(context.Background())
 		if err == nil || err != goaviatrix.ErrNotFound {
 			return fmt.Errorf("controller bgp max as limit configured when it should be destroyed")
 		}

--- a/docs/resources/aviatrix_controller_bgp_max_as_limit_config.md
+++ b/docs/resources/aviatrix_controller_bgp_max_as_limit_config.md
@@ -15,8 +15,7 @@ The **aviatrix_controller_bgp_max_as_limit_config** resource allows management o
 ```hcl
 # Create an Aviatrix Controller BGP max AS limit config
 resource "aviatrix_controller_bgp_max_as_limit_config" "test_max_as_limit" {
-  max_as_limit                = 1
-  max_as_limit_non_rfc1918    = 2
+  max_as_limit = 1
 }
 ```
 
@@ -25,8 +24,7 @@ resource "aviatrix_controller_bgp_max_as_limit_config" "test_max_as_limit" {
 
 The following arguments are supported:
 
-* `max_as_limit` - (Optional) The maximum AS path limit allowed by transit gateways when handling BGP/Peering route propagation with RFC1918 CIDRs. Must be a number in the range [1-254].
-* `max_as_limit_non_rfc1918` - (Optional) The maximum AS path limit allowed by transit gateways when handling BGP/Peering route propagation with non-RFC1918 CIDRs. Must be a number in the range [1-254].
+* `max_as_limit` - The maximum AS path limit allowed by transit gateways when handling BGP/Peering route propagation. Must be a number in the range [1-254].
 
 ## Import
 

--- a/goaviatrix/controller_bgp_max_as_limit_config.go
+++ b/goaviatrix/controller_bgp_max_as_limit_config.go
@@ -45,8 +45,12 @@ func (c *Client) GetControllerBgpMaxAsLimit(ctx context.Context) (int, error) {
 		"CID":    c.CID,
 	}
 
+	type BgpMaxAsLimitResults struct {
+		BgpMaxAsLimit string `json:"bgp_max_as_limit"`
+	}
+
 	type BgpMaxAsLimitResponse struct {
-		Results string
+		Results BgpMaxAsLimitResults
 	}
 
 	var resp BgpMaxAsLimitResponse
@@ -54,11 +58,11 @@ func (c *Client) GetControllerBgpMaxAsLimit(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if resp.Results == "" {
+	if resp.Results.BgpMaxAsLimit == "" {
 		return 0, ErrNotFound
 	}
 
-	maxAsLimit, err := strconv.Atoi(resp.Results)
+	maxAsLimit, err := strconv.Atoi(resp.Results.BgpMaxAsLimit)
 	if err != nil {
 		return 0, fmt.Errorf("error converting max_as_limit to int: %v", err)
 	}

--- a/goaviatrix/controller_bgp_max_as_limit_config.go
+++ b/goaviatrix/controller_bgp_max_as_limit_config.go
@@ -23,22 +23,6 @@ func (c *Client) SetControllerBgpMaxAsLimit(ctx context.Context, maxAsLimit int)
 	return c.PostAPIContext(ctx, data["action"], data, checkFunc)
 }
 
-func (c *Client) SetControllerBgpMaxAsLimitNonRfc1918(ctx context.Context, maxAsLimitNonRfc1918 int) error {
-	data := map[string]string{
-		"action":       "set_bgp_max_as_limit_non_rfc1918",
-		"CID":          c.CID,
-		"max_as_limit": fmt.Sprint(maxAsLimitNonRfc1918),
-	}
-
-	checkFunc := func(action, reason string, ret bool) error {
-		if !ret && !strings.Contains(reason, "Configured BGP maximum AS limit is not changed") {
-			return fmt.Errorf("rest API %s Post failed: %s", action, reason)
-		}
-		return nil
-	}
-	return c.PostAPIContext(ctx, data["action"], data, checkFunc)
-}
-
 func (c *Client) DisableControllerBgpMaxAsLimit(ctx context.Context) error {
 	data := map[string]string{
 		"action":       "set_bgp_max_as_limit",
@@ -55,61 +39,31 @@ func (c *Client) DisableControllerBgpMaxAsLimit(ctx context.Context) error {
 	return c.PostAPIContext(ctx, data["action"], data, checkFunc)
 }
 
-func (c *Client) DisableControllerBgpMaxAsLimitNonRfc1918(ctx context.Context) error {
-	data := map[string]string{
-		"action":       "set_bgp_max_as_limit_non_rfc1918",
-		"CID":          c.CID,
-		"max_as_limit": "",
-	}
-
-	checkFunc := func(action, reason string, ret bool) error {
-		if !ret && !strings.Contains(reason, "Configured BGP maximum AS limit is not changed") {
-			return fmt.Errorf("rest API %s Post failed: %s", action, reason)
-		}
-		return nil
-	}
-	return c.PostAPIContext(ctx, data["action"], data, checkFunc)
-}
-
-func (c *Client) GetControllerBgpMaxAsLimit(ctx context.Context) (int, int, error) {
+func (c *Client) GetControllerBgpMaxAsLimit(ctx context.Context) (int, error) {
 	data := map[string]string{
 		"action": "show_bgp_max_as_limit",
 		"CID":    c.CID,
 	}
 
-	type BgpMaxAsLimitResults struct {
-		MaxAsLimit           string `json:"bgp_max_as_limit_rfc1918"`
-		MaxAsLimitNonRfc1918 string `json:"bgp_max_as_limit_non_rfc1918"`
-	}
-
 	type BgpMaxAsLimitResponse struct {
-		Results BgpMaxAsLimitResults
+		Results string
 	}
 
 	var resp BgpMaxAsLimitResponse
 	err := c.GetAPIContext(ctx, &resp, data["action"], data, BasicCheck)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
+	}
+	if resp.Results == "" {
+		return 0, ErrNotFound
 	}
 
-	if resp.Results.MaxAsLimit == "" && resp.Results.MaxAsLimitNonRfc1918 == "" {
-		return 0, 0, ErrNotFound
+	maxAsLimit, err := strconv.Atoi(resp.Results)
+	if err != nil {
+		return 0, fmt.Errorf("error converting max_as_limit to int: %v", err)
 	}
-
-	var maxAsLimit, maxAsLimitNonRfc1918 int
-	if resp.Results.MaxAsLimit != "" {
-		maxAsLimit, err = strconv.Atoi(resp.Results.MaxAsLimit)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error converting max_as_limit to int: %v", err)
-		}
+	if maxAsLimit < 1 || maxAsLimit > 254 {
+		return 0, fmt.Errorf("rest API show_bgp_max_as_limit returned invalid value for max_as_limit: %d. It must be an integer in the range of [1-254]", maxAsLimit)
 	}
-
-	if resp.Results.MaxAsLimitNonRfc1918 != "" {
-		maxAsLimitNonRfc1918, err = strconv.Atoi(resp.Results.MaxAsLimitNonRfc1918)
-		if err != nil {
-			return 0, 0, fmt.Errorf("error converting max_as_limit_non_rfc1918 to int: %v", err)
-		}
-	}
-
-	return maxAsLimit, maxAsLimitNonRfc1918, nil
+	return maxAsLimit, nil
 }


### PR DESCRIPTION
Revert previous change that added separate configurations for rfc1918 and non-rfc1918 cidrs