### PR TITLE
AVX-14274: Fix fail_close_enabled being set to incorrect value

### DIFF
--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -279,6 +279,11 @@ func resourceAviatrixFireNetCreate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("could not enable fail close: %v", err)
 		}
+	} else {
+		err := client.DisableFirenetFailClose(fireNet)
+		if err != nil {
+			return fmt.Errorf("could not disable fail close during creation: %v", err)
+		}
 	}
 
 	var egressStaticCidrs []string


### PR DESCRIPTION
Normally fail_close_enabled is defaulted to false, however,
in some cases (not sure all the cases) it is set to true.
To be safe, I will call the disable API if user sets
fail_close_enabled = false in the Create function. This is okay
because even if it already disabled, API will return 'configuration
not changed' error that we already ignore in the API function.