### PR TITLE
AVX-10415: update list_version_info in terraform accordingly due to API & backend change

### DIFF
--- a/goaviatrix/version.go
+++ b/goaviatrix/version.go
@@ -168,6 +168,7 @@ func (c *Client) GetLatestVersion() (string, error) {
 	listVersionInfo := url.Values{}
 	listVersionInfo.Add("CID", c.CID)
 	listVersionInfo.Add("action", "list_version_info")
+	listVersionInfo.Add("latest_version", strconv.FormatBool(true))
 	Url.RawQuery = listVersionInfo.Encode()
 	resp, err := c.Get(Url.String(), nil)
 	if err != nil {


### PR DESCRIPTION
Backend is changing list_version_info call to only return current version. To get the latest version, please add --latest_version option to list_version_info or calling get_latest_release_version api.