### PR TITLE
AVX-14208: Ignore 'configuration not changed' error from edit_firenet API

### DIFF
--- a/goaviatrix/firenet.go
+++ b/goaviatrix/firenet.go
@@ -212,9 +212,6 @@ func (c *Client) EditFireNetInspection(fireNet *FireNet) error {
 
 	checkFunc := func(act, method, reason string, ret bool) error {
 		if !ret {
-			if strings.Contains(reason, "configuration not found") {
-				return nil
-			}
 			if strings.Contains(reason, "configuration not changed") {
 				return nil
 			}

--- a/goaviatrix/firenet.go
+++ b/goaviatrix/firenet.go
@@ -215,6 +215,9 @@ func (c *Client) EditFireNetInspection(fireNet *FireNet) error {
 			if strings.Contains(reason, "configuration not found") {
 				return nil
 			}
+			if strings.Contains(reason, "configuration not changed") {
+				return nil
+			}
 			return fmt.Errorf("rest API %s %s failed: %s", act, method, reason)
 		}
 		return nil


### PR DESCRIPTION
Another API call that got messed up in the GetAPI/PostAPI refactor.