### PR TITLE
22125: added phase1_remote_identifier in s2c

### DIFF
--- a/docs/resources/aviatrix_site2cloud.md
+++ b/docs/resources/aviatrix_site2cloud.md
@@ -115,6 +115,7 @@ The following arguments are supported:
 * `enable_ikev2` - (Optional) Switch to enable IKEv2. Valid values: true, false. Default value: false.
 * `forward_traffic_to_transit` - (Optional) Enable spoke gateway with mapped site2cloud configurations to forward traffic from site2cloud connection to Aviatrix Transit Gateway. Default value: false. Valid values: true or false. Available in provider version 2.17.2+.
 * `enable_event_triggered_ha` - (Optional) Enable Event Triggered HA. Default value: false. Valid values: true or false. Available as of provider version R2.19+.
+* `phase1_remote_identifier` - (Optional) Phase 1 remote identifier of the IPsec tunnel. This can be configured to be either the public IP address or the private IP address of the peer terminating the IPsec tunnel. Available as of provider version R2.19+.
 
 ## Attribute Reference
 

--- a/goaviatrix/site2cloud.go
+++ b/goaviatrix/site2cloud.go
@@ -78,6 +78,7 @@ type Site2Cloud struct {
 	BackupLocalTunnelIp           string `form:"backup_local_tunnel_ip,omitempty"`
 	BackupRemoteTunnelIp          string `form:"backup_remote_tunnel_ip,omitempty"`
 	EnableSingleIpHA              bool
+	Phase1RemoteIdentifier        string
 }
 
 type EditSite2Cloud struct {
@@ -96,6 +97,7 @@ type EditSite2Cloud struct {
 	LocalSourceVirtualCIDRs       string `form:"local_src_virt_cidrs,omitempty"`
 	LocalDestinationRealCIDRs     string `form:"local_dst_real_cidrs,omitempty"`
 	LocalDestinationVirtualCIDRs  string `form:"local_dst_virt_cidrs,omitempty"`
+	Phase1RemoteIdentifier        string `form:"phase1_remote_identifier,omitempty"`
 }
 
 type Site2CloudResp struct {
@@ -151,6 +153,7 @@ type EditSite2CloudConnDetail struct {
 	ManualBGPCidrs                []string      `json:"conn_bgp_manual_advertise_cidrs"`
 	EventTriggeredHA              string        `json:"event_triggered_ha"`
 	EnableSingleIpHA              string        `json:"single_ip_ha,omitempty"`
+	Phase1RemoteIdentifier        []string      `json:"phase1_remote_id"`
 }
 
 type Site2CloudConnDetailResp struct {
@@ -441,6 +444,10 @@ func (c *Client) GetSite2CloudConnDetail(site2cloud *Site2Cloud) (*Site2Cloud, e
 			site2cloud.BackupRemoteTunnelIp = s2cConnDetail.BgpBackupRemoteIP
 		}
 		site2cloud.EnableSingleIpHA = s2cConnDetail.EnableSingleIpHA == "enabled"
+		if len(s2cConnDetail.Phase1RemoteIdentifier) == 0 {
+			return nil, errors.New("could not get phase 1 remote identifier")
+		}
+		site2cloud.Phase1RemoteIdentifier = s2cConnDetail.Phase1RemoteIdentifier[0]
 		return site2cloud, nil
 	}
 


### PR DESCRIPTION
use remote_gateway_ip = 1.2.3.4

1.
Create s2c without using phase1_remote_identifier
Change phase1_remote_identifier to 1.2.3.4 -> no diff
Change phase1_remote_identifier to 3.3.3.3 -> diff -> set to 3.3.3.3 after apply

2.
Create s2c with phase1_remote_identifier = 1.2.3.4
Delete phase1_remote_identifier -> no diff
Change phase1_remote_identifier to 1.2.3.4 -> no diff
Change phase1_remote_identifier to 3.3.3.3 -> diff -> set to 3.3.3.3 after apply

3.
Create s2c with phase1_remote_identifier = 3.3.3.3
Delete phase1_remote_identifier -> diff -> set to 1.2.3.4 after apply

Destroy 