### PR TITLE
22813: Fix issue where update single_az_ha not applied to HA gateway

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -2051,12 +2051,9 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("single_az_ha") {
-		haEnabled := false
 		haSubnet := d.Get("peering_ha_subnet").(string)
 		haZone := d.Get("peering_ha_zone").(string)
-		if haSubnet != "" || haZone != "" {
-			haEnabled = true
-		}
+		haEnabled := haSubnet != "" || haZone != ""
 
 		singleAZGateway := &goaviatrix.Gateway{
 			GwName: d.Get("gw_name").(string),

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -2069,7 +2069,7 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 			singleAZGateway.SingleAZ = "disabled"
 		}
 
-		if singleAZGateway.SingleAZ == "enabled" {
+		if singleAZ {
 			log.Printf("[INFO] Enable Single AZ GW HA: %#v", singleAZGateway)
 
 			err := client.EnableSingleAZGateway(singleAZGateway)
@@ -2086,7 +2086,7 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 					return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
 				}
 			}
-		} else if singleAZGateway.SingleAZ == "disabled" {
+		} else {
 			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
 			err := client.DisableSingleAZGateway(singleAZGateway)
 			if err != nil {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1525,12 +1525,9 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 	}
 
 	if d.HasChange("single_az_ha") {
-		haEnabled := false
 		haSubnet := d.Get("ha_subnet").(string)
 		haZone := d.Get("ha_zone").(string)
-		if haSubnet != "" || haZone != "" {
-			haEnabled = true
-		}
+		haEnabled := haSubnet != "" || haZone != ""
 
 		singleAZGateway := &goaviatrix.Gateway{
 			GwName: d.Get("gw_name").(string),

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1315,36 +1315,6 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 			"'aviatrix_spoke_transit_attachment' to attach this spoke to transit gateways")
 	}
 
-	if d.HasChange("single_az_ha") {
-		singleAZGateway := &goaviatrix.Gateway{
-			GwName: d.Get("gw_name").(string),
-		}
-
-		singleAZ := d.Get("single_az_ha").(bool)
-
-		if singleAZ {
-			singleAZGateway.SingleAZ = "enabled"
-		} else {
-			singleAZGateway.SingleAZ = "disabled"
-		}
-
-		if singleAZGateway.SingleAZ == "enabled" {
-			log.Printf("[INFO] Enable Single AZ GW HA: %#v", singleAZGateway)
-
-			err := client.EnableSingleAZGateway(singleAZGateway)
-			if err != nil {
-				return fmt.Errorf("failed to enable single AZ GW HA: %s", err)
-			}
-		} else if singleAZGateway.SingleAZ == "disabled" {
-			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
-			err := client.DisableSingleAZGateway(singleAZGateway)
-			if err != nil {
-				return fmt.Errorf("failed to disable single AZ GW HA: %s", err)
-			}
-		}
-
-	}
-
 	if d.HasChange("tag_list") || d.HasChange("tags") {
 		if !goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
 			return fmt.Errorf("error updating spoke gateway: adding tags is only supported for AWS (1), Azure (8), AzureGov (32), AWSGov (256), AWSChina (1024) and AzureChina (2048)")
@@ -1551,6 +1521,61 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 				}
 			}
 			newHaGwEnabled = true
+		}
+	}
+
+	if d.HasChange("single_az_ha") {
+		haEnabled := false
+		haSubnet := d.Get("ha_subnet").(string)
+		haZone := d.Get("ha_zone").(string)
+		if haSubnet != "" || haZone != "" {
+			haEnabled = true
+		}
+
+		singleAZGateway := &goaviatrix.Gateway{
+			GwName: d.Get("gw_name").(string),
+		}
+
+		singleAZ := d.Get("single_az_ha").(bool)
+		if singleAZ {
+			singleAZGateway.SingleAZ = "enabled"
+		} else {
+			singleAZGateway.SingleAZ = "disabled"
+		}
+
+		if singleAZGateway.SingleAZ == "enabled" {
+			log.Printf("[INFO] Enable Single AZ GW HA: %#v", singleAZGateway)
+
+			err := client.EnableSingleAZGateway(singleAZGateway)
+			if err != nil {
+				return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGateway.GwName, err)
+			}
+
+			if haEnabled {
+				singleAZGatewayHA := &goaviatrix.Gateway{
+					GwName: d.Get("gw_name").(string) + "-hagw",
+				}
+				err := client.EnableSingleAZGateway(singleAZGatewayHA)
+				if err != nil {
+					return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
+				}
+			}
+		} else if singleAZGateway.SingleAZ == "disabled" {
+			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
+			err := client.DisableSingleAZGateway(singleAZGateway)
+			if err != nil {
+				return fmt.Errorf("failed to disable single AZ GW HA for %s: %s", singleAZGateway.GwName, err)
+			}
+
+			if haEnabled {
+				singleAZGatewayHA := &goaviatrix.Gateway{
+					GwName: d.Get("gw_name").(string) + "-hagw",
+				}
+				err := client.DisableSingleAZGateway(singleAZGatewayHA)
+				if err != nil {
+					return fmt.Errorf("failed to disable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
+				}
+			}
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1543,7 +1543,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 			singleAZGateway.SingleAZ = "disabled"
 		}
 
-		if singleAZGateway.SingleAZ == "enabled" {
+		if singleAZ {
 			log.Printf("[INFO] Enable Single AZ GW HA: %#v", singleAZGateway)
 
 			err := client.EnableSingleAZGateway(singleAZGateway)
@@ -1560,7 +1560,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 					return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
 				}
 			}
-		} else if singleAZGateway.SingleAZ == "disabled" {
+		} else {
 			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
 			err := client.DisableSingleAZGateway(singleAZGateway)
 			if err != nil {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1842,12 +1842,9 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 	}
 
 	if d.HasChange("single_az_ha") {
-		haEnabled := false
 		haSubnet := d.Get("ha_subnet").(string)
 		haZone := d.Get("ha_zone").(string)
-		if haSubnet != "" || haZone != "" {
-			haEnabled = true
-		}
+		haEnabled := haSubnet != "" || haZone != ""
 
 		singleAZGateway := &goaviatrix.Gateway{
 			GwName: d.Get("gw_name").(string),

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1860,7 +1860,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			singleAZGateway.SingleAZ = "disabled"
 		}
 
-		if singleAZGateway.SingleAZ == "enabled" {
+		if singleAZ {
 			log.Printf("[INFO] Enable Single AZ GW HA: %#v", singleAZGateway)
 
 			err := client.EnableSingleAZGateway(singleAZGateway)
@@ -1877,7 +1877,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
 				}
 			}
-		} else if singleAZGateway.SingleAZ == "disabled" {
+		} else {
 			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
 			err := client.DisableSingleAZGateway(singleAZGateway)
 			if err != nil {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1682,36 +1682,6 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	if d.HasChange("single_az_ha") {
-		singleAZGateway := &goaviatrix.Gateway{
-			GwName: d.Get("gw_name").(string),
-		}
-
-		singleAZ := d.Get("single_az_ha").(bool)
-
-		if singleAZ {
-			singleAZGateway.SingleAZ = "enabled"
-		} else {
-			singleAZGateway.SingleAZ = "disabled"
-		}
-
-		if singleAZGateway.SingleAZ == "enabled" {
-			log.Printf("[INFO] Enable Single AZ GW HA: %#v", singleAZGateway)
-
-			err := client.EnableSingleAZGateway(singleAZGateway)
-			if err != nil {
-				return fmt.Errorf("failed to enable single AZ GW HA: %s", err)
-			}
-		} else if singleAZGateway.SingleAZ == "disabled" {
-			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
-			err := client.DisableSingleAZGateway(singleAZGateway)
-			if err != nil {
-				return fmt.Errorf("failed to disable single AZ GW HA: %s", err)
-			}
-		}
-
-	}
-
 	newHaGwEnabled := false
 	if d.HasChange("ha_subnet") || d.HasChange("ha_zone") || d.HasChange("ha_insane_mode_az") ||
 		(enablePrivateOob && (d.HasChange("ha_oob_management_subnet") || d.HasChange("ha_oob_availability_zone"))) ||
@@ -1868,6 +1838,61 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 
 			newHaGwEnabled = true
+		}
+	}
+
+	if d.HasChange("single_az_ha") {
+		haEnabled := false
+		haSubnet := d.Get("ha_subnet").(string)
+		haZone := d.Get("ha_zone").(string)
+		if haSubnet != "" || haZone != "" {
+			haEnabled = true
+		}
+
+		singleAZGateway := &goaviatrix.Gateway{
+			GwName: d.Get("gw_name").(string),
+		}
+
+		singleAZ := d.Get("single_az_ha").(bool)
+		if singleAZ {
+			singleAZGateway.SingleAZ = "enabled"
+		} else {
+			singleAZGateway.SingleAZ = "disabled"
+		}
+
+		if singleAZGateway.SingleAZ == "enabled" {
+			log.Printf("[INFO] Enable Single AZ GW HA: %#v", singleAZGateway)
+
+			err := client.EnableSingleAZGateway(singleAZGateway)
+			if err != nil {
+				return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGateway.GwName, err)
+			}
+
+			if haEnabled {
+				singleAZGatewayHA := &goaviatrix.Gateway{
+					GwName: d.Get("gw_name").(string) + "-hagw",
+				}
+				err := client.EnableSingleAZGateway(singleAZGatewayHA)
+				if err != nil {
+					return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
+				}
+			}
+		} else if singleAZGateway.SingleAZ == "disabled" {
+			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
+			err := client.DisableSingleAZGateway(singleAZGateway)
+			if err != nil {
+				return fmt.Errorf("failed to disable single AZ GW HA for %s: %s", singleAZGateway.GwName, err)
+			}
+
+			if haEnabled {
+				singleAZGatewayHA := &goaviatrix.Gateway{
+					GwName: d.Get("gw_name").(string) + "-hagw",
+				}
+				err := client.DisableSingleAZGateway(singleAZGatewayHA)
+				if err != nil {
+					return fmt.Errorf("failed to disable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
For gateway/spoke/transit with HA, single_az_ha is updated separately for primary and HA. 
Solution: Update (enable or disable) both primary and ha(if enabled) in Update function.
 