### PR TITLE
21531: firewall_instance suppress user_data diff

### DIFF
--- a/aviatrix/resource_aviatrix_firewall_instance.go
+++ b/aviatrix/resource_aviatrix_firewall_instance.go
@@ -186,6 +186,9 @@ func resourceAviatrixFirewallInstance() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Description: "Advanced option. Bootstrap storage name. Applicable to Check Point Series and Fortinet Series deployment only.",
+				DiffSuppressFunc: func(k, o, n string, d *schema.ResourceData) bool {
+					return strings.TrimSpace(o) == strings.TrimSpace(n)
+				},
 			},
 			"instance_id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
The backend is trimming trailing whitespace
from the user_data field. So, we should
suppress the diff.