### PR TITLE
Respect proxies servers

### DIFF
--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -114,6 +114,7 @@ func (c *Client) init(controllerIP string) (*Client, error) {
 
 	if c.HTTPClient == nil {
 		tr := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},


### PR DESCRIPTION
Currently our HTTP client is configured to not
try to use proxies if present. This change will
tell the client to try to look for proxies in the
default env variables HTTP_PROXY and HTTPS_PROXY.

This should have no effect on user's who are not using
proxies.