### PR TITLE
AVX-16002: Export BGP LAN IPs for BGP over LAN enabled GCP transit gateway

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -604,16 +604,18 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Description: "Transit gateway lan interface cidr for the HA gateway.",
 			},
 			"bgp_lan_ip_list": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Computed:    true,
-				Description: "List of available BGP LAN interface IPs for transit external device connection creation. Currently, only supports GCP.",
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Description: "List of available BGP LAN interface IPs for transit external device connection creation. " +
+					"Only supports GCP. Available as of provider version R2.21.0+.",
 			},
 			"ha_bgp_lan_ip_list": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Computed:    true,
-				Description: "List of available BGP LAN interface IPs for transit external device HA connection creation. Currently, only supports GCP.",
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Description: "List of available BGP LAN interface IPs for transit external device HA connection creation. " +
+					"Only supports GCP. Available as of provider version R2.21.0+.",
 			},
 		},
 	}
@@ -1521,7 +1523,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 			}
 		}
 
-		bgpLanIpInfo, err := client.GetBbpLanIPList(&goaviatrix.TransitVpc{GwName: gateway.GwName})
+		bgpLanIpInfo, err := client.GetBgpLanIPList(&goaviatrix.TransitVpc{GwName: gateway.GwName})
 		if err != nil {
 			return fmt.Errorf("could not get BGP LAN IP info for GCP transit gateway %s: %v", gateway.GwName, err)
 		}

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -396,8 +396,8 @@ In addition to all arguments above, the following attributes are exported:
 * `ha_private_ip` - Private IP address of the HA transit gateway created.
 * `lan_interface_cidr` - LAN interface CIDR of the transit gateway created (will be used when enabling FQDN Firenet in Azure). Available in provider version R2.17.1+.
 * `ha_lan_interface_cidr` - LAN interface CIDR of the HA transit gateway created (will be used when enabling FQDN Firenet in Azure). Available in provider version R2.18+.
-* `bgp_lan_ip_list` - List of available BGP LAN interface IPs for transit external device connection creation. Currently, only supports GCP.
-* `ha_bgp_lan_ip_list` - List of available BGP LAN interface IPs for transit external device HA connection creation. Currently, only supports GCP.
+* `bgp_lan_ip_list` - List of available BGP LAN interface IPs for transit external device connection creation. Only supports GCP. Available as of provider version R2.21.0+.
+* `ha_bgp_lan_ip_list` - List of available BGP LAN interface IPs for transit external device HA connection creation. Only supports GCP. Available as of provider version R2.21.0+.
 
 The following arguments are deprecated:
 

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -396,6 +396,8 @@ In addition to all arguments above, the following attributes are exported:
 * `ha_private_ip` - Private IP address of the HA transit gateway created.
 * `lan_interface_cidr` - LAN interface CIDR of the transit gateway created (will be used when enabling FQDN Firenet in Azure). Available in provider version R2.17.1+.
 * `ha_lan_interface_cidr` - LAN interface CIDR of the HA transit gateway created (will be used when enabling FQDN Firenet in Azure). Available in provider version R2.18+.
+* `bgp_lan_ip_list` - List of available BGP LAN interface IPs for transit external device connection creation. Currently, only supports GCP.
+* `ha_bgp_lan_ip_list` - List of available BGP LAN interface IPs for transit external device HA connection creation. Currently, only supports GCP.
 
 The following arguments are deprecated:
 

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -565,7 +565,7 @@ func (c *Client) EditTransitConnectionRemoteSubnet(vpcId, connName, remoteSubnet
 	return c.PostAPI(data["action"], data, BasicCheck)
 }
 
-func (c *Client) GetBbpLanIPList(transitGateway *TransitVpc) (*TransitGatewayBgpLanIpInfo, error) {
+func (c *Client) GetBgpLanIPList(transitGateway *TransitVpc) (*TransitGatewayBgpLanIpInfo, error) {
 	form := map[string]string{
 		"CID":                  c.CID,
 		"action":               "list_aviatrix_transit_advanced_config",


### PR DESCRIPTION
bgp_lan_ip_list corresponds to primary GCP transit gateway, and ha_bgp_lan_ip_list corresponds to HA.