### PR TITLE
AVX-13823: Parallel Primary/HA pair upgrade

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -2533,7 +2533,7 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 			}()
 			wg.Wait()
 			if primaryErr != nil && haErr != nil {
-				return fmt.Errorf("could not upgrade either primary or HA gateway "+
+				return fmt.Errorf("could not upgrade primary and HA gateway "+
 					"software_version=%s peering_ha_software_version=%s: primaryErr: %v haErr: %v",
 					swVersion, haSwVersion, primaryErr, haErr)
 			} else if primaryErr != nil {

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -509,7 +510,7 @@ func resourceAviatrixGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				Description: "ha_software_version can be used to set the desired software version of the HA gateway. " +
+				Description: "peering_ha_software_version can be used to set the desired software version of the HA gateway. " +
 					"If set, we will attempt to update the gateway to the specified version. " +
 					"If left blank, the gateway software version will continue to be managed through the aviatrix_controller_config resource.",
 			},
@@ -524,7 +525,7 @@ func resourceAviatrixGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				Description: "ha_image_version can be used to set the desired image version of the HA gateway. " +
+				Description: "peering_ha_image_version can be used to set the desired image version of the HA gateway. " +
 					"If set, we will attempt to update the gateway to the specified version.",
 			},
 			"elb_dns_name": {
@@ -2501,31 +2502,71 @@ func resourceAviatrixGatewayUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	if d.HasChanges("software_version", "image_version") {
-		swVersion := d.Get("software_version").(string)
-		imageVersion := d.Get("image_version").(string)
-		gw := &goaviatrix.Gateway{
-			GwName:          d.Get("gw_name").(string),
-			SoftwareVersion: swVersion,
-			ImageVersion:    imageVersion,
-		}
-		err := client.UpgradeGateway(gw)
-		if err != nil {
-			return fmt.Errorf("could not upgrade primary gateway during update image_version=%s software_version=%s: %v", gw.ImageVersion, gw.SoftwareVersion, err)
-		}
-	}
-	if haEnabled && d.HasChanges("peering_ha_image_version", "peering_ha_software_version") {
-		haSwVersion := d.Get("peering_ha_software_version").(string)
-		haImageVersion := d.Get("peering_ha_image_version").(string)
-		if haSwVersion != "" || haImageVersion != "" {
-			hagw := &goaviatrix.Gateway{
-				GwName:          gateway.GwName + "-hagw",
-				SoftwareVersion: haSwVersion,
-				ImageVersion:    haImageVersion,
+	primaryHasVersionChange := d.HasChanges("software_version", "image_version")
+	haHasVersionChange := haEnabled && d.HasChanges("peering_ha_software_version", "peering_ha_image_version")
+	primaryHasImageVersionChange := d.HasChange("image_version")
+	haHasImageVersionChange := d.HasChange("peering_ha_image_version")
+	if primaryHasVersionChange || haHasVersionChange {
+		if primaryHasVersionChange && haHasVersionChange && !primaryHasImageVersionChange && !haHasImageVersionChange {
+			// Both Primary and HA have changed just their software_version
+			// so we can perform upgrade in parallel.
+			swVersion := d.Get("software_version").(string)
+			gw := &goaviatrix.Gateway{
+				GwName:          d.Get("gw_name").(string),
+				SoftwareVersion: swVersion,
 			}
-			err = client.UpgradeGateway(hagw)
-			if err != nil {
-				return fmt.Errorf("could not upgrade PSF HA gateway during update image_version=%s software_version=%s: %v", hagw.ImageVersion, hagw.SoftwareVersion, err)
+			haSwVersion := d.Get("peering_ha_software_version").(string)
+			hagw := &goaviatrix.Gateway{
+				GwName:          d.Get("gw_name").(string) + "-hagw",
+				SoftwareVersion: haSwVersion,
+			}
+			var wg sync.WaitGroup
+			wg.Add(2)
+			var primaryErr, haErr error
+			go func() {
+				primaryErr = client.UpgradeGateway(gw)
+				wg.Done()
+			}()
+			go func() {
+				haErr = client.UpgradeGateway(hagw)
+				wg.Done()
+			}()
+			wg.Wait()
+			if primaryErr != nil && haErr != nil {
+				return fmt.Errorf("could not upgrade either primary or HA gateway "+
+					"software_version=%s peering_ha_software_version=%s: primaryErr: %v haErr: %v",
+					swVersion, haSwVersion, primaryErr, haErr)
+			} else if primaryErr != nil {
+				return fmt.Errorf("could not upgrade primary gateway software_version=%s: %v", swVersion, primaryErr)
+			} else if haErr != nil {
+				return fmt.Errorf("could not upgrade HA gateway peering_ha_software_version=%s: %v", haSwVersion, primaryErr)
+			}
+		} else { // Only primary or only HA has changed, or they have changed image_version
+			if primaryHasVersionChange {
+				swVersion := d.Get("software_version").(string)
+				imageVersion := d.Get("image_version").(string)
+				gw := &goaviatrix.Gateway{
+					GwName:          d.Get("gw_name").(string),
+					SoftwareVersion: swVersion,
+					ImageVersion:    imageVersion,
+				}
+				err := client.UpgradeGateway(gw)
+				if err != nil {
+					return fmt.Errorf("could not upgrade gateway during update image_version=%s software_version=%s: %v", gw.ImageVersion, gw.SoftwareVersion, err)
+				}
+			}
+			if haHasVersionChange {
+				haSwVersion := d.Get("peering_ha_software_version").(string)
+				haImageVersion := d.Get("peering_ha_image_version").(string)
+				hagw := &goaviatrix.Gateway{
+					GwName:          d.Get("gw_name").(string) + "-hagw",
+					SoftwareVersion: haSwVersion,
+					ImageVersion:    haImageVersion,
+				}
+				err := client.UpgradeGateway(hagw)
+				if err != nil {
+					return fmt.Errorf("could not upgrade HA gateway during update image_version=%s software_version=%s: %v", hagw.ImageVersion, hagw.SoftwareVersion, err)
+				}
 			}
 		}
 	}

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -2094,31 +2095,71 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if d.HasChanges("software_version", "image_version") {
-		swVersion := d.Get("software_version").(string)
-		imageVersion := d.Get("image_version").(string)
-		gw := &goaviatrix.Gateway{
-			GwName:          d.Get("gw_name").(string),
-			SoftwareVersion: swVersion,
-			ImageVersion:    imageVersion,
-		}
-		err := client.UpgradeGateway(gw)
-		if err != nil {
-			return fmt.Errorf("could not upgrade spoke gateway during update image_version=%s software_version=%s: %v", gw.ImageVersion, gw.SoftwareVersion, err)
-		}
-	}
-	if haEnabled && d.HasChanges("ha_image_version", "ha_software_version") {
-		haSwVersion := d.Get("ha_software_version").(string)
-		haImageVersion := d.Get("ha_image_version").(string)
-		if haSwVersion != "" || haImageVersion != "" {
-			hagw := &goaviatrix.Gateway{
-				GwName:          gateway.GwName + "-hagw",
-				SoftwareVersion: haSwVersion,
-				ImageVersion:    haImageVersion,
+	primaryHasVersionChange := d.HasChanges("software_version", "image_version")
+	haHasVersionChange := haEnabled && d.HasChanges("ha_software_version", "ha_image_version")
+	primaryHasImageVersionChange := d.HasChange("image_version")
+	haHasImageVersionChange := d.HasChange("ha_image_version")
+	if primaryHasVersionChange || haHasVersionChange {
+		if primaryHasVersionChange && haHasVersionChange && !primaryHasImageVersionChange && !haHasImageVersionChange {
+			// Both Primary and HA have changed just their software_version
+			// so we can perform upgrade in parallel.
+			swVersion := d.Get("software_version").(string)
+			gw := &goaviatrix.Gateway{
+				GwName:          d.Get("gw_name").(string),
+				SoftwareVersion: swVersion,
 			}
-			err := client.UpgradeGateway(hagw)
-			if err != nil {
-				return fmt.Errorf("could not upgrade HA spoke gateway during update image_version=%s software_version=%s: %v", hagw.ImageVersion, hagw.SoftwareVersion, err)
+			haSwVersion := d.Get("ha_software_version").(string)
+			hagw := &goaviatrix.Gateway{
+				GwName:          d.Get("gw_name").(string) + "-hagw",
+				SoftwareVersion: haSwVersion,
+			}
+			var wg sync.WaitGroup
+			wg.Add(2)
+			var primaryErr, haErr error
+			go func() {
+				primaryErr = client.UpgradeGateway(gw)
+				wg.Done()
+			}()
+			go func() {
+				haErr = client.UpgradeGateway(hagw)
+				wg.Done()
+			}()
+			wg.Wait()
+			if primaryErr != nil && haErr != nil {
+				return fmt.Errorf("could not upgrade either primary or HA spoke gateway "+
+					"software_version=%s ha_software_version=%s: primaryErr: %v haErr: %v",
+					swVersion, haSwVersion, primaryErr, haErr)
+			} else if primaryErr != nil {
+				return fmt.Errorf("could not upgrade primary spoke gateway software_version=%s: %v", swVersion, primaryErr)
+			} else if haErr != nil {
+				return fmt.Errorf("could not upgrade HA spoke gateway ha_software_version=%s: %v", haSwVersion, primaryErr)
+			}
+		} else { // Only primary or only HA has changed, or they have changed image_version
+			if primaryHasVersionChange {
+				swVersion := d.Get("software_version").(string)
+				imageVersion := d.Get("image_version").(string)
+				gw := &goaviatrix.Gateway{
+					GwName:          d.Get("gw_name").(string),
+					SoftwareVersion: swVersion,
+					ImageVersion:    imageVersion,
+				}
+				err := client.UpgradeGateway(gw)
+				if err != nil {
+					return fmt.Errorf("could not upgrade spoke gateway during update image_version=%s software_version=%s: %v", gw.ImageVersion, gw.SoftwareVersion, err)
+				}
+			}
+			if haHasVersionChange {
+				haSwVersion := d.Get("ha_software_version").(string)
+				haImageVersion := d.Get("ha_image_version").(string)
+				hagw := &goaviatrix.Gateway{
+					GwName:          d.Get("gw_name").(string) + "-hagw",
+					SoftwareVersion: haSwVersion,
+					ImageVersion:    haImageVersion,
+				}
+				err := client.UpgradeGateway(hagw)
+				if err != nil {
+					return fmt.Errorf("could not upgrade HA spoke gateway during update image_version=%s software_version=%s: %v", hagw.ImageVersion, hagw.SoftwareVersion, err)
+				}
 			}
 		}
 	}

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -2126,7 +2126,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 			}()
 			wg.Wait()
 			if primaryErr != nil && haErr != nil {
-				return fmt.Errorf("could not upgrade either primary or HA spoke gateway "+
+				return fmt.Errorf("could not upgrade primary and HA spoke gateway "+
 					"software_version=%s ha_software_version=%s: primaryErr: %v haErr: %v",
 					swVersion, haSwVersion, primaryErr, haErr)
 			} else if primaryErr != nil {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2837,7 +2837,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}()
 			wg.Wait()
 			if primaryErr != nil && haErr != nil {
-				return fmt.Errorf("could not upgrade either primary or HA transit gateway "+
+				return fmt.Errorf("could not upgrade primary and HA transit gateway "+
 					"software_version=%s ha_software_version=%s: primaryErr: %v haErr: %v",
 					swVersion, haSwVersion, primaryErr, haErr)
 			} else if primaryErr != nil {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
@@ -2805,31 +2806,71 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	if d.HasChanges("software_version", "image_version") {
-		swVersion := d.Get("software_version").(string)
-		imageVersion := d.Get("image_version").(string)
-		gw := &goaviatrix.Gateway{
-			GwName:          d.Get("gw_name").(string),
-			SoftwareVersion: swVersion,
-			ImageVersion:    imageVersion,
-		}
-		err := client.UpgradeGateway(gw)
-		if err != nil {
-			return fmt.Errorf("could not upgrade transit gateway during update image_version=%s software_version=%s: %v", gw.ImageVersion, gw.SoftwareVersion, err)
-		}
-	}
-	if haEnabled && d.HasChanges("ha_image_version", "ha_software_version") {
-		haSwVersion := d.Get("ha_software_version").(string)
-		haImageVersion := d.Get("ha_image_version").(string)
-		if haSwVersion != "" || haImageVersion != "" {
+	primaryHasVersionChange := d.HasChanges("software_version", "image_version")
+	haHasVersionChange := haEnabled && d.HasChanges("ha_software_version", "ha_image_version")
+	primaryHasImageVersionChange := d.HasChange("image_version")
+	haHasImageVersionChange := d.HasChange("ha_image_version")
+	if primaryHasVersionChange || haHasVersionChange {
+		if primaryHasVersionChange && haHasVersionChange && !primaryHasImageVersionChange && !haHasImageVersionChange {
+			// Both Primary and HA have changed just their software_version
+			// so we can perform upgrade in parallel.
+			swVersion := d.Get("software_version").(string)
+			gw := &goaviatrix.Gateway{
+				GwName:          d.Get("gw_name").(string),
+				SoftwareVersion: swVersion,
+			}
+			haSwVersion := d.Get("ha_software_version").(string)
 			hagw := &goaviatrix.Gateway{
 				GwName:          d.Get("gw_name").(string) + "-hagw",
 				SoftwareVersion: haSwVersion,
-				ImageVersion:    haImageVersion,
 			}
-			err := client.UpgradeGateway(hagw)
-			if err != nil {
-				return fmt.Errorf("could not upgrade HA transit gateway during update image_version=%s software_version=%s: %v", hagw.ImageVersion, hagw.SoftwareVersion, err)
+			var wg sync.WaitGroup
+			wg.Add(2)
+			var primaryErr, haErr error
+			go func() {
+				primaryErr = client.UpgradeGateway(gw)
+				wg.Done()
+			}()
+			go func() {
+				haErr = client.UpgradeGateway(hagw)
+				wg.Done()
+			}()
+			wg.Wait()
+			if primaryErr != nil && haErr != nil {
+				return fmt.Errorf("could not upgrade either primary or HA transit gateway "+
+					"software_version=%s ha_software_version=%s: primaryErr: %v haErr: %v",
+					swVersion, haSwVersion, primaryErr, haErr)
+			} else if primaryErr != nil {
+				return fmt.Errorf("could not upgrade primary transit gateway software_version=%s: %v", swVersion, primaryErr)
+			} else if haErr != nil {
+				return fmt.Errorf("could not upgrade HA transit gateway ha_software_version=%s: %v", haSwVersion, primaryErr)
+			}
+		} else { // Only primary or only HA has changed, or they have changed image_version
+			if primaryHasVersionChange {
+				swVersion := d.Get("software_version").(string)
+				imageVersion := d.Get("image_version").(string)
+				gw := &goaviatrix.Gateway{
+					GwName:          d.Get("gw_name").(string),
+					SoftwareVersion: swVersion,
+					ImageVersion:    imageVersion,
+				}
+				err := client.UpgradeGateway(gw)
+				if err != nil {
+					return fmt.Errorf("could not upgrade transit gateway during update image_version=%s software_version=%s: %v", gw.ImageVersion, gw.SoftwareVersion, err)
+				}
+			}
+			if haHasVersionChange {
+				haSwVersion := d.Get("ha_software_version").(string)
+				haImageVersion := d.Get("ha_image_version").(string)
+				hagw := &goaviatrix.Gateway{
+					GwName:          d.Get("gw_name").(string) + "-hagw",
+					SoftwareVersion: haSwVersion,
+					ImageVersion:    haImageVersion,
+				}
+				err := client.UpgradeGateway(hagw)
+				if err != nil {
+					return fmt.Errorf("could not upgrade HA transit gateway during update image_version=%s software_version=%s: %v", hagw.ImageVersion, hagw.SoftwareVersion, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In the scenario where a user is trying to upgrade
both primary and ha software_version, we can do the
upgrade in parallel.

If user is trying to upgrade image_version as well,
then we cannot safely do parallel upgrade. So, we fall
back to doing it serially.