### PR TITLE
Revert "AVX-14725: allow using 2 rmt gw ip when ha disabled and suppress diff"

### DIFF
--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -47,19 +47,6 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Description: "Remote Gateway IP.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					oldIpList := strings.Split(old, ",")
-					newIpList := strings.Split(new, ",")
-					if len(oldIpList) == len(newIpList) {
-						for i := range oldIpList {
-							if strings.TrimSpace(oldIpList[i]) != strings.TrimSpace(newIpList[i]) {
-								return false
-							}
-						}
-						return true
-					}
-					return false
-				},
 			},
 			"connection_type": {
 				Type:        schema.TypeString,
@@ -556,6 +543,8 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 	ph1RemoteIdList := goaviatrix.ExpandStringList(phase1RemoteIdentifier)
 	if haEnabled && len(ph1RemoteIdList) != 0 && len(ph1RemoteIdList) != 2 {
 		return fmt.Errorf("please either set two phase 1 remote IDs or none, when HA is enabled")
+	} else if !haEnabled && len(phase1RemoteIdentifier) > 1 {
+		return fmt.Errorf("please either set one phase 1 remote ID or none, when HA is disabled")
 	}
 
 	if _, ok := d.GetOk("prepend_as_path"); ok {
@@ -929,6 +918,8 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 		ph1RemoteIdList := goaviatrix.ExpandStringList(phase1RemoteIdentifier)
 		if haEnabled && len(ph1RemoteIdList) != 0 && len(ph1RemoteIdList) != 2 {
 			return fmt.Errorf("please either set two phase 1 remote IDs or none, when HA is enabled")
+		} else if !haEnabled && len(phase1RemoteIdentifier) > 1 {
+			return fmt.Errorf("please either set one phase 1 remote ID or none, when HA is disabled")
 		}
 
 		if len(ph1RemoteIdList) == 0 && haEnabled {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -287,7 +287,6 @@ func TransitExternalDeviceConnPh1RemoteIdDiffSuppressFunc(k, old, new string, d 
 	}
 
 	ip := d.Get("remote_gateway_ip").(string)
-	ipList := strings.Split(ip, ",")
 	haip := d.Get("backup_remote_gateway_ip").(string)
 	o, n := d.GetChange("phase1_remote_identifier")
 	haEnabled := d.Get("ha_enabled").(bool)
@@ -300,30 +299,24 @@ func TransitExternalDeviceConnPh1RemoteIdDiffSuppressFunc(k, old, new string, d 
 			if len(ph1RemoteIdListNew) != 2 || len(ph1RemoteIdListOld) != 2 {
 				return false
 			}
-			return ph1RemoteIdListOld[0] == ipList[0] && ph1RemoteIdListNew[0] == ipList[0] &&
+			return ph1RemoteIdListOld[0] == ip && ph1RemoteIdListNew[0] == ip &&
 				strings.TrimSpace(ph1RemoteIdListOld[1]) == haip && strings.TrimSpace(ph1RemoteIdListNew[1]) == haip
 		} else {
-			if len(ph1RemoteIdListNew) == 1 && len(ph1RemoteIdListOld) == 1 {
-				return ph1RemoteIdListOld[0] == ipList[0] && ph1RemoteIdListNew[0] == ipList[0]
-			} else if len(ph1RemoteIdListNew) == 2 && len(ph1RemoteIdListOld) == 2 && len(ipList) == 2 {
-				return strings.TrimSpace(ph1RemoteIdListOld[0]) == strings.TrimSpace(ipList[0]) &&
-					strings.TrimSpace(ph1RemoteIdListOld[1]) == strings.TrimSpace(ipList[1]) &&
-					strings.TrimSpace(ph1RemoteIdListNew[0]) == strings.TrimSpace(ipList[0]) &&
-					strings.TrimSpace(ph1RemoteIdListNew[1]) == strings.TrimSpace(ipList[1])
-			} else {
+			if len(ph1RemoteIdListNew) != 1 {
 				return false
 			}
+			return ph1RemoteIdListOld[0] == ip && ph1RemoteIdListNew[0] == ip
 		}
 	}
 
 	if !haEnabled {
-		if len(ph1RemoteIdListOld) == 1 && ph1RemoteIdListOld[0] == ipList[0] && len(ph1RemoteIdListNew) == 0 {
+		if len(ph1RemoteIdListOld) == 1 && ph1RemoteIdListOld[0] == ip && len(ph1RemoteIdListNew) == 0 {
 			return true
 		}
 	}
 
 	if haEnabled {
-		if len(ph1RemoteIdListOld) == 2 && ph1RemoteIdListOld[0] == ipList[0] && strings.TrimSpace(ph1RemoteIdListOld[1]) == haip && len(ph1RemoteIdListNew) == 0 {
+		if len(ph1RemoteIdListOld) == 2 && ph1RemoteIdListOld[0] == ip && strings.TrimSpace(ph1RemoteIdListOld[1]) == haip && len(ph1RemoteIdListNew) == 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
Reverts AviatrixSystems/terraform-provider-aviatrix#1111

This feature is only supported by API, not by UI. Will create a Jira to block the use of:
`ha_enabled` = false + 2 ip in `remote_gateway_ip` 