### PR TITLE
21782: Fix transit peering bgp as path prepend

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -66,22 +66,24 @@ func resourceAviatrixTransitGatewayPeering() *schema.Resource {
 				},
 			},
 			"prepend_as_path1": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name1.",
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: goaviatrix.ValidateASN,
 				},
+				MaxItems: 25,
 			},
 			"prepend_as_path2": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name2.",
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: goaviatrix.ValidateASN,
 				},
+				MaxItems: 25,
 			},
 			"enable_peering_over_private_network": {
 				Type:        schema.TypeBool,
@@ -181,7 +183,7 @@ func resourceAviatrixTransitGatewayPeeringCreate(d *schema.ResourceData, meta in
 
 	if _, ok := d.GetOk("prepend_as_path1"); ok {
 		var prependASPath []string
-		for _, v := range d.Get("prepend_as_path1").(*schema.Set).List() {
+		for _, v := range d.Get("prepend_as_path1").([]interface{}) {
 			prependASPath = append(prependASPath, v.(string))
 		}
 		transGwPeering := &goaviatrix.TransitGatewayPeering{
@@ -197,7 +199,7 @@ func resourceAviatrixTransitGatewayPeeringCreate(d *schema.ResourceData, meta in
 
 	if _, ok := d.GetOk("prepend_as_path2"); ok {
 		var prependASPath []string
-		for _, v := range d.Get("prepend_as_path2").(*schema.Set).List() {
+		for _, v := range d.Get("prepend_as_path2").([]interface{}) {
 			prependASPath = append(prependASPath, v.(string))
 		}
 		transGwPeering := &goaviatrix.TransitGatewayPeering{
@@ -350,7 +352,7 @@ func resourceAviatrixTransitGatewayPeeringUpdate(d *schema.ResourceData, meta in
 
 	if d.HasChange("prepend_as_path1") {
 		var prependASPath []string
-		for _, v := range d.Get("prepend_as_path1").(*schema.Set).List() {
+		for _, v := range d.Get("prepend_as_path1").([]interface{}) {
 			prependASPath = append(prependASPath, v.(string))
 		}
 
@@ -363,7 +365,7 @@ func resourceAviatrixTransitGatewayPeeringUpdate(d *schema.ResourceData, meta in
 
 	if d.HasChange("prepend_as_path2") {
 		var prependASPath []string
-		for _, v := range d.Get("prepend_as_path2").(*schema.Set).List() {
+		for _, v := range d.Get("prepend_as_path2").([]interface{}) {
 			prependASPath = append(prependASPath, v.(string))
 		}
 		transitGwPeering := &goaviatrix.TransitGatewayPeering{

--- a/docs/resources/aviatrix_transit_gateway_peering.md
+++ b/docs/resources/aviatrix_transit_gateway_peering.md
@@ -22,12 +22,12 @@ resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering" {
   gateway1_excluded_tgw_connections   = ["vpn_connection_a"]
   gateway2_excluded_tgw_connections   = ["vpn_connection_b"]
   prepend_as_path1                    = [
-    "111",
-    "222"
+    "65001",
+    "65001",
+    "65001"
   ]
   prepend_as_path2                    = [
-    "333",
-    "444"
+    "65002"
   ]
   enable_peering_over_private_network         = false
   enable_insane_mode_encryption_over_internet = false
@@ -47,8 +47,8 @@ The following arguments are supported:
 * `gateway2_excluded_network_cidrs` - (Optional) List of excluded network CIDRs for the second transit gateway.
 * `gateway1_excluded_tgw_connections` - (Optional) List of excluded TGW connections for the first transit gateway.
 * `gateway2_excluded_tgw_connections` - (Optional) List of excluded TGW connections for the second transit gateway.
-* `prepend_as_path1` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name1. Available in provider version R2.17.2+.
-* `prepend_as_path2` - (Optional) AS Path Prepend customized by specifying AS PATH for a BGP connection. Applies on transit_gateway_name2. Available in provider version R2.17.2+.
+* `prepend_as_path1` - (Optional) AS Path Prepend for BGP connection. Can only use the transit's own local AS number, repeated up to 25 times. Applies on transit_gateway_name1. Available in provider version R2.17.2+.
+* `prepend_as_path2` - (Optional) AS Path Prepend for BGP connection. Can only use the transit's own local AS number, repeated up to 25 times. Applies on transit_gateway_name2. Available in provider version R2.17.2+.
 * `enable_peering_over_private_network` - (Optional) Enable peering over private network. ActiveMesh and Insane Mode is required on both transit gateways. Available in provider version R2.17.1+.
 * `enable_single_tunnel_mode` - (Optional) Enable peering with Single Tunnel mode. False by default. Available as of provider version R2.18+.
 * `enable_insane_mode_encryption_over_internet` - (Optional) Enable Insane Mode Encryption over Internet. Type: Boolean. Default: false. Required with `tunnel_count`. Conflicts with `enable_peering_over_private_network` and `enable_single_tunnel_mode`. Available as of provider version R2.19+.


### PR DESCRIPTION
Prepend AS Path allows for customization of routing priority by injecting a prepend to the AS Path, which makes the AS Path longer thus deprioritizing it compared to shorter paths. You are supposed to be able to inject your own AS number in the prepend up to 25 times, so we need to use TypeList instead of TypeSet to allow for duplicates.