### PR TITLE
AVX-14725: allow using 2 rmt gw ip when ha disabled and suppress diff

### DIFF
--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -47,6 +47,19 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Description: "Remote Gateway IP.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldIpList := strings.Split(old, ",")
+					newIpList := strings.Split(new, ",")
+					if len(oldIpList) == len(newIpList) {
+						for i := range oldIpList {
+							if strings.TrimSpace(oldIpList[i]) != strings.TrimSpace(newIpList[i]) {
+								return false
+							}
+						}
+						return true
+					}
+					return false
+				},
 			},
 			"connection_type": {
 				Type:        schema.TypeString,
@@ -543,8 +556,6 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 	ph1RemoteIdList := goaviatrix.ExpandStringList(phase1RemoteIdentifier)
 	if haEnabled && len(ph1RemoteIdList) != 0 && len(ph1RemoteIdList) != 2 {
 		return fmt.Errorf("please either set two phase 1 remote IDs or none, when HA is enabled")
-	} else if !haEnabled && len(phase1RemoteIdentifier) > 1 {
-		return fmt.Errorf("please either set one phase 1 remote ID or none, when HA is disabled")
 	}
 
 	if _, ok := d.GetOk("prepend_as_path"); ok {
@@ -918,8 +929,6 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 		ph1RemoteIdList := goaviatrix.ExpandStringList(phase1RemoteIdentifier)
 		if haEnabled && len(ph1RemoteIdList) != 0 && len(ph1RemoteIdList) != 2 {
 			return fmt.Errorf("please either set two phase 1 remote IDs or none, when HA is enabled")
-		} else if !haEnabled && len(phase1RemoteIdentifier) > 1 {
-			return fmt.Errorf("please either set one phase 1 remote ID or none, when HA is disabled")
 		}
 
 		if len(ph1RemoteIdList) == 0 && haEnabled {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -288,6 +288,7 @@ func TransitExternalDeviceConnPh1RemoteIdDiffSuppressFunc(k, old, new string, d 
 	}
 
 	ip := d.Get("remote_gateway_ip").(string)
+	ipList := strings.Split(ip, ",")
 	haip := d.Get("backup_remote_gateway_ip").(string)
 	o, n := d.GetChange("phase1_remote_identifier")
 	haEnabled := d.Get("ha_enabled").(bool)
@@ -300,24 +301,35 @@ func TransitExternalDeviceConnPh1RemoteIdDiffSuppressFunc(k, old, new string, d 
 			if len(ph1RemoteIdListNew) != 2 || len(ph1RemoteIdListOld) != 2 {
 				return false
 			}
-			return ph1RemoteIdListOld[0] == ip && ph1RemoteIdListNew[0] == ip &&
+			return ph1RemoteIdListOld[0] == ipList[0] && ph1RemoteIdListNew[0] == ipList[0] &&
 				strings.TrimSpace(ph1RemoteIdListOld[1]) == haip && strings.TrimSpace(ph1RemoteIdListNew[1]) == haip
 		} else {
-			if len(ph1RemoteIdListNew) != 1 {
+			if len(ph1RemoteIdListNew) == 1 && len(ph1RemoteIdListOld) == 1 {
+				return ph1RemoteIdListOld[0] == ipList[0] && ph1RemoteIdListNew[0] == ipList[0]
+			} else if len(ph1RemoteIdListNew) == 2 && len(ph1RemoteIdListOld) == 2 && len(ipList) == 2 {
+				return strings.TrimSpace(ph1RemoteIdListOld[0]) == strings.TrimSpace(ipList[0]) &&
+					strings.TrimSpace(ph1RemoteIdListOld[1]) == strings.TrimSpace(ipList[1]) &&
+					strings.TrimSpace(ph1RemoteIdListNew[0]) == strings.TrimSpace(ipList[0]) &&
+					strings.TrimSpace(ph1RemoteIdListNew[1]) == strings.TrimSpace(ipList[1])
+			} else {
 				return false
 			}
-			return ph1RemoteIdListOld[0] == ip && ph1RemoteIdListNew[0] == ip
 		}
 	}
 
 	if !haEnabled {
-		if len(ph1RemoteIdListOld) == 1 && ph1RemoteIdListOld[0] == ip && len(ph1RemoteIdListNew) == 0 {
+		if len(ph1RemoteIdListOld) == 1 && ph1RemoteIdListOld[0] == ipList[0] && len(ph1RemoteIdListNew) == 0 {
+			return true
+		}
+		if len(ph1RemoteIdListOld) == 2 && strings.TrimSpace(ph1RemoteIdListOld[0]) == strings.TrimSpace(ipList[0]) &&
+			strings.TrimSpace(ph1RemoteIdListOld[1]) == strings.TrimSpace(ipList[1]) &&
+			len(ph1RemoteIdListNew) == 0 {
 			return true
 		}
 	}
 
 	if haEnabled {
-		if len(ph1RemoteIdListOld) == 2 && ph1RemoteIdListOld[0] == ip && strings.TrimSpace(ph1RemoteIdListOld[1]) == haip && len(ph1RemoteIdListNew) == 0 {
+		if len(ph1RemoteIdListOld) == 2 && ph1RemoteIdListOld[0] == ipList[0] && strings.TrimSpace(ph1RemoteIdListOld[1]) == haip && len(ph1RemoteIdListNew) == 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
1.
Transit ha enabled, active mesh enabled
Create external conn using
ha_enabled=false
remote_gateway_ip=1.2.3.4, 5.6.7.8

Terraform plan -> no diff

Set ph1_remote_id=1.2.3.4, 5.6.7.8
Terraform plan -> no diff

Set ph1_remote_id=[]
Terraform plan -> no diff

Remove ph1_remote_id
Terraform plan -> no diff

Set ph1_remote_id to something else
Terraform plan -> diff

Destroy -> pass


2.
Transit ha enabled, active mesh enabled
Create external conn using
ha_enabled=false
remote_gateway_ip=1.2.3.4, 5.6.7.8
ph1_remote_id=1.2.3.4, 5.6.7.8

Terraform plan -> no diff

Set ph1_remote_id=[]
Terraform plan -> no diff

Remove ph1_remote_id
Terraform plan -> no diff

Set ph1_remote_id to something else
Terraform plan -> diff

Destroy -> pass


3.
Transit ha enabled, active mesh enabled
Create external conn using
ha_enabled=true
remote_gateway_ip=1.2.3.4
backup_remote_gateway_ip=5.6.7.8
ph1_remote_id=1.2.3.4, 5.6.7.8

Terraform plan -> no diff

Set ph1_remote_id=[]
Terraform plan -> no diff

Remove ph1_remote_id
Terraform plan -> no diff

Set ph1_remote_id to something else
Terraform plan -> diff

Destroy -> pass


4.
Transit ha enabled, active mesh enabled
Create external conn using
ha_enabled=true
remote_gateway_ip=1.2.3.4
backup_remote_gateway_ip=5.6.7.8
ph1_remote_id not set

Terraform plan -> no diff

Set ph1_remote_id=[]
Terraform plan -> no diff

Set ph1_remote_id=1.2.3.4, 5.6.7.8
Terraform plan -> no diff

Set ph1_remote_id to something else
Terraform plan -> diff

Destroy -> pass