### PR TITLE
AVX-11160: Fix typo in get_compatible_image_version

### DIFF
--- a/goaviatrix/version.go
+++ b/goaviatrix/version.go
@@ -277,10 +277,10 @@ func ParseVersion(version string) (string, *AviatrixVersion, error) {
 
 func (c *Client) GetCompatibleImageVersion(ctx context.Context, cloudType int, softwareVersion string) (string, error) {
 	form := map[string]string{
-		"action":          "get_compatible_image_version",
-		"CID":             c.CID,
-		"software_verion": softwareVersion,
-		"cloud_type":      strconv.Itoa(cloudType),
+		"action":           "get_compatible_image_version",
+		"CID":              c.CID,
+		"software_version": softwareVersion,
+		"cloud_type":       strconv.Itoa(cloudType),
 	}
 	var data struct {
 		Results struct {


### PR DESCRIPTION
API used to have typo but they have fixed it. So now TF side needs to fix the typo as well.