### PR TITLE
21805: don't update fqdn domain_names if not managed inline

### DIFF
--- a/aviatrix/resource_aviatrix_fqdn.go
+++ b/aviatrix/resource_aviatrix_fqdn.go
@@ -192,7 +192,7 @@ func resourceAviatrixFQDNCreate(d *schema.ResourceData, meta interface{}) error 
 	if fqdnStatus := d.Get("fqdn_enabled").(bool); fqdnStatus {
 		fqdn.FQDNStatus = "enabled"
 
-		log.Printf("[INOF] Enable FQDN tag status: %#v", fqdn)
+		log.Printf("[INFO] Enable FQDN tag status: %#v", fqdn)
 
 		err := client.UpdateFQDNStatus(fqdn)
 		if err != nil {
@@ -279,7 +279,7 @@ func resourceAviatrixFQDNRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("couldn't list FQDN domains: %s", err)
 	}
-	log.Printf("[INOF] Enable FQDN tag status: %#v", newfqdn)
+	log.Printf("[INFO] Enable FQDN tag status: %#v", newfqdn)
 
 	if newfqdn != nil {
 		// This is nothing IF ListDomains return empty
@@ -293,7 +293,7 @@ func resourceAviatrixFQDNRead(d *schema.ResourceData, meta interface{}) error {
 			filter = append(filter, dn)
 		}
 
-		log.Printf("[INOF] 3Enable FQDN tag status: %#v", fqdn)
+		log.Printf("[INFO] Enable FQDN tag status: %#v", fqdn)
 
 		// Only write domain names to state if the user has enabled in-line domain names.
 		if d.Get("manage_domain_names").(bool) {
@@ -408,7 +408,7 @@ func resourceAviatrixFQDNUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 	// Update Domain list
-	if d.HasChange("domain_names") {
+	if d.HasChange("domain_names") && enabledInlineDomainNames {
 		if hasSetDomainNames {
 			names := d.Get("domain_names").([]interface{})
 			for _, domain := range names {


### PR DESCRIPTION
Resolves: #909 

After importing a resource that uses a manage_* attribute, the user will have to perform another apply step if they set the manage_* attribute to false. Let's look at an example terraform configuration:

```hcl
# main.tf
resource "aviatrix_fqdn" "test_fqdn" {
  fqdn_tag            = "my_tag"
  fqdn_enabled        = true
  fqdn_mode           = "white"
  manage_domain_names = false
}

resource "aviatrix_fqdn_tag_rule" "test" {
  fqdn_tag_name = aviatrix_fqdn.test_fqdn.fqdn_tag
  for_each      = var.domain_names
  fqdn          = each.value["fqdn"]
  protocol      = each.value["proto"]
  port          = each.value["port"]
}

# variables.tf
variable "domain_names" {
  type = map(object({
    fqdn  = string
    proto = string
    port  = string
  }))
}

# terraform.auto.tfvars
domain_names = {
  "google" = {
    fqdn  = "*.google.com"
    proto = "tcp"
    port  = "80"
  },
  "golang" = {
    fqdn  = "golang.org"
    proto = "tcp"
    port  = "443"
  },
  "nano-reef" = {
    fqdn  = "nano-reef.com"
    proto = "tcp"
    port  = "334"
  }
}
```
In this case, the user want to manage `aviatrix_fqdn` `domain_names` in standalone resources, not inline the `aviatrix_fqdn` resource. So the user sets the attribute `manage_domain_names` to `false` and defines their tag rules in `aviatrix_fqdn_tag_rule` resources. When the user imports the `aviatrix_fqdn` resource, it is successful but running `terraform plan` does not produce an empty plan.
```
aviatrix_fqdn.test_fqdn: Refreshing state... [id=my_tag]
aviatrix_fqdn_tag_rule.test["google"]: Refreshing state... [id=my_tag~*.google.com~tcp~80~Base Policy]
aviatrix_fqdn_tag_rule.test["golang"]: Refreshing state... [id=my_tag~golang.org~tcp~443~Base Policy]
aviatrix_fqdn_tag_rule.test["nano-reef"]: Refreshing state... [id=my_tag~nano-reef.com~tcp~334~Base Policy]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aviatrix_fqdn.test_fqdn will be updated in-place
  ~ resource "aviatrix_fqdn" "test_fqdn" {
        id                  = "my_tag"
      ~ manage_domain_names = true -> false
        # (3 unchanged attributes hidden)

      - domain_names {
          - action = "Base Policy" -> null
          - fqdn   = "nano-reef.com" -> null
          - port   = "334" -> null
          - proto  = "tcp" -> null
        }
      - domain_names {
          - action = "Base Policy" -> null
          - fqdn   = "*.google.com" -> null
          - port   = "80" -> null
          - proto  = "tcp" -> null
        }
      - domain_names {
          - action = "Base Policy" -> null
          - fqdn   = "golang.org" -> null
          - port   = "443" -> null
          - proto  = "tcp" -> null
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```

This happens because during a `terraform import` the provider cannot know what value the user set for `manage_domain_names`, so we always assume it's the default value: true. Since we assume true, we also read in the inline `domain_names` resources. When we run `terraform plan` Terraform will notice the diff between statefile and user configuration, and want to update. This update is supposed to be safe to run and not modify real infrastructure instead it should just rectify the statefile. However, in the case of `aviatrix_fqdn` there is a bug causing the update to actually modify real infrastructure. This PR fixes the bug, making the update safe to run.
