### PR TITLE
Ignore docs and test-infra for CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,9 +1,16 @@
 name: go
 
-on: [push, pull_request]
+on: 
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'test-infra/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'test-infra/**'
 
 jobs:
-
   build:
     name: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't need to run build, test and lint for changes to docs or test-infra