### PR TITLE
21011: Allow 'aviatrix' host_os in device_registration

### DIFF
--- a/aviatrix/resource_aviatrix_device_registration.go
+++ b/aviatrix/resource_aviatrix_device_registration.go
@@ -59,8 +59,8 @@ func resourceAviatrixDeviceRegistration() *schema.Resource {
 				Optional:     true,
 				Default:      "ios",
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ios"}, false),
-				Description:  "Device host OS. Default value is 'ios'. Only valid value is 'ios'.",
+				ValidateFunc: validation.StringInSlice([]string{"ios", "aviatrix"}, false),
+				Description:  "Device host OS. Default value is 'ios'. Valid values are 'ios' or 'aviatrix'.",
 			},
 			"ssh_port": {
 				Type:        schema.TypeInt,

--- a/docs/resources/aviatrix_device_registration.md
+++ b/docs/resources/aviatrix_device_registration.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `password` - (Optional) Password for SSH into the router. Either `key_file` or `password` must be set to register a device successfully. This attribute can also be set via environment variable 'AVIATRIX_DEVICE_PASSWORD'. If both are set, the value in the config file will be used.
 
 ### Optional
-* `host_os` - (Optional) Device host OS.  Default value is 'ios'. Only valid value is 'ios'.
+* `host_os` - (Optional) Device host OS. Default value is 'ios'. Valid values are 'ios' or 'aviatrix'.
 * `ssh_port` - (Optional) SSH port for connecting to the device. Default value is 22.
 * `address_1` - (Optional) Address line 1.
 * `address_2` - (Optional) Address line 2.


### PR DESCRIPTION
When a user registers a managed CloudN it is saved
in the db as a CloudWAN device registration with
host_os set to 'aviatrix'.