### PR TITLE
0022016: Fix issue where vpn_protocol for VPN Gateway not being set into state after create for Azure

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1219,7 +1219,11 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 			d.Set("max_vpn_conn", gw.MaxConn)
 			d.Set("enable_vpn_nat", gw.EnableVpnNat)
 			if gw.ElbState == "enabled" {
-				d.Set("vpn_protocol", strings.ToUpper(gw.VpnProtocol))
+				if strings.ToUpper(gw.VpnProtocol) == "UDP" {
+					d.Set("vpn_protocol", "UDP")
+				} else {
+					d.Set("vpn_protocol", "TCP")
+				}
 			} else {
 				d.Set("vpn_protocol", "UDP")
 			}


### PR DESCRIPTION
Change setting logic of "vpn_protocol" back to 6.3/2.18.0 release.