### PR TITLE
AVX-14620: Write resource into state if resource create fails and resource is saved into the DB

### DIFF
--- a/aviatrix/resource_aviatrix_account_user.go
+++ b/aviatrix/resource_aviatrix_account_user.go
@@ -62,6 +62,10 @@ func resourceAviatrixAccountUserCreate(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[INFO] Creating Aviatrix account user: %#v", user)
 
+	d.SetId(user.UserName)
+	flag := false
+	defer resourceAviatrixAccountUserReadIfRequired(d, meta, &flag)
+
 	err := client.CreateAccountUser(user)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Account User: %s", err)
@@ -69,8 +73,15 @@ func resourceAviatrixAccountUserCreate(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[DEBUG] Aviatrix account user %s created", user.UserName)
 
-	d.SetId(user.UserName)
-	return resourceAviatrixAccountUserRead(d, meta)
+	return resourceAviatrixAccountUserReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAccountUserReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAccountUserRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixAccountUserRead(d *schema.ResourceData, meta interface{}) error {
@@ -137,7 +148,7 @@ func resourceAviatrixAccountUserUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	d.Partial(false)
-	return nil
+	return resourceAviatrixAccountUserRead(d, meta)
 }
 
 func resourceAviatrixAccountUserDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_aws_peer.go
+++ b/aviatrix/resource_aviatrix_aws_peer.go
@@ -106,13 +106,24 @@ func resourceAviatrixAWSPeerCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Creating Aviatrix aws_peer: %#v", awsPeer)
 
+	d.SetId(awsPeer.VpcID1 + "~" + awsPeer.VpcID2)
+	flag := false
+	defer resourceAviatrixAWSPeerReadIfRequired(d, meta, &flag)
+
 	_, err := client.CreateAWSPeer(awsPeer)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix AWSPeer: %s", err)
 	}
 
-	d.SetId(awsPeer.VpcID1 + "~" + awsPeer.VpcID2)
-	return resourceAviatrixAWSPeerRead(d, meta)
+	return resourceAviatrixAWSPeerReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAWSPeerReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAWSPeerRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixAWSPeerRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_aws_tgw.go
+++ b/aviatrix/resource_aviatrix_aws_tgw.go
@@ -427,14 +427,14 @@ func resourceAviatrixAWSTgwCreate(d *schema.ResourceData, meta interface{}) erro
 		awsTgw.NotCreateDefaultDomains = true
 	}
 
+	d.SetId(awsTgw.Name)
+	flag := false
+	defer resourceAviatrixAWSTgwReadIfRequired(d, meta, &flag)
+
 	err1 := client.CreateAWSTgw(awsTgw)
 	if err1 != nil {
 		return fmt.Errorf("failed to create AWS TGW: %s", err1)
 	}
-	d.SetId(awsTgw.Name)
-
-	flag := false
-	defer resourceAviatrixAWSTgwReadIfRequired(d, meta, &flag)
 
 	if manageSecurityDomain {
 		for i := range domainsToCreate {

--- a/aviatrix/resource_aviatrix_aws_tgw_directconnect.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_directconnect.go
@@ -77,13 +77,24 @@ func resourceAviatrixAWSTgwDirectConnectCreate(d *schema.ResourceData, meta inte
 		awsTgwDirectConnect.LearnedCidrsApproval = "no"
 	}
 
+	d.SetId(awsTgwDirectConnect.TgwName + "~" + awsTgwDirectConnect.DxGatewayID)
+	flag := false
+	defer resourceAviatrixAWSTgwDirectConnectReadIfRequired(d, meta, &flag)
+
 	err := client.CreateAwsTgwDirectConnect(awsTgwDirectConnect)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix AWS TGW Direct Connect: %s", err)
 	}
 
-	d.SetId(awsTgwDirectConnect.TgwName + "~" + awsTgwDirectConnect.DxGatewayID)
-	return resourceAviatrixAWSTgwDirectConnectRead(d, meta)
+	return resourceAviatrixAWSTgwDirectConnectReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAWSTgwDirectConnectReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAWSTgwDirectConnectRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixAWSTgwDirectConnectRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_aws_tgw_peering.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_peering.go
@@ -45,13 +45,24 @@ func resourceAviatrixAWSTgwPeeringCreate(d *schema.ResourceData, meta interface{
 
 	log.Printf("[INFO] Creating Aviatrix AWS tgw peering: %#v", awsTgwPeering)
 
+	d.SetId(awsTgwPeering.TgwName1 + "~" + awsTgwPeering.TgwName2)
+	flag := false
+	defer resourceAviatrixAWSTgwPeeringReadIfRequired(d, meta, &flag)
+
 	err := client.CreateAwsTgwPeering(awsTgwPeering)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix AWS tgw peering: %s", err)
 	}
 
-	d.SetId(awsTgwPeering.TgwName1 + "~" + awsTgwPeering.TgwName2)
-	return resourceAviatrixAWSTgwPeeringRead(d, meta)
+	return resourceAviatrixAWSTgwPeeringReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAWSTgwPeeringReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAWSTgwPeeringRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixAWSTgwPeeringRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_aws_tgw_peering_domain_conn.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_peering_domain_conn.go
@@ -59,13 +59,24 @@ func resourceAviatrixAWSTgwPeeringDomainConnCreate(d *schema.ResourceData, meta 
 
 	log.Printf("[INFO] Creating Aviatrix domain connection between tgw: %s and %s", domainConn.TgwName1, domainConn.TgwName2)
 
+	d.SetId(domainConn.TgwName1 + ":" + domainConn.DomainName1 + "~" + domainConn.TgwName2 + ":" + domainConn.DomainName2)
+	flag := false
+	defer resourceAviatrixAWSTgwPeeringDomainConnReadIfRequired(d, meta, &flag)
+
 	err := client.CreateDomainConn(domainConn)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix domain connection between two tgws: %s", err)
 	}
 
-	d.SetId(domainConn.TgwName1 + ":" + domainConn.DomainName1 + "~" + domainConn.TgwName2 + ":" + domainConn.DomainName2)
-	return resourceAviatrixAWSTgwPeeringDomainConnRead(d, meta)
+	return resourceAviatrixAWSTgwPeeringDomainConnReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAWSTgwPeeringDomainConnReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAWSTgwPeeringDomainConnRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixAWSTgwPeeringDomainConnRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_aws_tgw_transit_gateway_attachment.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_transit_gateway_attachment.go
@@ -64,13 +64,24 @@ func resourceAviatrixAwsTgwTransitGatewayAttachmentCreate(d *schema.ResourceData
 		TransitGatewayName: d.Get("transit_gateway_name").(string),
 	}
 
+	d.SetId(awsTgwTransitGwAttachment.TgwName + "~" + awsTgwTransitGwAttachment.VpcID)
+	flag := false
+	defer resourceAviatrixAwsTgwTransitGatewayAttachmentReadIfRequired(d, meta, &flag)
+
 	err := client.CreateAwsTgwTransitGwAttachment(awsTgwTransitGwAttachment)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix AWS tgw transit gateway Attachment: %s", err)
 	}
 
-	d.SetId(awsTgwTransitGwAttachment.TgwName + "~" + awsTgwTransitGwAttachment.VpcID)
-	return resourceAviatrixAwsTgwTransitGatewayAttachmentRead(d, meta)
+	return resourceAviatrixAwsTgwTransitGatewayAttachmentReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAwsTgwTransitGatewayAttachmentReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAwsTgwTransitGatewayAttachmentRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixAwsTgwTransitGatewayAttachmentRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment.go
@@ -120,17 +120,15 @@ func resourceAviatrixAwsTgwVpcAttachmentCreate(d *schema.ResourceData, meta inte
 
 	log.Printf("[INFO] Attaching vpc: %s to tgw %s", awsTgwVpcAttachment.VpcID, awsTgwVpcAttachment.TgwName)
 
+	d.SetId(awsTgwVpcAttachment.TgwName + "~" + awsTgwVpcAttachment.SecurityDomainName + "~" + awsTgwVpcAttachment.VpcID)
 	flag := false
+	defer resourceAviatrixAwsTgwVpcAttachmentReadIfRequired(d, meta, &flag)
 
 	if isFirewallSecurityDomain {
 		err = client.CreateAwsTgwVpcAttachmentForFireNet(awsTgwVpcAttachment)
 		if err != nil {
 			return fmt.Errorf("failed to create Aviatrix Aws Tgw Vpc Attach for FireNet: %s", err)
 		}
-
-		d.SetId(awsTgwVpcAttachment.TgwName + "~" + awsTgwVpcAttachment.SecurityDomainName + "~" + awsTgwVpcAttachment.VpcID)
-
-		defer resourceAviatrixAwsTgwVpcAttachmentReadIfRequired(d, meta, &flag)
 
 		if awsTgwVpcAttachment.EdgeAttachment != "" {
 			err = client.UpdateFirewallAttachmentAccessFromOnprem(awsTgwVpcAttachment)
@@ -147,8 +145,6 @@ func resourceAviatrixAwsTgwVpcAttachmentCreate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return fmt.Errorf("failed to create Aviatrix Aws Tgw Vpc Attach: %s", err)
 		}
-
-		d.SetId(awsTgwVpcAttachment.TgwName + "~" + awsTgwVpcAttachment.SecurityDomainName + "~" + awsTgwVpcAttachment.VpcID)
 	}
 
 	return resourceAviatrixAwsTgwVpcAttachmentReadIfRequired(d, meta, &flag)

--- a/aviatrix/resource_aviatrix_azure_peer.go
+++ b/aviatrix/resource_aviatrix_azure_peer.go
@@ -85,13 +85,24 @@ func resourceAviatrixAzurePeerCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Creating Aviatrix Azure peer: %#v", azurePeer)
 
+	d.SetId(azurePeer.VNet1 + "~" + azurePeer.VNet2)
+	flag := false
+	defer resourceAviatrixAzurePeerReadIfRequired(d, meta, &flag)
+
 	err := client.CreateAzurePeer(azurePeer)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Azure Peer: %s", err)
 	}
 
-	d.SetId(azurePeer.VNet1 + "~" + azurePeer.VNet2)
-	return resourceAviatrixAzurePeerRead(d, meta)
+	return resourceAviatrixAzurePeerReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAzurePeerReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAzurePeerRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixAzurePeerRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_azure_spoke_native_peering.go
+++ b/aviatrix/resource_aviatrix_azure_spoke_native_peering.go
@@ -59,13 +59,24 @@ func resourceAviatrixAzureSpokeNativePeeringCreate(d *schema.ResourceData, meta 
 
 	log.Printf("[INFO] Creating Aviatrix Azure spoke native peering: %#v", azureSpokeNativePeering)
 
+	d.SetId(azureSpokeNativePeering.TransitGatewayName + "~" + azureSpokeNativePeering.SpokeAccountName + "~" + azureSpokeNativePeering.SpokeVpcID)
+	flag := false
+	defer resourceAviatrixAzureSpokeNativePeeringReadIfRequired(d, meta, &flag)
+
 	err := client.CreateAzureSpokeNativePeering(azureSpokeNativePeering)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Azure spoke native peering: %s", err)
 	}
 
-	d.SetId(azureSpokeNativePeering.TransitGatewayName + "~" + azureSpokeNativePeering.SpokeAccountName + "~" + azureSpokeNativePeering.SpokeVpcID)
-	return resourceAviatrixAzureSpokeNativePeeringRead(d, meta)
+	return resourceAviatrixAzureSpokeNativePeeringReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAzureSpokeNativePeeringReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAzureSpokeNativePeeringRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixAzureSpokeNativePeeringRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_azure_vng_conn.go
+++ b/aviatrix/resource_aviatrix_azure_vng_conn.go
@@ -61,11 +61,22 @@ func resourceAviatrixAzureVngConnCreate(d *schema.ResourceData, meta interface{}
 
 	azureVngConn := marshalAzureVngConnInput(d)
 
+	d.SetId(azureVngConn.ConnectionName)
+	flag := false
+	defer resourceAviatrixAzureVngConnReadIfRequired(d, meta, &flag)
+
 	if err := client.ConnectAzureVng(azureVngConn); err != nil {
 		return fmt.Errorf("could not connect to azure vng: %v", err)
 	}
 
-	d.SetId(azureVngConn.ConnectionName)
+	return resourceAviatrixAzureVngConnReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixAzureVngConnReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixAzureVngConnRead(d, meta)
+	}
 	return nil
 }
 

--- a/aviatrix/resource_aviatrix_firewall_management_access.go
+++ b/aviatrix/resource_aviatrix_firewall_management_access.go
@@ -45,13 +45,24 @@ func resourceAviatrixFirewallManagementAccessCreate(d *schema.ResourceData, meta
 
 	log.Printf("[INFO] Creating Aviatrix firewall management access: %#v", firewallManagementAccess)
 
+	d.SetId(firewallManagementAccess.TransitFireNetGatewayName + "~" + firewallManagementAccess.ManagementAccessResourceName)
+	flag := false
+	defer resourceAviatrixFirewallManagementAccessReadIfRequired(d, meta, &flag)
+
 	err := client.CreateFirewallManagementAccess(firewallManagementAccess)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix firewall management access: %s", err)
 	}
 
-	d.SetId(firewallManagementAccess.TransitFireNetGatewayName + "~" + firewallManagementAccess.ManagementAccessResourceName)
-	return resourceAviatrixFirewallManagementAccessRead(d, meta)
+	return resourceAviatrixFirewallManagementAccessReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixFirewallManagementAccessReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixFirewallManagementAccessRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixFirewallManagementAccessRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_firewall_policy.go
+++ b/aviatrix/resource_aviatrix_firewall_policy.go
@@ -107,11 +107,22 @@ func resourceAviatrixFirewallPolicyCreate(d *schema.ResourceData, meta interface
 
 	fw := marshalFirewallPolicyInput(d)
 
+	d.SetId(getFirewallPolicyID(fw))
+	flag := false
+	defer resourceAviatrixFirewallPolicyReadIfRequired(d, meta, &flag)
+
 	if err := client.AddFirewallPolicy(fw); err != nil {
 		return err
 	}
 
-	d.SetId(getFirewallPolicyID(fw))
+	return resourceAviatrixFirewallPolicyReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixFirewallPolicyReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixFirewallPolicyRead(d, meta)
+	}
 	return nil
 }
 

--- a/aviatrix/resource_aviatrix_fqdn.go
+++ b/aviatrix/resource_aviatrix_fqdn.go
@@ -133,15 +133,14 @@ func resourceAviatrixFQDNCreate(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[INFO] Creating Aviatrix FQDN: %#v", fqdn)
 
+	d.SetId(fqdn.FQDNTag)
+	flag := false
+	defer resourceAviatrixFQDNReadIfRequired(d, meta, &flag)
+
 	err := client.CreateFQDN(fqdn)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix FQDN: %s", err)
 	}
-
-	d.SetId(fqdn.FQDNTag)
-
-	flag := false
-	defer resourceAviatrixFQDNReadIfRequired(d, meta, &flag)
 
 	if hasSetDomainNames && enabledInlineDomainNames {
 		names := d.Get("domain_names").([]interface{})
@@ -492,7 +491,8 @@ func resourceAviatrixFQDNUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.Partial(false)
-	return nil
+	d.SetId(fqdn.FQDNTag)
+	return resourceAviatrixFQDNRead(d, meta)
 }
 
 func resourceAviatrixFQDNDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_fqdn_pass_through.go
+++ b/aviatrix/resource_aviatrix_fqdn_pass_through.go
@@ -54,7 +54,7 @@ func resourceAviatrixFQDNPassThroughCreate(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(gw.GwName)
-	return nil
+	return resourceAviatrixFQDNPassThroughRead(d, meta)
 }
 
 func resourceAviatrixFQDNPassThroughRead(d *schema.ResourceData, meta interface{}) error {
@@ -97,8 +97,9 @@ func resourceAviatrixFQDNPassThroughRead(d *schema.ResourceData, meta interface{
 func resourceAviatrixFQDNPassThroughUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 
+	gw := &goaviatrix.Gateway{GwName: d.Get("gw_name").(string)}
+
 	if d.HasChange("pass_through_cidrs") {
-		gw := &goaviatrix.Gateway{GwName: d.Get("gw_name").(string)}
 		var cidrs []string
 		for _, v := range d.Get("pass_through_cidrs").(*schema.Set).List() {
 			cidrs = append(cidrs, v.(string))
@@ -108,7 +109,8 @@ func resourceAviatrixFQDNPassThroughUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	return nil
+	d.SetId(gw.GwName)
+	return resourceAviatrixFQDNPassThroughRead(d, meta)
 }
 
 func resourceAviatrixFQDNPassThroughDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -957,6 +957,10 @@ func resourceAviatrixGatewayCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Creating Aviatrix gateway: %#v", gateway)
 
+	d.SetId(gateway.GwName)
+	flag := false
+	defer resourceAviatrixGatewayReadIfRequired(d, meta, &flag)
+
 	if d.Get("enable_public_subnet_filtering").(bool) {
 		err := client.CreatePublicSubnetFilteringGateway(gateway)
 		if err != nil {
@@ -976,11 +980,6 @@ func resourceAviatrixGatewayCreate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("failed to create Aviatrix gateway: %s", err)
 		}
 	}
-
-	d.SetId(gateway.GwName)
-
-	flag := false
-	defer resourceAviatrixGatewayReadIfRequired(d, meta, &flag)
 
 	if customerManagedKeys != "" && enableEncryptVolume {
 		gwEncVolume := &goaviatrix.Gateway{

--- a/aviatrix/resource_aviatrix_gateway_dnat.go
+++ b/aviatrix/resource_aviatrix_gateway_dnat.go
@@ -147,13 +147,25 @@ func resourceAviatrixGatewayDNatCreate(d *schema.ResourceData, meta interface{})
 			gateway.DnatPolicy = append(gateway.DnatPolicy, *customPolicy)
 		}
 	}
+
+	d.SetId(gateway.GatewayName)
+	flag := false
+	defer resourceAviatrixGatewayDNatReadIfRequired(d, meta, &flag)
+
 	err := client.UpdateDNat(gateway)
 	if err != nil {
 		return fmt.Errorf("failed to update DNAT for gateway(name: %s) due to: %s", gateway.GatewayName, err)
 	}
 
-	d.SetId(gateway.GatewayName)
-	return resourceAviatrixGatewayDNatRead(d, meta)
+	return resourceAviatrixGatewayDNatReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixGatewayDNatReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixGatewayDNatRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixGatewayDNatRead(d *schema.ResourceData, meta interface{}) error {
@@ -262,7 +274,7 @@ func resourceAviatrixGatewayDNatUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	d.Partial(false)
-	d.SetId(d.Get("gw_name").(string))
+	d.SetId(gateway.GatewayName)
 	return resourceAviatrixGatewayDNatRead(d, meta)
 }
 

--- a/aviatrix/resource_aviatrix_gateway_snat.go
+++ b/aviatrix/resource_aviatrix_gateway_snat.go
@@ -157,13 +157,25 @@ func resourceAviatrixGatewaySNatCreate(d *schema.ResourceData, meta interface{})
 			gateway.SnatPolicy = append(gateway.SnatPolicy, *customPolicy)
 		}
 	}
+
+	d.SetId(gateway.GatewayName)
+	flag := false
+	defer resourceAviatrixGatewaySNatReadIfRequired(d, meta, &flag)
+
 	err := client.EnableSNat(gateway)
 	if err != nil {
 		return fmt.Errorf("failed to configure policies for 'customized_snat' mode due to: %s", err)
 	}
 
-	d.SetId(gateway.GatewayName)
-	return resourceAviatrixGatewaySNatRead(d, meta)
+	return resourceAviatrixGatewaySNatReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixGatewaySNatReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixGatewaySNatRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixGatewaySNatRead(d *schema.ResourceData, meta interface{}) error {
@@ -292,7 +304,7 @@ func resourceAviatrixGatewaySNatUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	d.Partial(false)
-	d.SetId(d.Get("gw_name").(string))
+	d.SetId(gateway.GatewayName)
 	return resourceAviatrixGatewaySNatRead(d, meta)
 }
 

--- a/aviatrix/resource_aviatrix_geo_vpn.go
+++ b/aviatrix/resource_aviatrix_geo_vpn.go
@@ -79,16 +79,15 @@ func resourceAviatrixGeoVPNCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("please specify 'elb_dns_names' to enable Aviatrix Geo VPN")
 	}
 
+	d.SetId(geoVPN.ServiceName + "~" + geoVPN.DomainName)
+	flag := false
+	defer resourceAviatrixGeoVPNReadIfRequired(d, meta, &flag)
+
 	geoVPN.ElbDNSName = elbDNSNames[0]
 	err := client.EnableGeoVPN(geoVPN)
 	if err != nil {
 		return fmt.Errorf("failed to enable Aviatrix Geo VPN due to: %s", err)
 	}
-
-	d.SetId(geoVPN.ServiceName + "~" + geoVPN.DomainName)
-
-	flag := false
-	defer resourceAviatrixGeoVPNReadIfRequired(d, meta, &flag)
 
 	for i := 1; i < len(elbDNSNames); i++ {
 		geoVPN.ElbDNSName = elbDNSNames[i]

--- a/aviatrix/resource_aviatrix_periodic_ping.go
+++ b/aviatrix/resource_aviatrix_periodic_ping.go
@@ -56,11 +56,22 @@ func resourceAviatrixPeriodicPingCreate(d *schema.ResourceData, meta interface{}
 
 	pp := marshalPeriodicPingInput(d)
 
+	d.SetId(pp.GwName)
+	flag := false
+	defer resourceAviatrixPeriodicPingReadIfRequired(d, meta, &flag)
+
 	if err := client.CreatePeriodicPing(pp); err != nil {
 		return err
 	}
 
-	d.SetId(pp.GwName)
+	return resourceAviatrixPeriodicPingReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixPeriodicPingReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixPeriodicPingRead(d, meta)
+	}
 	return nil
 }
 

--- a/aviatrix/resource_aviatrix_rbac_group.go
+++ b/aviatrix/resource_aviatrix_rbac_group.go
@@ -45,15 +45,17 @@ func resourceAviatrixRbacGroupCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Creating Aviatrix RBAC permission group: %#v", group)
 
+	d.SetId(group.GroupName)
+	flag := false
+	defer resourceAviatrixRbacGroupReadIfRequired(d, meta, &flag)
+
 	err := client.CreatePermissionGroup(group)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix RBAC permission group: %s", err)
 	}
 
 	log.Printf("[DEBUG] Aviatrix RBAC permission group %s created", group.GroupName)
-	d.SetId(group.GroupName)
-	flag := false
-	defer resourceAviatrixRbacGroupReadIfRequired(d, meta, &flag)
+
 	if d.Get("local_login").(bool) {
 		err := client.EnableLocalLoginForRBACGroup(groupName)
 		if err != nil {

--- a/aviatrix/resource_aviatrix_rbac_group_access_account_attachment.go
+++ b/aviatrix/resource_aviatrix_rbac_group_access_account_attachment.go
@@ -45,6 +45,10 @@ func resourceAviatrixRbacGroupAccessAccountAttachmentCreate(d *schema.ResourceDa
 
 	log.Printf("[INFO] Creating Aviatrix RBAC permission group access account attachment: %#v", attachment)
 
+	d.SetId(attachment.GroupName + "~" + attachment.AccessAccountName)
+	flag := false
+	defer resourceAviatrixRbacGroupAccessAccountAttachmentReadIfRequired(d, meta, &flag)
+
 	err := client.CreateRbacGroupAccessAccountAttachment(attachment)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix RBAC permission group access account attachment: %s", err)
@@ -52,8 +56,15 @@ func resourceAviatrixRbacGroupAccessAccountAttachmentCreate(d *schema.ResourceDa
 
 	log.Printf("[DEBUG] Aviatrix RBAC permission group access account attachment created")
 
-	d.SetId(attachment.GroupName + "~" + attachment.AccessAccountName)
-	return resourceAviatrixRbacGroupAccessAccountAttachmentRead(d, meta)
+	return resourceAviatrixRbacGroupAccessAccountAttachmentReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixRbacGroupAccessAccountAttachmentReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixRbacGroupAccessAccountAttachmentRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixRbacGroupAccessAccountAttachmentRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_rbac_group_permission_attachment.go
+++ b/aviatrix/resource_aviatrix_rbac_group_permission_attachment.go
@@ -63,6 +63,10 @@ func resourceAviatrixRbacGroupPermissionAttachmentCreate(d *schema.ResourceData,
 
 	log.Printf("[INFO] Creating Aviatrix RBAC group permission attachment: %#v", attachment)
 
+	d.SetId(attachment.GroupName + "~" + attachment.PermissionName)
+	flag := false
+	defer resourceAviatrixRbacGroupPermissionAttachmentReadIfRequired(d, meta, &flag)
+
 	err := client.CreateRbacGroupPermissionAttachment(attachment)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix RBAC group permission attachment: %s", err)
@@ -70,8 +74,15 @@ func resourceAviatrixRbacGroupPermissionAttachmentCreate(d *schema.ResourceData,
 
 	log.Printf("[DEBUG] Aviatrix RBAC group permission attachment created")
 
-	d.SetId(attachment.GroupName + "~" + attachment.PermissionName)
-	return resourceAviatrixRbacGroupPermissionAttachmentRead(d, meta)
+	return resourceAviatrixRbacGroupPermissionAttachmentReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixRbacGroupPermissionAttachmentReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixRbacGroupPermissionAttachmentRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixRbacGroupPermissionAttachmentRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_rbac_group_user_attachment.go
+++ b/aviatrix/resource_aviatrix_rbac_group_user_attachment.go
@@ -45,6 +45,10 @@ func resourceAviatrixRbacGroupUserAttachmentCreate(d *schema.ResourceData, meta 
 
 	log.Printf("[INFO] Creating Aviatrix RBAC permission group user attachment: %#v", attachment)
 
+	d.SetId(attachment.GroupName + "~" + attachment.UserName)
+	flag := false
+	defer resourceAviatrixRbacGroupUserAttachmentReadIfRequired(d, meta, &flag)
+
 	err := client.CreateRbacGroupUserAttachment(attachment)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix RBAC permission group user attachment: %s", err)
@@ -52,8 +56,15 @@ func resourceAviatrixRbacGroupUserAttachmentCreate(d *schema.ResourceData, meta 
 
 	log.Printf("[DEBUG] Aviatrix RBAC permission group user attachment created")
 
-	d.SetId(attachment.GroupName + "~" + attachment.UserName)
-	return resourceAviatrixRbacGroupUserAttachmentRead(d, meta)
+	return resourceAviatrixRbacGroupUserAttachmentReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixRbacGroupUserAttachmentReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixRbacGroupUserAttachmentRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixRbacGroupUserAttachmentRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_saml_endpoint.go
+++ b/aviatrix/resource_aviatrix_saml_endpoint.go
@@ -101,13 +101,25 @@ func resourceAviatrixSamlEndpointCreate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
+
+	d.SetId(samlEndpoint.EndPointName)
+	flag := false
+	defer resourceAviatrixSamlEndpointReadIfRequired(d, meta, &flag)
+
 	err = client.CreateSamlEndpoint(samlEndpoint)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix SAML endpoint: %s", err)
 	}
 
-	d.SetId(samlEndpoint.EndPointName)
-	return resourceAviatrixSamlEndpointRead(d, meta)
+	return resourceAviatrixSamlEndpointReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixSamlEndpointReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixSamlEndpointRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixSamlEndpointRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_segmentation_security_domain.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain.go
@@ -39,11 +39,22 @@ func resourceAviatrixSegmentationSecurityDomainCreate(d *schema.ResourceData, me
 
 	domain := marshalSegmentationSecurityDomainInput(d)
 
+	d.SetId(domain.DomainName)
+	flag := false
+	defer resourceAviatrixSegmentationSecurityDomainReadIfRequired(d, meta, &flag)
+
 	if err := client.CreateSegmentationSecurityDomain(domain); err != nil {
 		return fmt.Errorf("could not create security domain: %v", err)
 	}
 
-	d.SetId(domain.DomainName)
+	return resourceAviatrixSegmentationSecurityDomainReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixSegmentationSecurityDomainReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixSegmentationSecurityDomainRead(d, meta)
+	}
 	return nil
 }
 

--- a/aviatrix/resource_aviatrix_segmentation_security_domain_association.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain_association.go
@@ -54,13 +54,22 @@ func resourceAviatrixSegmentationSecurityDomainAssociationCreate(d *schema.Resou
 
 	association := marshalSegmentationSecurityDomainAssociationInput(d)
 
+	d.SetId(association.TransitGatewayName + "~" + association.SecurityDomainName + "~" + association.AttachmentName)
+	flag := false
+	defer resourceAviatrixSegmentationSecurityDomainAssociationReadIfRequired(d, meta, &flag)
+
 	if err := client.CreateSegmentationSecurityDomainAssociation(association); err != nil {
 		return fmt.Errorf("could not create segmentation security domain association: %v", err)
 	}
 
-	id := association.TransitGatewayName + "~" + association.SecurityDomainName + "~" + association.AttachmentName
-	d.SetId(id)
+	return resourceAviatrixSegmentationSecurityDomainAssociationReadIfRequired(d, meta, &flag)
+}
 
+func resourceAviatrixSegmentationSecurityDomainAssociationReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixSegmentationSecurityDomainAssociationRead(d, meta)
+	}
 	return nil
 }
 

--- a/aviatrix/resource_aviatrix_segmentation_security_domain_connection_policy.go
+++ b/aviatrix/resource_aviatrix_segmentation_security_domain_connection_policy.go
@@ -51,12 +51,22 @@ func resourceAviatrixSegmentationSecurityDomainConnectionPolicyCreate(d *schema.
 
 	policy := marshalSegmentationSecurityDomainConnectionPolicyInput(d)
 
+	d.SetId(policy.Domain1.DomainName + "~" + policy.Domain2.DomainName)
+	flag := false
+	defer resourceAviatrixSegmentationSecurityDomainConnectionPolicyReadIfRequired(d, meta, &flag)
+
 	if err := client.CreateSegmentationSecurityDomainConnectionPolicy(policy); err != nil {
 		return fmt.Errorf("could not create security domain connection policy: %v", err)
 	}
 
-	id := policy.Domain1.DomainName + "~" + policy.Domain2.DomainName
-	d.SetId(id)
+	return resourceAviatrixSegmentationSecurityDomainConnectionPolicyReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixSegmentationSecurityDomainConnectionPolicyReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixSegmentationSecurityDomainConnectionPolicyRead(d, meta)
+	}
 	return nil
 }
 

--- a/aviatrix/resource_aviatrix_site2cloud.go
+++ b/aviatrix/resource_aviatrix_site2cloud.go
@@ -605,15 +605,14 @@ func resourceAviatrixSite2CloudCreate(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[INFO] Creating Aviatrix Site2Cloud: %#v", s2c)
 
+	d.SetId(s2c.TunnelName + "~" + s2c.VpcID)
+	flag := false
+	defer resourceAviatrixSite2CloudReadIfRequired(d, meta, &flag)
+
 	err := client.CreateSite2Cloud(s2c)
 	if err != nil {
 		return fmt.Errorf("failed Site2Cloud create: %s", err)
 	}
-
-	d.SetId(s2c.TunnelName + "~" + s2c.VpcID)
-
-	flag := false
-	defer resourceAviatrixSite2CloudReadIfRequired(d, meta, &flag)
 
 	enableDeadPeerDetection := d.Get("enable_dead_peer_detection").(bool)
 	if !enableDeadPeerDetection {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -745,15 +745,14 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[INFO] Creating Aviatrix Spoke Gateway: %#v", gateway)
 
+	d.SetId(gateway.GwName)
+	flag := false
+	defer resourceAviatrixSpokeGatewayReadIfRequired(d, meta, &flag)
+
 	err := client.LaunchSpokeVpc(gateway)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Spoke Gateway: %s", err)
 	}
-
-	d.SetId(gateway.GwName)
-
-	flag := false
-	defer resourceAviatrixSpokeGatewayReadIfRequired(d, meta, &flag)
 
 	if customerManagedKeys != "" && enableEncryptVolume {
 		gwEncVolume := &goaviatrix.Gateway{

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -48,12 +48,24 @@ func resourceAviatrixSpokeTransitAttachmentCreate(d *schema.ResourceData, meta i
 	client := meta.(*goaviatrix.Client)
 
 	attachment := marshalSpokeTransitAttachmentInput(d)
+
+	d.SetId(attachment.SpokeGwName + "~" + attachment.TransitGwName)
+	flag := false
+	defer resourceAviatrixSpokeTransitAttachmentReadIfRequired(d, meta, &flag)
+
 	if err := client.CreateSpokeTransitAttachment(attachment); err != nil {
 		return fmt.Errorf("could not attach spoke: %s to transit %s: %v", attachment.SpokeGwName, attachment.TransitGwName, err)
 	}
 
-	d.SetId(attachment.SpokeGwName + "~" + attachment.TransitGwName)
-	return resourceAviatrixSpokeTransitAttachmentRead(d, meta)
+	return resourceAviatrixSpokeTransitAttachmentReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixSpokeTransitAttachmentReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixSpokeTransitAttachmentRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixSpokeTransitAttachmentRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_trans_peer.go
+++ b/aviatrix/resource_aviatrix_trans_peer.go
@@ -52,13 +52,24 @@ func resourceAviatrixTransPeerCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Creating Aviatrix transitive peering: %#v", transPeer)
 
+	d.SetId(transPeer.Source + "~" + transPeer.Nexthop + "~" + transPeer.ReachableCidr)
+	flag := false
+	defer resourceAviatrixTransPeerReadIfRequired(d, meta, &flag)
+
 	err := client.CreateTransPeer(transPeer)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Transitive peering: %s", err)
 	}
 
-	d.SetId(transPeer.Source + "~" + transPeer.Nexthop + "~" + transPeer.ReachableCidr)
-	return resourceAviatrixTransPeerRead(d, meta)
+	return resourceAviatrixTransPeerReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixTransPeerReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixTransPeerRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixTransPeerRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_transit_firenet_policy.go
+++ b/aviatrix/resource_aviatrix_transit_firenet_policy.go
@@ -45,13 +45,24 @@ func resourceAviatrixTransitFireNetPolicyCreate(d *schema.ResourceData, meta int
 
 	log.Printf("[INFO] Creating Aviatrix transit firenet policy: %#v", transitFireNetPolicy)
 
+	d.SetId(transitFireNetPolicy.TransitFireNetGatewayName + "~" + transitFireNetPolicy.InspectedResourceName)
+	flag := false
+	defer resourceAviatrixTransitFireNetPolicyReadIfRequired(d, meta, &flag)
+
 	err := client.CreateTransitFireNetPolicy(transitFireNetPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix transit firenet Policy: %s", err)
 	}
 
-	d.SetId(transitFireNetPolicy.TransitFireNetGatewayName + "~" + transitFireNetPolicy.InspectedResourceName)
-	return resourceAviatrixTransitFireNetPolicyRead(d, meta)
+	return resourceAviatrixTransitFireNetPolicyReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixTransitFireNetPolicyReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixTransitFireNetPolicyRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixTransitFireNetPolicyRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -947,15 +947,14 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 	log.Printf("[INFO] Creating Aviatrix Transit Gateway: %#v", gateway)
 
+	d.SetId(gateway.GwName)
+	flag := false
+	defer resourceAviatrixTransitGatewayReadIfRequired(d, meta, &flag)
+
 	err := client.LaunchTransitVpc(gateway)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Transit Gateway: %s", err)
 	}
-
-	d.SetId(gateway.GwName)
-
-	flag := false
-	defer resourceAviatrixTransitGatewayReadIfRequired(d, meta, &flag)
 
 	if customerManagedKeys != "" && enableEncryptVolume {
 		gwEncVolume := &goaviatrix.Gateway{

--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -171,15 +171,14 @@ func resourceAviatrixTransitGatewayPeeringCreate(d *schema.ResourceData, meta in
 
 	log.Printf("[INFO] Creating Aviatrix Transit Gateway peering: %#v", transitGatewayPeering)
 
+	d.SetId(transitGatewayPeering.TransitGatewayName1 + "~" + transitGatewayPeering.TransitGatewayName2)
+	flag := false
+	defer resourceAviatrixTransitGatewayPeeringReadIfRequired(d, meta, &flag)
+
 	err := client.CreateTransitGatewayPeering(transitGatewayPeering)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Transit Gateway peering: %s", err)
 	}
-
-	d.SetId(transitGatewayPeering.TransitGatewayName1 + "~" + transitGatewayPeering.TransitGatewayName2)
-
-	flag := false
-	defer resourceAviatrixTransitGatewayPeeringReadIfRequired(d, meta, &flag)
 
 	if _, ok := d.GetOk("prepend_as_path1"); ok {
 		var prependASPath []string

--- a/aviatrix/resource_aviatrix_tunnel.go
+++ b/aviatrix/resource_aviatrix_tunnel.go
@@ -75,13 +75,24 @@ func resourceAviatrixTunnelCreate(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[INFO] Creating Aviatrix tunnel: %#v", tunnel)
 
+	d.SetId(tunnel.VpcName1 + "~" + tunnel.VpcName2)
+	flag := false
+	defer resourceAviatrixTunnelReadIfRequired(d, meta, &flag)
+
 	err := client.CreateTunnel(tunnel)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Tunnel: %s", err)
 	}
 
-	d.SetId(tunnel.VpcName1 + "~" + tunnel.VpcName2)
-	return resourceAviatrixTunnelRead(d, meta)
+	return resourceAviatrixTunnelReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixTunnelReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixTunnelRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixTunnelRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_vpn_profile.go
+++ b/aviatrix/resource_aviatrix_vpn_profile.go
@@ -129,13 +129,24 @@ func resourceAviatrixProfileCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Creating Aviatrix Profile with Policy: %v", profile.Policy)
 
+	d.SetId(profile.Name)
+	flag := false
+	defer resourceAviatrixProfileReadIfRequired(d, meta, &flag)
+
 	err := client.CreateProfile(profile)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix Profile: %s", err)
 	}
 
-	d.SetId(profile.Name)
-	return resourceAviatrixProfileRead(d, meta)
+	return resourceAviatrixProfileReadIfRequired(d, meta, &flag)
+}
+
+func resourceAviatrixProfileReadIfRequired(d *schema.ResourceData, meta interface{}, flag *bool) error {
+	if !(*flag) {
+		*flag = true
+		return resourceAviatrixProfileRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAviatrixProfileRead(d *schema.ResourceData, meta interface{}) error {

--- a/aviatrix/resource_aviatrix_vpn_user.go
+++ b/aviatrix/resource_aviatrix_vpn_user.go
@@ -113,14 +113,15 @@ func resourceAviatrixVPNUserCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Creating Aviatrix VPN User: %#v", vpnUser)
 
-	err := client.CreateVPNUser(vpnUser)
-	if err != nil {
-		return fmt.Errorf("failed to create Aviatrix VPNUser: %s", err)
-	}
 	d.SetId(vpnUser.UserName)
 
 	flag := false
 	defer resourceAviatrixVPNUserReadIfRequired(d, meta, &flag)
+
+	err := client.CreateVPNUser(vpnUser)
+	if err != nil {
+		return fmt.Errorf("failed to create Aviatrix VPNUser: %s", err)
+	}
 
 	if manageUserAttachment && len(d.Get("profiles").([]interface{})) != 0 {
 		for _, profileName := range d.Get("profiles").([]interface{}) {


### PR DESCRIPTION
The resource will also be tainted.

resource_aviatrix_account_user.go
resource_aviatrix_aws_peer.go
resource_aviatrix_aws_tgw.go
resource_aviatrix_aws_tgw_directconnect.go
resource_aviatrix_aws_tgw_peering.go
resource_aviatrix_aws_tgw_peering_domain_conn.go
resource_aviatrix_aws_tgw_transit_gateway_attachment.go
resource_aviatrix_aws_tgw_vpc_attachment.go
resource_aviatrix_azure_peer.go
resource_aviatrix_azure_spoke_native_peering.go
resource_aviatrix_azure_vng_conn.go
resource_aviatrix_firewall.go
resource_aviatrix_firewall_instance_association.go
resource_aviatrix_firewall_management_access.go
resource_aviatrix_firewall_policy.go
resource_aviatrix_firewall_tag.go
resource_aviatrix_fqdn.go
resource_aviatrix_gateway.go
resource_aviatrix_gateway_dnat.go
resource_aviatrix_gateway_snat.go
resource_aviatrix_geo_vpn.go
resource_aviatrix_periodic_ping.go
resource_aviatrix_rbac_group.go
resource_aviatrix_rbac_group_access_account_attachment.go
resource_aviatrix_rbac_group_permission_attachment.go
resource_aviatrix_rbac_group_user_attachment.go
resource_aviatrix_saml_endpoint.go
resource_aviatrix_segmentation_security_domain.go
resource_aviatrix_segmentation_security_domain_association.go
resource_aviatrix_segmentation_security_domain_connection_policy.go
resource_aviatrix_site2cloud.go
resource_aviatrix_spoke_gateway.go
resource_aviatrix_spoke_transit_attachment.go
resource_aviatrix_trans_peer.go
resource_aviatrix_transit_external_device_conn.go
resource_aviatrix_transit_firenet_policy.go
resource_aviatrix_transit_gateway.go
resource_aviatrix_transit_gateway_peering.go
resource_aviatrix_tunnel.go
resource_aviatrix_vgw_conn.go
resource_aviatrix_vpn_profile.go
resource_aviatrix_vpn_user.go