### PR TITLE
AVX-18618: Make interface and connection mutually exclusive in gateway_snat and gateway_dnat

### DIFF
--- a/aviatrix/resource_aviatrix_gateway_snat.go
+++ b/aviatrix/resource_aviatrix_gateway_snat.go
@@ -70,8 +70,7 @@ func resourceAviatrixGatewaySNat() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Description: "This is a qualifier condition that specifies output interface " +
-								"where the rule applies. When left blank, this field is not used. Default value: 'eth0'. " +
-								"Empty string is not a valid value.",
+								"where the rule applies. When left blank, this field is not used.",
 						},
 						"mark": {
 							Type:     schema.TypeString,
@@ -148,6 +147,10 @@ func resourceAviatrixGatewaySNatCreate(d *schema.ResourceData, meta interface{})
 		policies := d.Get("snat_policy").([]interface{})
 		for _, policy := range policies {
 			pl := policy.(map[string]interface{})
+			connection := pl["connection"].(string)
+			if (connection != "" && connection != "None") && pl["interface"].(string) != "" {
+				return fmt.Errorf("failed to create policies for 'cutomised_snat' mode: 'interface' must be empty when 'connection' is set")
+			}
 			customPolicy := &goaviatrix.PolicyRule{
 				SrcIP:           pl["src_cidr"].(string),
 				SrcPort:         pl["src_port"].(string),
@@ -289,6 +292,10 @@ func resourceAviatrixGatewaySNatUpdate(d *schema.ResourceData, meta interface{})
 			policies := d.Get("snat_policy").([]interface{})
 			for _, policy := range policies {
 				pl := policy.(map[string]interface{})
+				connection := pl["connection"].(string)
+				if (connection != "" && connection != "None") && pl["interface"].(string) != "" {
+					return fmt.Errorf("failed to update policies for 'cutomised_snat' mode: 'interface' must be empty when 'connection' is set")
+				}
 				customPolicy := &goaviatrix.PolicyRule{
 					SrcIP:           pl["src_cidr"].(string),
 					SrcPort:         pl["src_port"].(string),

--- a/docs/resources/aviatrix_gateway_dnat.md
+++ b/docs/resources/aviatrix_gateway_dnat.md
@@ -44,8 +44,8 @@ The following arguments are supported:
   * `dst_cidr` - (Optional) This is a qualifier condition that specifies a destination IP address range where the rule applies. When not specified, this field is not used.
   * `dst_port` - (Optional) This is a qualifier condition that specifies a destination port where the rule applies. When not specified, this field is not used.
   * `protocol` - (Optional) This is a qualifier condition that specifies a destination port protocol where the rule applies. When not specified, this field is not used.
-  * `interface` - (Optional) This is a qualifier condition that specifies output interface where the rule applies. When not specified, this field is not used. Empty string is not a valid value.
-  * `connection` - (Optional) Default value: "None".
+  * `interface` - (Optional) This is a qualifier condition that specifies output interface where the rule applies. When not specified, this field is not used. Must be empty when `connection` is set.
+  * `connection` - (Optional) This is a qualifier condition that specifies output connection where the rule applies. Default value: "None".
   * `mark` - (Optional) This is a rule field that specifies a tag or mark of a TCP session when all qualifier conditions meet. When not specified, this field is not used.
   * `dnat_ips` - (Optional) This is a rule field that specifies the translated destination IP address when all specified qualifier conditions meet. When not specified, this field is not used. One of the rule field must be specified for this rule to take effect.
   * `dnat_port` - (Optional) This is a rule field that specifies the translated destination port when all specified qualifier conditions meet. When not specified, this field is not used. One of the rule field must be specified for this rule to take effect.

--- a/docs/resources/aviatrix_gateway_snat.md
+++ b/docs/resources/aviatrix_gateway_snat.md
@@ -46,8 +46,8 @@ The following arguments are supported:
   * `dst_cidr` - (Optional) This is a qualifier condition that specifies a destination IP address range where the rule applies. When not specified, this field is not used.
   * `dst_port` - (Optional) This is a qualifier condition that specifies a destination port where the rule applies. When not specified, this field is not used.
   * `protocol` - (Optional) This is a qualifier condition that specifies a destination port protocol where the rule applies. Valid values: 'all', 'tcp', 'udp', 'icmp'. 'Default: 'all'.
-  * `interface` - (Optional) This is a qualifier condition that specifies output interface where the rule applies. When not specified, this field is not used. Empty string is not a valid value.
-  * `connection` - (Optional) Default value: "None".
+  * `interface` - (Optional) This is a qualifier condition that specifies output interface where the rule applies. When not specified, this field is not used. Must be empty when `connection` is set.
+  * `connection` - (Optional) This is a qualifier condition that specifies output connection where the rule applies. Default value: "None".
   * `mark` - (Optional) This is a qualifier condition that specifies a tag or mark of a TCP session where the rule applies. When not specified, this field is not used.
   * `snat_ips` - (Optional) This is a rule field that specifies the changed source IP address when all specified qualifier conditions meet. When not specified, this field is not used. One of the rule fields must be specified for this rule to take effect.
   * `snat_port` - (Optional) This is a rule field that specifies the changed source port when all specified qualifier conditions meet. When not specified, this field is not used. One of the rule fields must be specified for this rule to take effect.


### PR DESCRIPTION
- Return an error when both interface and connection attributes are set in gateway_snat and gateway_dnat
- Add default value for protocol in gateway_dnat
- Update gateway_snat and gateway_dnat documentation