### PR TITLE
AVX-15492: Fix acceptance tests for 6.5.b release

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ build13: fmtcheck
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=600s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -timeout=1800s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 600m

--- a/aviatrix/resource_aviatrix_account_test.go
+++ b/aviatrix/resource_aviatrix_account_test.go
@@ -172,7 +172,7 @@ func TestAccAviatrixAccount_basic(t *testing.T) {
 	var account goaviatrix.Account
 
 	rInt := acctest.RandInt()
-	importStateVerifyIgnore := []string{"aws_secret_key", "audit_account"}
+	importStateVerifyIgnore := []string{"aws_secret_key", "aws_access_key", "audit_account"}
 
 	skipAcc := os.Getenv("SKIP_ACCOUNT")
 	skipAWS := os.Getenv("SKIP_ACCOUNT_AWS")

--- a/aviatrix/resource_aviatrix_controller_config_test.go
+++ b/aviatrix/resource_aviatrix_controller_config_test.go
@@ -22,6 +22,7 @@ func TestAccAviatrixControllerConfig_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_CONTROLLER_CONFIG to yes to skip Controller Config tests"
 	resourceName := "aviatrix_controller_config.test_controller_config"
+	importStateVerifyIgnore := []string{"backup_cloud_type", "backup_configuration", "manage_gateway_upgrades", "multiple_backups"}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -42,9 +43,10 @@ func TestAccAviatrixControllerConfig_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: importStateVerifyIgnore,
 			},
 		},
 	})

--- a/aviatrix/resource_aviatrix_vgw_conn_test.go
+++ b/aviatrix/resource_aviatrix_vgw_conn_test.go
@@ -29,6 +29,7 @@ func TestAccAviatrixVGWConn_basic(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resourceName := "aviatrix_vgw_conn.test_vgw_conn"
+	importStateVerifyIgnore := []string{"enable_learned_cidrs_approval"}
 
 	skipAcc := os.Getenv("SKIP_VGW_CONN")
 	if skipAcc == "yes" {
@@ -58,9 +59,10 @@ func TestAccAviatrixVGWConn_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: importStateVerifyIgnore,
 			},
 		},
 	})

--- a/test-infra/azure/outputs.tf
+++ b/test-infra/azure/outputs.tf
@@ -7,3 +7,6 @@ output "group" {
 output "subnet" {
    value = azurerm_subnet.aviatrix.address_prefix
 }
+output "guid" {
+   value = azurerm_virtual_network.aviatrix.guid
+}

--- a/test-infra/cmdExportOutput.sh
+++ b/test-infra/cmdExportOutput.sh
@@ -3,7 +3,7 @@
 # SetEnv takes two arguments, key and value
 SetEnv () {
   echo "$1=$2"
-  export $1=$2
+  export $1="$2"
 }
 
 SetEnv ARM_APPLICATION_ID $(terraform output -raw ARM_APPLICATION_ID)
@@ -11,8 +11,8 @@ SetEnv ARM_APPLICATION_KEY $(terraform output -raw ARM_APPLICATION_KEY)
 SetEnv ARM_DIRECTORY_ID $(terraform output -raw ARM_DIRECTORY_ID)
 SetEnv ARM_SUBSCRIPTION_ID $(terraform output -raw ARM_SUBSCRIPTION_ID)
 SetEnv AZURE_GW_SIZE $(terraform output -raw AZURE_GW_SIZE)
-SetEnv AZURE_REGION $(terraform output -raw AZURE_REGION)
-SetEnv AZURE_REGION2 $(terraform output -raw AZURE_REGION2)
+SetEnv AZURE_REGION "$(terraform output -raw AZURE_REGION)"
+SetEnv AZURE_REGION2 "$(terraform output -raw AZURE_REGION2)"
 SetEnv AZURE_SUBNET $(terraform output -raw AZURE_SUBNET)
 SetEnv AZURE_SUBNET2 $(terraform output -raw AZURE_SUBNET2)
 SetEnv AZURE_VNET_ID $(terraform output -raw AZURE_VNET_ID)
@@ -71,6 +71,7 @@ SetEnv AZURE_VNG $(terraform output -raw AZURE_VNG)
 SetEnv SKIP_DATA_ACCOUNT "no"
 SetEnv SKIP_DATA_CALLER_IDENTITY "no"
 SetEnv SKIP_DATA_FIRENET "no"
+SetEnv SKIP_DATA_FIRENET_FIREWALL_MANAGER "no"
 SetEnv SKIP_DATA_FIRENET_VENDOR_INTEGRATION "no"
 SetEnv SKIP_DATA_FIREWALL "no"
 SetEnv SKIP_DATA_GATEWAY "no"
@@ -89,7 +90,7 @@ SetEnv SKIP_ACCOUNT "no"
 SetEnv SKIP_ACCOUNT_AWS "no"
 SetEnv SKIP_ACCOUNT_AZURE "no"
 SetEnv SKIP_ACCOUNT_GCP "no"
-SetEnv SKIP_ACCOUNT_OCI "yes"
+SetEnv SKIP_ACCOUNT_OCI "no"
 SetEnv SKIP_ACCOUNT_AZUREGOV "yes"
 SetEnv SKIP_ACCOUNT_AWSGOV "no"
 SetEnv SKIP_ACCOUNT_AWSCHINA_IAM "yes"
@@ -151,12 +152,13 @@ SetEnv SKIP_GATEWAY_GCP "no"
 SetEnv SKIP_GATEWAY_AZURE "no"
 SetEnv SKIP_GATEWAY_OCI "yes"
 SetEnv SKIP_GATEWAY_AWSGOV "yes"
+SetEnv SKIP_GATEWAY_CERTIFICATE_CONFIG "no"
 SetEnv SKIP_GATEWAY_DNAT "no"
 SetEnv SKIP_GATEWAY_DNAT_AWS "no"
 SetEnv SKIP_GATEWAY_DNAT_AZURE "no"
 SetEnv SKIP_GATEWAY_SNAT "no"
 SetEnv SKIP_GATEWAY_SNAT_AWS "no"
-SetEnv SKIP_GATEWAY_SNAT_AZURE "yes"
+SetEnv SKIP_GATEWAY_SNAT_AZURE "no"
 SetEnv SKIP_GEO_VPN "no"
 SetEnv SKIP_NETFLOW_AGENT "no"
 SetEnv SKIP_PERIODIC_PING "no"

--- a/test-infra/outputs.tf
+++ b/test-infra/outputs.tf
@@ -79,7 +79,7 @@ output "AZURE_REGION" {
 }
 
 output "AZURE_VNET_ID" {
-  value = "${module.aviatrix_azure_vpc1.vnet}:${module.aviatrix_azure_vpc1.group}"
+  value = "${module.aviatrix_azure_vpc1.vnet}:${module.aviatrix_azure_vpc1.group}:${module.aviatrix_azure_vpc1.guid}"
 }
 
 output "AZURE_SUBNET" {
@@ -91,7 +91,7 @@ output "AZURE_REGION2" {
 }
 
 output "AZURE_VNET_ID2" {
-  value = "${module.aviatrix_azure_vpc2.vnet}:${module.aviatrix_azure_vpc2.group}"
+  value = "${module.aviatrix_azure_vpc2.vnet}:${module.aviatrix_azure_vpc2.group}:${module.aviatrix_azure_vpc2.guid}"
 }
 
 output "AZURE_SUBNET2" {


### PR DESCRIPTION
1. resource_aviatrix_account_test.go
2. resource_aviatrix_controller_config_test.go
3. resource_aviatrix_vgw_conn_test.go
4. Fix the format change for Azure VPC ID from 2-tuple to 3-tuple
5. Change single resource test timeout from 600s to 1800