### PR TITLE
Revert "AVX-14274: Fix fail_close_enabled being set to incorrect value"

### DIFF
--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -279,11 +279,6 @@ func resourceAviatrixFireNetCreate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("could not enable fail close: %v", err)
 		}
-	} else {
-		err := client.DisableFirenetFailClose(fireNet)
-		if err != nil {
-			return fmt.Errorf("could not disable fail close during creation: %v", err)
-		}
 	}
 
 	var egressStaticCidrs []string


### PR DESCRIPTION
Reverts AviatrixSystems/terraform-provider-aviatrix#1090

This change creates more issues than it solves. Specifically because this is an optional/computed attribute, we cannot know in Create if the user intentionally set the attribute to false, or they just left it blank in the config.