### PR TITLE
23019: Fix issue where Enabling EBS volume encryption after initial gateway deployment only updates primary gateway

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -2188,6 +2188,20 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwEncVolume.GwName, err)
 			}
+
+			haSubnet := d.Get("peering_ha_subnet").(string)
+			haZone := d.Get("peering_ha_zone").(string)
+			haEnabled := haSubnet != "" || haZone != ""
+			if haEnabled {
+				gwHAEncVolume := &goaviatrix.Gateway{
+					GwName:              d.Get("gw_name").(string) + "-hagw",
+					CustomerManagedKeys: d.Get("customer_managed_keys").(string),
+				}
+				err := client.EnableEncryptVolume(gwHAEncVolume)
+				if err != nil {
+					return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwHAEncVolume.GwName, err)
+				}
+			}
 		} else {
 			return fmt.Errorf("can't disable Encrypt Volume for gateway: %s", gateway.GwName)
 		}

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1649,6 +1649,20 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 			if err != nil {
 				return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwEncVolume.GwName, err)
 			}
+
+			haSubnet := d.Get("ha_subnet").(string)
+			haZone := d.Get("ha_zone").(string)
+			haEnabled := haSubnet != "" || haZone != ""
+			if haEnabled {
+				gwHAEncVolume := &goaviatrix.Gateway{
+					GwName:              d.Get("gw_name").(string) + "-hagw",
+					CustomerManagedKeys: d.Get("customer_managed_keys").(string),
+				}
+				err := client.EnableEncryptVolume(gwHAEncVolume)
+				if err != nil {
+					return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwHAEncVolume.GwName, err)
+				}
+			}
 		} else {
 			return fmt.Errorf("can't disable Encrypt Volume for gateway: %s", gateway.GwName)
 		}

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2382,6 +2382,20 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if err != nil {
 				return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwEncVolume.GwName, err)
 			}
+
+			haSubnet := d.Get("ha_subnet").(string)
+			haZone := d.Get("ha_zone").(string)
+			haEnabled := haSubnet != "" || haZone != ""
+			if haEnabled {
+				gwHAEncVolume := &goaviatrix.Gateway{
+					GwName:              d.Get("gw_name").(string) + "-hagw",
+					CustomerManagedKeys: d.Get("customer_managed_keys").(string),
+				}
+				err := client.EnableEncryptVolume(gwHAEncVolume)
+				if err != nil {
+					return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwHAEncVolume.GwName, err)
+				}
+			}
 		} else {
 			return fmt.Errorf("can't disable Encrypt Volume for gateway: %s", gateway.GwName)
 		}


### PR DESCRIPTION
If gateway/spoke/transit was created unencrypted, update enable_encrypt_volume would only encrypt primary gateway/spoke/transit. Solution is to also encrypt HA.