### PR TITLE
21779: Give warning when aviatrix account fails audit in read

### DIFF
--- a/aviatrix/resource_aviatrix_account.go
+++ b/aviatrix/resource_aviatrix_account.go
@@ -3,10 +3,10 @@ package aviatrix
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/docs/resources/aviatrix_account.md
+++ b/docs/resources/aviatrix_account.md
@@ -150,6 +150,9 @@ The following arguments are supported:
 * `alicloud_access_key` - (Optional) Alibaba Cloud Access Key. Required when creating an account for Alibaba Cloud.
 * `alicloud_secret_key` - (Optional) Alibaba Cloud Secret Key. Required when creating an account for Alibaba Cloud.
 
+### Misc.
+* `audit_account` - (Optional) Specify whether to enable the audit account feature. If this feature is enabled, terraform will give a warning if there is an issue with the account credentials. Valid values: true, false. Default: true. **Note: The warning may still appear for a few hours after fixing the underlying issue.**
+
 -> **NOTE:** Please make sure that the IAM roles/profiles have already been created before running this, if `aws_iam = true`. More information on the IAM roles is at https://docs.aviatrix.com/HowTos/iam_policies.html and https://docs.aviatrix.com/HowTos/HowTo_IAM_role.html
 
 ## Import


### PR DESCRIPTION
Changed CRUD functions in aviatrix account to include context so that a warning can be given on audit failure. I only use the context in the new API call.