### PR TITLE
Revert "22222: add local_subnet to transit_external_device_conn"

### DIFF
--- a/docs/resources/aviatrix_transit_external_device_conn.md
+++ b/docs/resources/aviatrix_transit_external_device_conn.md
@@ -76,7 +76,6 @@ The following arguments are supported:
 * `bgp_local_as_num` - (Optional) BGP local ASN (Autonomous System Number). Integer between 1-4294967294. Required for 'bgp' connection.
 * `bgp_remote_as_num` - (Optional) BGP remote ASN (Autonomous System Number). Integer between 1-4294967294. Required for 'bgp' connection.
 * `remote_subnet` - (Optional) Remote CIDRs joined as a string with ','. Required for a 'static' type connection.
-* `local_subnet` - (Optional) Local CIDRs joined as a string with ','.
 
 ~> **NOTE:** To create a BGP over LAN connection with an Azure Transit Gateway, the Transit Gateway must have it's 'enable_bgp_over_lan' attribute set to true.
 

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -22,7 +22,6 @@ type ExternalDeviceConn struct {
 	BgpRemoteAsNum         int    `form:"external_device_as_number,omitempty"`
 	RemoteGatewayIP        string `form:"external_device_ip_address"`
 	RemoteSubnet           string `form:"remote_subnet,omitempty"`
-	LocalSubnet            string `form:"local_subnet,omitempty"`
 	DirectConnect          string `form:"direct_connect,omitempty"`
 	PreSharedKey           string `form:"pre_shared_key,omitempty"`
 	LocalTunnelCidr        string `form:"local_tunnel_ip,omitempty"`
@@ -63,7 +62,6 @@ type EditExternalDeviceConnDetail struct {
 	BgpStatus              string        `json:"bgp_status,omitempty"`
 	RemoteGatewayIP        string        `json:"peer_ip,omitempty"`
 	RemoteSubnet           string        `json:"remote_cidr,omitempty"`
-	LocalSubnet            string        `json:"local_cidr"`
 	DirectConnect          bool          `json:"direct_connect_primary,omitempty"`
 	LocalTunnelCidr        string        `json:"bgp_local_ip,omitempty"`
 	RemoteTunnelCidr       string        `json:"bgp_remote_ip,omitempty"`
@@ -169,7 +167,6 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 			}
 		} else {
 			externalDeviceConn.RemoteSubnet = externalDeviceConnDetail.RemoteSubnet
-			externalDeviceConn.LocalSubnet = externalDeviceConnDetail.LocalSubnet
 			externalDeviceConn.ConnectionType = "static"
 		}
 		externalDeviceConn.RemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[0]


### PR DESCRIPTION
According to Colby, for transit_external_device_conn, we should not allow users to change local_subnet since it's dynamic. Although this option is available in the controller, Colby said it should be a bug.