### PR TITLE
AVX-14149: Handle ErrNotFound properly

### DIFF
--- a/aviatrix/resource_aviatrix_cloudn_transit_gateway_attachment.go
+++ b/aviatrix/resource_aviatrix_cloudn_transit_gateway_attachment.go
@@ -2,6 +2,7 @@ package aviatrix
 
 import (
 	"context"
+	"errors"
 	"log"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
@@ -154,7 +155,7 @@ func resourceAviatrixCloudnTransitGatewayAttachmentRead(ctx context.Context, d *
 	attachment := marshalCloudnTransitGatewayAttachmentInput(d)
 
 	attachment, err := client.GetCloudnTransitGatewayAttachment(ctx, connName)
-	if err == goaviatrix.ErrNotFound {
+	if errors.Is(err, goaviatrix.ErrNotFound) {
 		d.SetId("")
 		return nil
 	}

--- a/aviatrix/resource_aviatrix_cloudn_transit_gateway_attachment.go
+++ b/aviatrix/resource_aviatrix_cloudn_transit_gateway_attachment.go
@@ -2,7 +2,6 @@ package aviatrix
 
 import (
 	"context"
-	"errors"
 	"log"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
@@ -155,7 +154,7 @@ func resourceAviatrixCloudnTransitGatewayAttachmentRead(ctx context.Context, d *
 	attachment := marshalCloudnTransitGatewayAttachmentInput(d)
 
 	attachment, err := client.GetCloudnTransitGatewayAttachment(ctx, connName)
-	if errors.Is(err, goaviatrix.ErrNotFound) {
+	if err == goaviatrix.ErrNotFound {
 		d.SetId("")
 		return nil
 	}

--- a/aviatrix/resource_aviatrix_controller_config.go
+++ b/aviatrix/resource_aviatrix_controller_config.go
@@ -323,11 +323,7 @@ func resourceAviatrixControllerConfigRead(d *schema.ResourceData, meta interface
 	log.Printf("[INFO] Getting controller %s configuration", d.Id())
 	result, err := client.GetHttpAccessEnabled()
 	if err != nil {
-		if err == goaviatrix.ErrNotFound {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("could not read Aviatrix Controller Config: %s", err)
+		return fmt.Errorf("could not read Aviatrix Controller http access configuration: %s", err)
 	}
 
 	if result[1:5] == "True" {

--- a/goaviatrix/aws_tgw_vpc_attachment.go
+++ b/goaviatrix/aws_tgw_vpc_attachment.go
@@ -73,12 +73,18 @@ func (c *Client) GetAwsTgwVpcAttachment(awsTgwVpcAttachment *AwsTgwVpcAttachment
 	}
 	awsTgw, err := c.ListTgwDetails(awsTgw)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("couldn't find AWS TGW %s: %v", awsTgwVpcAttachment.TgwName, err)
 	}
 	awsTgwVpcAttachment.Region = awsTgw.Region
 
 	err = c.GetAwsTgwDomain(awsTgw, awsTgwVpcAttachment.SecurityDomainName)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, errors.New("aws tgw does not have security domain: " + err.Error())
 	}
 
@@ -184,7 +190,7 @@ func (c *Client) GetAwsTgwDomain(awsTgw *AWSTgw, sDM string) error {
 		mDomain[data.Results[i]] = true
 	}
 	if !mDomain[sDM] {
-		return errors.New(awsTgw.Name + " does not have security domain: " + sDM)
+		return ErrNotFound
 	}
 
 	return nil

--- a/goaviatrix/cloudn_transit_gateway_attachment.go
+++ b/goaviatrix/cloudn_transit_gateway_attachment.go
@@ -33,11 +33,17 @@ func (c *Client) CreateCloudnTransitGatewayAttachment(ctx context.Context, attac
 func (c *Client) GetCloudnTransitGatewayAttachment(ctx context.Context, connName string) (*CloudnTransitGatewayAttachment, error) {
 	deviceName, err := c.GetDeviceName(connName)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("could not get cloudn transit gateway attachment device name: %w", err)
 	}
 
 	vpcID, err := c.GetDeviceAttachmentVpcID(connName)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("could not get cloudn transit gateway attachment VPC id: %w", err)
 	}
 

--- a/goaviatrix/cloudn_transit_gateway_attachment.go
+++ b/goaviatrix/cloudn_transit_gateway_attachment.go
@@ -33,12 +33,12 @@ func (c *Client) CreateCloudnTransitGatewayAttachment(ctx context.Context, attac
 func (c *Client) GetCloudnTransitGatewayAttachment(ctx context.Context, connName string) (*CloudnTransitGatewayAttachment, error) {
 	deviceName, err := c.GetDeviceName(connName)
 	if err != nil {
-		return nil, fmt.Errorf("could not get cloudn transit gateway attachment device name: %v", err)
+		return nil, fmt.Errorf("could not get cloudn transit gateway attachment device name: %w", err)
 	}
 
 	vpcID, err := c.GetDeviceAttachmentVpcID(connName)
 	if err != nil {
-		return nil, fmt.Errorf("could not get cloudn transit gateway attachment VPC id: %v", err)
+		return nil, fmt.Errorf("could not get cloudn transit gateway attachment VPC id: %w", err)
 	}
 
 	type site2cloudResp struct {

--- a/goaviatrix/device_transit_gateway_attachment.go
+++ b/goaviatrix/device_transit_gateway_attachment.go
@@ -39,11 +39,17 @@ func (c *Client) CreateDeviceTransitGatewayAttachment(attachment *DeviceTransitG
 func (c *Client) GetDeviceTransitGatewayAttachment(attachment *DeviceTransitGatewayAttachment) (*DeviceTransitGatewayAttachment, error) {
 	deviceName, err := c.GetDeviceName(attachment.ConnectionName)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("could not get device name: %v", err)
 	}
 
 	vpcID, err := c.GetDeviceAttachmentVpcID(attachment.ConnectionName)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("could not get device attachment VPC id: %v", err)
 	}
 

--- a/goaviatrix/device_virtual_wan_attachment.go
+++ b/goaviatrix/device_virtual_wan_attachment.go
@@ -25,11 +25,17 @@ func (c *Client) CreateDeviceVirtualWanAttachment(attachment *DeviceVirtualWanAt
 func (c *Client) GetDeviceVirtualWanAttachment(attachment *DeviceVirtualWanAttachment) (*DeviceVirtualWanAttachment, error) {
 	deviceName, err := c.GetDeviceName(attachment.ConnectionName)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("could not get device name: %v", err)
 	}
 
 	vpcID, err := c.GetDeviceAttachmentVpcID(attachment.ConnectionName)
 	if err != nil {
+		if err == ErrNotFound {
+			return nil, err
+		}
 		return nil, fmt.Errorf("could not get device attachment VPC id: %v", err)
 	}
 

--- a/goaviatrix/security_domain.go
+++ b/goaviatrix/security_domain.go
@@ -2,7 +2,6 @@ package goaviatrix
 
 import (
 	"context"
-	"fmt"
 )
 
 // AwsTGW simple struct to hold aws_tgw details
@@ -242,5 +241,5 @@ func (c *Client) GetIntraDomainInspectionStatus(ctx context.Context, intraDomain
 		}
 	}
 
-	return fmt.Errorf("could not find security domain %s in tgw %s", intraDomainInspection.RouteDomainName, intraDomainInspection.TgwName)
+	return ErrNotFound
 }


### PR DESCRIPTION
To make sure the equality check `err == ErrNotFound` works correctly, we need to make sure we return just ErrNotFound, not ErrNotFound wrapped in another error.