### PR TITLE
20979: transit_gateway_peering insane mode over internet

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-const defaultTransitPeeringPublicTunnels = 4
-
 func resourceAviatrixTransitGatewayPeering() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAviatrixTransitGatewayPeeringCreate,

--- a/docs/resources/aviatrix_transit_gateway_peering.md
+++ b/docs/resources/aviatrix_transit_gateway_peering.md
@@ -29,7 +29,8 @@ resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering" {
     "333",
     "444"
   ]
-  enable_peering_over_private_network = false
+  enable_peering_over_private_network         = false
+  enable_insane_mode_encryption_over_internet = false
 }
 ```
 
@@ -50,6 +51,8 @@ The following arguments are supported:
 * `prepend_as_path2` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name2. Available in provider version R2.17.2+.
 * `enable_peering_over_private_network` - (Optional) Enable peering over private network. ActiveMesh and Insane Mode is required on both transit gateways. Available in provider version R2.17.1+.
 * `enable_single_tunnel_mode` - (Optional) Enable peering with Single Tunnel mode. False by default. Available as of provider version R2.18+.
+* `enable_insane_mode_encryption_over_internet` - (Optional) Enable Insane Mode Encryption over Internet. Type: Boolean. Default: false. Required with `tunnel_count`. Conflicts with `enable_peering_over_private_network` and `enable_single_tunnel_mode`. Available as of provider version R2.19+.
+* `tunnel_count` - (Optional) Number of public tunnels. Type: Integer. Valid Range: 2-20. Required with `enable_insane_mode_encryption_over_internet`. Conflicts with `enable_peering_over_private_network` and `enable_single_tunnel_mode`. Available as of provider version R2.19+.
   
 ~> **NOTE:** `enable_single_tunnel_mode` is only valid when `enable_peering_over_private_network` is set to `true`. Private Transit Gateway Peering with Single-Tunnel Mode expands the existing Insane Mode Transit Gateway Peering Over Private Network to apply it to single IPSec tunnel. One use case is for low speed encryption between cloud networks.
 

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -18,6 +18,8 @@ type TransitGatewayPeering struct {
 	Gateway1ExcludedTGWConnections      string `form:"source_exclude_connections,omitempty"`
 	Gateway2ExcludedTGWConnections      string `form:"destination_exclude_connections,omitempty"`
 	PrivateIPPeering                    bool   `form:"private_ip_peering,omitempty"`
+	InsaneModeOverInternet              bool   `form:"insane_mode_over_internet,omitempty"`
+	TunnelCount                         int    `form:"tunnel_count,omitempty"`
 	Gateway1ExcludedCIDRsSlice          []string
 	Gateway2ExcludedCIDRsSlice          []string
 	Gateway1ExcludedTGWConnectionsSlice []string
@@ -42,10 +44,12 @@ type TransitGatewayPeeringDetailsAPIResp struct {
 }
 
 type TransitGatewayPeeringDetailsResults struct {
-	Site1                 TransitGatewayPeeringDetail `json:"site_1"`
-	Site2                 TransitGatewayPeeringDetail `json:"site_2"`
-	PrivateNetworkPeering bool                        `json:"private_network_peering"`
-	Tunnels               []TunnelsDetail             `json:"tunnels"`
+	Site1                  TransitGatewayPeeringDetail `json:"site_1"`
+	Site2                  TransitGatewayPeeringDetail `json:"site_2"`
+	PrivateNetworkPeering  bool                        `json:"private_network_peering"`
+	Tunnels                []TunnelsDetail             `json:"tunnels"`
+	InsaneModeOverInternet bool                        `json:"insane_mode_over_internet"`
+	TunnelCount            int                         `json:"tunnel_count"`
 }
 
 type TransitGatewayPeeringDetail struct {
@@ -135,6 +139,8 @@ func (c *Client) GetTransitGatewayPeeringDetails(transitGatewayPeering *TransitG
 	transitGatewayPeering.Gateway2ExcludedCIDRsSlice = data.Results.Site2.ExcludedCIDRs
 	transitGatewayPeering.Gateway2ExcludedTGWConnectionsSlice = data.Results.Site2.ExcludedTGWConnections
 	transitGatewayPeering.PrivateIPPeering = data.Results.PrivateNetworkPeering
+	transitGatewayPeering.InsaneModeOverInternet = data.Results.InsaneModeOverInternet
+	transitGatewayPeering.TunnelCount = data.Results.TunnelCount
 	transitGatewayPeering.PrependAsPath1 = data.Results.Site1.ConnBGPPrependAsPath
 	transitGatewayPeering.PrependAsPath2 = data.Results.Site2.ConnBGPPrependAsPath
 


### PR DESCRIPTION
Add two attributes to support insane mode peering over
internet:
- enable_insane_mode_encryption_over_internet
- tunnel_count