### PR TITLE
AVX-18561: make public_ip optional and will not overwrite if provided by user

### DIFF
--- a/aviatrix/data_source_aviatrix_firenet_vendor_integration.go
+++ b/aviatrix/data_source_aviatrix_firenet_vendor_integration.go
@@ -30,8 +30,8 @@ func dataSourceAviatrixFireNetVendorIntegration() *schema.Resource {
 			},
 			"public_ip": {
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The public IP address of the firewall management interface for API calls from the Aviatrix Controller.",
+				Optional:    true,
+				Description: "The IP address of the firewall management interface for API calls from the Aviatrix Controller.",
 			},
 			"username": {
 				Type:        schema.TypeString,
@@ -116,7 +116,10 @@ func dataSourceAviatrixFireNetVendorIntegrationRead(d *schema.ResourceData, meta
 			d.Set("vpc_id", fI.VpcID)
 		}
 		d.Set("instance_id", fI.InstanceID)
-		d.Set("public_ip", fI.ManagementPublicIP)
+
+		if d.Get("public_ip").(string) == "" {
+			d.Set("public_ip", fI.ManagementPublicIP)
+		}
 	}
 
 	vendorInfo := &goaviatrix.VendorInfo{

--- a/docs/data-sources/aviatrix_firenet_vendor_integration.md
+++ b/docs/data-sources/aviatrix_firenet_vendor_integration.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `vpc_id` - (Required) VPC ID.
 * `instance_id` - (Required) ID of Firewall instance.
 * `vendor_type` - (Required) Select PAN. Valid values: "Generic", "Palo Alto Networks VM-Series", "Aviatrix FQDN Gateway" and "Fortinet FortiGate".
-* `public_ip` - (Optional) The IP address of the firewall management interface for API calls from the Aviatrix Controller.
+* `public_ip` - (Optional) The IP address of the firewall management interface for API calls from the Aviatrix Controller. If not set, the public IP of the firewall instance will be used. If the private IP is provided, please make sure that the controller can access the firewall.
 * `username` - (Optional) Firewall login name for API calls from the Controller. Required for vendor type "Generic", "Palo Alto Networks VM-Series" and "Aviatrix FQDN Gateway".
 * `password` - (Optional) Firewall login password for API calls. Required for vendor type "Generic", "Palo Alto Networks VM-Series" and "Aviatrix FQDN Gateway".
 * `api_token` - (Optional) API token for API calls. Required and valid only for vendor type "Fortinet FortiGate".  

--- a/docs/data-sources/aviatrix_firenet_vendor_integration.md
+++ b/docs/data-sources/aviatrix_firenet_vendor_integration.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `vpc_id` - (Required) VPC ID.
 * `instance_id` - (Required) ID of Firewall instance.
 * `vendor_type` - (Required) Select PAN. Valid values: "Generic", "Palo Alto Networks VM-Series", "Aviatrix FQDN Gateway" and "Fortinet FortiGate".
-* `public_ip` - (Required) The public IP address of the firewall management interface for API calls from the Aviatrix Controller.
+* `public_ip` - (Optional) The IP address of the firewall management interface for API calls from the Aviatrix Controller.
 * `username` - (Optional) Firewall login name for API calls from the Controller. Required for vendor type "Generic", "Palo Alto Networks VM-Series" and "Aviatrix FQDN Gateway".
 * `password` - (Optional) Firewall login password for API calls. Required for vendor type "Generic", "Palo Alto Networks VM-Series" and "Aviatrix FQDN Gateway".
 * `api_token` - (Optional) API token for API calls. Required and valid only for vendor type "Fortinet FortiGate".  


### PR DESCRIPTION
- Making it optional because in UI, it's automatically populated once an instance is selected.
- Also in UI, you can input an IP (e.g. private IP) and let UI use it.
- I don't want to change the name of this attribute since it's going to affect existing users. But the doc is a little confusing now because it's named "public". Any suggestions?