### PR TITLE
fix20592: check default domains when changing manage_security_domain from false to true

### DIFF
--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -110,6 +110,15 @@ func intInSlice(needle int, haystack []int) bool {
 	return false
 }
 
+func stringInSlice(needle string, haystack []string) bool {
+	for _, element := range haystack {
+		if element == needle {
+			return true
+		}
+	}
+	return false
+}
+
 var (
 	awsTagMatcher   = regexp.MustCompile(`^[a-zA-Z0-9+\-=._ :/@ ]*$`)
 	azureTagMatcher = regexp.MustCompile(`^[a-zA-Z0-9+\-=._ :@ ]*$`)


### PR DESCRIPTION
Problem:
For example, a TGW was created with manage_security_domain set to false, and not all default domains were created. 
If change manage_security_domain to true, it will crash.

Solution:
in update()
1. when dealing with existing domains in DB, add default domains to avoid crash
2. add a check for default domains, error out if one or more default domains are missing
3. if default domains were not created, create default domains first 