### PR TITLE
AVX-21060 Sort lists in aviatrix_firewall_instance_images data source

### DIFF
--- a/aviatrix/data_source_aviatrix_firewall_instance_images.go
+++ b/aviatrix/data_source_aviatrix_firewall_instance_images.go
@@ -66,7 +66,7 @@ func dataSourceAviatrixFirewallInstanceImagesRead(d *schema.ResourceData, meta i
 		sort.Slice(versionList, func(i, j int) bool {
 			return sortVersion(versionList, i, j)
 		})
-		fI["firewall_image_version"] = reverseArray(versionList)
+		fI["firewall_image_version"] = versionList
 		sizeList := image.Size
 		sort.Slice(sizeList, func(i, j int) bool {
 			return sortSize(sizeList, i, j)

--- a/aviatrix/data_source_aviatrix_firewall_instance_images.go
+++ b/aviatrix/data_source_aviatrix_firewall_instance_images.go
@@ -2,12 +2,13 @@ package aviatrix
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"log"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/go-version"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/aviatrix/data_source_aviatrix_firewall_instance_images.go
+++ b/aviatrix/data_source_aviatrix_firewall_instance_images.go
@@ -64,7 +64,7 @@ func dataSourceAviatrixFirewallInstanceImagesRead(d *schema.ResourceData, meta i
 		fI["firewall_image"] = image.Image
 		versionList := image.Version
 		sort.Slice(versionList, func(i, j int) bool {
-			return sortVersion(versionList, i, j)
+			return sortVersion(versionList, i, j, image.Image)
 		})
 		fI["firewall_image_version"] = versionList
 		sizeList := image.Size

--- a/aviatrix/data_source_aviatrix_firewall_instance_images.go
+++ b/aviatrix/data_source_aviatrix_firewall_instance_images.go
@@ -2,6 +2,7 @@ package aviatrix
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -93,12 +94,14 @@ func sortImageVersion(listVersion []string) []string {
 					if compareVersion2(listVersion[i], listVersion[j], splitFlag) == 2 {
 						listVersion[i], listVersion[j] = listVersion[j], listVersion[i]
 					}
-				} else {
+				} else if strings.Contains(listVersion[i], "-") {
 					//format: Rab-xxx.xxx
 					splitFlag = "-"
 					if compareVersion2(listVersion[i], listVersion[j], splitFlag) == 2 {
 						listVersion[i], listVersion[j] = listVersion[j], listVersion[i]
 					}
+				} else {
+					log.Printf("need to add a new method sort this version format")
 				}
 			} else if checkFirstCharacter(listVersion[i]) == "P" {
 				//format: Pa-bc-xx.xx.xx
@@ -128,11 +131,20 @@ func compareVersion(version1, version2, splitFlag string) (res int) {
 	imageVersionArray1 := strings.Split(version1, splitFlag)
 	imageVersionArray2 := strings.Split(version2, splitFlag)
 	for index := range imageVersionArray1 {
-		reg, _ := regexp.Compile("[^0-9]+")
+		reg, err := regexp.Compile("[^0-9]+")
+		if err != nil {
+			log.Printf("[WARN] Failed to remove character value %s: %v", imageVersionArray1[index], err)
+		}
 		v1SliceString := reg.ReplaceAllString(imageVersionArray1[index], ".")
 		v2SliceString := reg.ReplaceAllString(imageVersionArray2[index], ".")
-		int1, _ := strconv.ParseFloat(v1SliceString, 32)
-		int2, _ := strconv.ParseFloat(v2SliceString, 32)
+		int1, err := strconv.ParseFloat(v1SliceString, 32)
+		if err != nil {
+			log.Printf("[WARN] Failed to convert string to float %s: %v", v1SliceString, err)
+		}
+		int2, err := strconv.ParseFloat(v2SliceString, 32)
+		if err != nil {
+			log.Printf("[WARN] Failed to convert string to float %s: %v", v1SliceString, err)
+		}
 		if int1 > int2 {
 			return 1
 		}
@@ -148,11 +160,20 @@ func compareVersion2(version1, version2, flag string) (res int) {
 	imageVersionArray1 := strings.Split(version1, flag)
 	imageVersionArray2 := strings.Split(version2, flag)
 	for index := range imageVersionArray1 {
-		reg, _ := regexp.Compile("[^0-9.]+")
+		reg, err := regexp.Compile("[^0-9.]+")
+		if err != nil {
+			log.Printf("[WARN] Failed to remove character value %s: %v", imageVersionArray1[index], err)
+		}
 		v1SliceString := reg.ReplaceAllString(imageVersionArray1[index], "")
 		v2SliceString := reg.ReplaceAllString(imageVersionArray2[index], "")
-		int1, _ := strconv.ParseFloat(v1SliceString, 32)
-		int2, _ := strconv.ParseFloat(v2SliceString, 32)
+		int1, err := strconv.ParseFloat(v1SliceString, 32)
+		if err != nil {
+			log.Printf("[WARN] Failed to convert string to float %s: %v", v1SliceString, err)
+		}
+		int2, err := strconv.ParseFloat(v2SliceString, 32)
+		if err != nil {
+			log.Printf("[WARN] Failed to convert string to float %s: %v", v1SliceString, err)
+		}
 		if int1 > int2 {
 			return 1
 		}

--- a/aviatrix/data_source_aviatrix_firewall_instance_images.go
+++ b/aviatrix/data_source_aviatrix_firewall_instance_images.go
@@ -133,10 +133,7 @@ func versionFormat2(version1, version2, flag string) bool {
 func compareVersion(version1, version2 string) bool {
 	v1, _ := version.NewVersion(version1)
 	v2, _ := version.NewVersion(version2)
-	if v1.LessThan(v2) {
-		return true
-	}
-	return false
+	return v1.LessThan(v2)
 }
 
 func checkFirstCharacter(input string) string {

--- a/aviatrix/data_source_aviatrix_firewall_instance_images.go
+++ b/aviatrix/data_source_aviatrix_firewall_instance_images.go
@@ -2,13 +2,7 @@ package aviatrix
 
 import (
 	"fmt"
-	"log"
-	"regexp"
 	"sort"
-	"strconv"
-	"strings"
-
-	"github.com/hashicorp/go-version"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -68,12 +62,16 @@ func dataSourceAviatrixFirewallInstanceImagesRead(d *schema.ResourceData, meta i
 	for _, image := range *firewallInstanceImages {
 		fI := make(map[string]interface{})
 		fI["firewall_image"] = image.Image
-		listVersion := image.Version
-		sort.Sort(sort.Reverse(byVersion(listVersion)))
-		fI["firewall_image_version"] = listVersion
-		listSize := image.Size
-		sort.Sort(sort.Reverse(bySize(listSize)))
-		fI["firewall_size"] = listSize
+		versionList := image.Version
+		sort.Slice(versionList, func(i, j int) bool {
+			return sortVersion(versionList, i, j)
+		})
+		fI["firewall_image_version"] = reverseArray(versionList)
+		sizeList := image.Size
+		sort.Slice(sizeList, func(i, j int) bool {
+			return sortSize(sizeList, i, j)
+		})
+		fI["firewall_size"] = sizeList
 		images = append(images, fI)
 	}
 
@@ -83,116 +81,4 @@ func dataSourceAviatrixFirewallInstanceImagesRead(d *schema.ResourceData, meta i
 
 	d.SetId(vpcId)
 	return nil
-}
-
-type byVersion []string
-
-func (p byVersion) Len() int {
-	return len(p)
-}
-func (p byVersion) Swap(i, j int) {
-	p[i], p[j] = p[j], p[i]
-}
-func (p byVersion) Less(i, j int) bool {
-	if checkFirstCharacter(p[i]) == "R" {
-		if strings.Contains(p[i], "_") {
-			return versionFormat1(p[i], p[j], "_")
-		} else if strings.Contains(p[i], "-") {
-			return versionFormat1(p[i], p[j], "-")
-		} else {
-			log.Printf("need to add a new method sort this version format")
-		}
-	} else if checkFirstCharacter(p[i]) == "P" {
-		return versionFormat2(p[i], p[j], "-")
-	} else {
-		return compareVersion(p[i], p[j])
-	}
-	return false
-}
-
-//Rxx.xx-xxx.xxx
-//Rxx.xx_revx.x
-func versionFormat1(version1, version2, flag string) bool {
-	//[Rxx.xx, xxx.xxx]
-	//[Rxx.xx, revx.x]
-	versionArray1 := strings.Split(version1, flag)
-	versionArray2 := strings.Split(version2, flag)
-	reg, _ := regexp.Compile("[^0-9.-]+")
-	if reg.ReplaceAllString(versionArray1[0], "") == reg.ReplaceAllString(versionArray2[0], "") {
-		return compareVersion(reg.ReplaceAllString(versionArray1[1], ""), reg.ReplaceAllString(versionArray2[1], ""))
-	}
-	return compareVersion(reg.ReplaceAllString(versionArray1[0], ""), reg.ReplaceAllString(versionArray2[0], ""))
-}
-
-//PA-VM-xx.xxx.xx
-func versionFormat2(version1, version2, flag string) bool {
-	versionArray1 := strings.Split(version1, flag)
-	versionArray2 := strings.Split(version2, flag)
-	return compareVersion(versionArray1[2], versionArray2[2])
-}
-
-func compareVersion(version1, version2 string) bool {
-	v1, _ := version.NewVersion(version1)
-	v2, _ := version.NewVersion(version2)
-	return v1.LessThan(v2)
-}
-
-func checkFirstCharacter(input string) string {
-	firstCharacter := input[0:1]
-	return firstCharacter
-}
-
-type bySize []string
-
-func (s bySize) Len() int {
-	return len(s)
-}
-func (s bySize) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s bySize) Less(i, j int) bool {
-	if strings.Contains(s[i], "-") {
-		return compareImageSizeTest(s[i], s[j], "-", 2)
-	} else if strings.Contains(s[i], ".") {
-		return compareImageSizeTest(s[i], s[j], ".", 1)
-	} else if strings.Contains(s[i], "_") {
-		return compareImageSizeTest(s[i], s[j], "_", 1)
-	}
-	return false
-}
-
-func compareImageSizeTest(imageSize1, imageSize2, flag string, indexFlag int) bool {
-	imageSizeArray1 := strings.Split(imageSize1, flag)
-	imageSizeArray2 := strings.Split(imageSize2, flag)
-	for index := range imageSizeArray1 {
-		if index >= indexFlag {
-			reg, err := regexp.Compile("[^0-9]+")
-			if err != nil {
-				log.Printf("[WARN] Failed to remove character value %s: %v", imageSizeArray1[index], err)
-			}
-			imageSizeIndex1 := reg.ReplaceAllString(imageSizeArray1[index], "")
-			imageSizeIndex2 := reg.ReplaceAllString(imageSizeArray2[index], "")
-			int1, err := strconv.Atoi(imageSizeIndex1)
-			if err != nil {
-				log.Printf("[WARN] Failed to convert string to float %s: %v", imageSizeIndex1, err)
-			}
-			int2, err := strconv.Atoi(imageSizeIndex2)
-			if err != nil {
-				log.Printf("[WARN] Failed to convert string to float %s: %v", imageSizeIndex2, err)
-			}
-			if int1 > int2 {
-				return true
-			}
-			if int1 < int2 {
-				return false
-			}
-		}
-		if imageSizeArray1[index] > imageSizeArray2[index] {
-			return true
-		}
-		if imageSizeArray1[index] < imageSizeArray2[index] {
-			return false
-		}
-	}
-	return true
 }

--- a/aviatrix/data_source_aviatrix_firewall_instance_images.go
+++ b/aviatrix/data_source_aviatrix_firewall_instance_images.go
@@ -94,60 +94,32 @@ func (p byVersion) Swap(i, j int) {
 func (p byVersion) Less(i, j int) bool {
 	if checkFirstCharacter(p[i]) == "R" {
 		if strings.Contains(p[i], "_") {
-			return compareVersion2(p[i], p[j], "_")
+			return compareVersion(p[i], p[j], "_", "", "[^0-9.]+")
 		} else if strings.Contains(p[i], "-") {
-			return compareVersion2(p[i], p[j], "-")
+			return compareVersion(p[i], p[j], "-", "", "[^0-9.]+")
 		} else {
 			log.Printf("need to add a new method sort this version format")
 		}
 	} else if checkFirstCharacter(p[i]) == "P" {
 		return compareVersion3(p[i], p[j], "-")
 	} else {
-		return compareVersion(p[i], p[j], ".")
+		return compareVersion(p[i], p[j], ".", ".", "[^0-9]+")
 	}
 	return false
 }
 
 //format: xx.xx.xx
-func compareVersion(version1, version2, splitFlag string) bool {
+//format: Rab-xxx.xxx and Rab_abcxx.x
+func compareVersion(version1, version2, splitFlag, secondFlag, regularExpression string) bool {
 	imageVersionArray1 := strings.Split(version1, splitFlag)
 	imageVersionArray2 := strings.Split(version2, splitFlag)
 	for index := range imageVersionArray1 {
-		reg, err := regexp.Compile("[^0-9]+")
+		reg, err := regexp.Compile(regularExpression)
 		if err != nil {
 			log.Printf("[WARN] Failed to remove character value %s: %v", imageVersionArray1[index], err)
 		}
-		v1SliceString := reg.ReplaceAllString(imageVersionArray1[index], ".")
-		v2SliceString := reg.ReplaceAllString(imageVersionArray2[index], ".")
-		int1, err := strconv.ParseFloat(v1SliceString, 32)
-		if err != nil {
-			log.Printf("[WARN] Failed to convert string to float %s: %v", v1SliceString, err)
-		}
-		int2, err := strconv.ParseFloat(v2SliceString, 32)
-		if err != nil {
-			log.Printf("[WARN] Failed to convert string to float %s: %v", v2SliceString, err)
-		}
-		if int1 > int2 {
-			return true
-		}
-		if int1 < int2 {
-			return false
-		}
-	}
-	return true
-}
-
-//format: Rab-xxx.xxx and Rab_abcxx.x
-func compareVersion2(version1, version2, flag string) bool {
-	imageVersionArray1 := strings.Split(version1, flag)
-	imageVersionArray2 := strings.Split(version2, flag)
-	for index := range imageVersionArray1 {
-		reg, err := regexp.Compile("[^0-9.]+")
-		if err != nil {
-			log.Printf("[WARN] Failed to remove character value %s: %v", imageVersionArray1[index], err)
-		}
-		v1SliceString := reg.ReplaceAllString(imageVersionArray1[index], "")
-		v2SliceString := reg.ReplaceAllString(imageVersionArray2[index], "")
+		v1SliceString := reg.ReplaceAllString(imageVersionArray1[index], secondFlag)
+		v2SliceString := reg.ReplaceAllString(imageVersionArray2[index], secondFlag)
 		int1, err := strconv.ParseFloat(v1SliceString, 32)
 		if err != nil {
 			log.Printf("[WARN] Failed to convert string to float %s: %v", v1SliceString, err)
@@ -170,7 +142,7 @@ func compareVersion2(version1, version2, flag string) bool {
 func compareVersion3(version1, version2, flag string) bool {
 	imageVersionArray1 := strings.Split(version1, flag)
 	imageVersionArray2 := strings.Split(version2, flag)
-	return compareVersion(imageVersionArray1[2], imageVersionArray2[2], ".")
+	return compareVersion(imageVersionArray1[2], imageVersionArray2[2], ".", ".", "[^0-9]+")
 }
 
 func checkFirstCharacter(input string) string {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -256,23 +256,31 @@ func compareVersion(version1, version2 string) bool {
 	return v1.GreaterThan(v2)
 }
 
-// checkVersionFormat removes special characters, only keep character, number, point and minus in a version
+// checkVersionFormat removes special characters, only keep dot, hyphen, alphanumerics in a version
 func checkVersionFormat(version string) string {
 	reg, _ := regexp.Compile("[^a-zA-Z0-9.-]+")
 	version = reg.ReplaceAllString(version, "")
-	pointNumber := strings.Count(version, ".")
-	if pointNumber > 2 {
-		version = removePoint(version)
+	dotNumber := strings.Count(version, ".")
+	if dotNumber > 2 {
+		version = removeAfterThirdDotValue(version)
 	}
 	return version
 }
 
-// removePoint removes all points after the second point in a version
-func removePoint(version string) string {
-	version = strings.Replace(version, ".", "$", 2)
-	version = strings.Replace(version, ".", "", -1)
-	version = strings.Replace(version, "$", ".", -1)
-	return version
+// removeAfterThirdDotValue removes everything after the third dot in a version
+func removeAfterThirdDotValue(version string) string {
+	time := 0
+	result := version
+	for i := 0; i < len(version); i++ {
+		if version[i] == '.' {
+			time++
+		}
+		if time == 3 {
+			result = version[0:i]
+			break
+		}
+	}
+	return result
 }
 
 func compareImageSize(imageSize1, imageSize2, flag string, indexFlag int) bool {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -235,7 +235,8 @@ func sortSize(sizeList []string, i, j int) bool {
 func compareCheckpointVersion(version1, version2, flag string) bool {
 	versionArray1 := strings.Split(version1, flag)
 	versionArray2 := strings.Split(version2, flag)
-	reg, _ := regexp.Compile("[^0-9.-]+")
+	const DotHyphenNumberRegexp = "[^0-9.-]+"
+	reg := regexp.MustCompile(DotHyphenNumberRegexp)
 	if reg.ReplaceAllString(versionArray1[0], "") == reg.ReplaceAllString(versionArray2[0], "") {
 		return compareVersion(reg.ReplaceAllString(versionArray1[1], ""), reg.ReplaceAllString(versionArray2[1], ""))
 	}
@@ -258,7 +259,8 @@ func compareVersion(version1, version2 string) bool {
 
 // checkVersionFormat removes special characters, only keep dot, hyphen, alphanumerics in a version
 func checkVersionFormat(version string) string {
-	reg, _ := regexp.Compile("[^a-zA-Z0-9.-]+")
+	const DotHyphenAlphanumericsRegexp = "[^a-zA-Z0-9.-]+"
+	reg := regexp.MustCompile(DotHyphenAlphanumericsRegexp)
 	version = reg.ReplaceAllString(version, "")
 	dotNumber := strings.Count(version, ".")
 	if dotNumber > 2 {
@@ -286,9 +288,10 @@ func removeAfterThirdDotValue(version string) string {
 func compareImageSize(imageSize1, imageSize2, flag string, indexFlag int) bool {
 	imageSizeArray1 := strings.Split(imageSize1, flag)
 	imageSizeArray2 := strings.Split(imageSize2, flag)
+	const NumberRegexp = "[^0-9]+"
+	reg := regexp.MustCompile(NumberRegexp)
 	for index := range imageSizeArray1 {
 		if index >= indexFlag {
-			reg, _ := regexp.Compile("[^0-9]+")
 			imageSizeIndex1 := reg.ReplaceAllString(imageSizeArray1[index], "")
 			imageSizeIndex2 := reg.ReplaceAllString(imageSizeArray2[index], "")
 			int1, _ := strconv.Atoi(imageSizeIndex1)

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -201,14 +201,7 @@ func DiffSuppressFuncGatewayVpcId(k, old, new string, d *schema.ResourceData) bo
 	return false
 }
 
-func reverseArray(arr []string) []string {
-	for i, j := 0, len(arr)-1; i < j; i, j = i+1, j-1 {
-		arr[i], arr[j] = arr[j], arr[i]
-	}
-	return arr
-}
-
-// sort the firewall_image_version list
+// sortVersion sorts the firewall_image_version list
 func sortVersion(versionList []string, i, j int) bool {
 	if checkFirstCharacter(versionList[i]) == "R" {
 		if strings.Contains(versionList[i], "_") {
@@ -217,16 +210,16 @@ func sortVersion(versionList []string, i, j int) bool {
 			return versionFormat1(versionList[i], versionList[j], "-")
 		} else {
 			log.Printf("need to add a new method sort this version format")
+			return false
 		}
 	} else if checkFirstCharacter(versionList[i]) == "P" {
 		return versionFormat2(versionList[i], versionList[j], "-")
 	} else {
 		return compareVersion(versionList[i], versionList[j])
 	}
-	return false
 }
 
-// sort the firewall_size list
+// sortSize sorts the firewall_size list
 func sortSize(sizeList []string, i, j int) bool {
 	if strings.Contains(sizeList[i], "-") {
 		return compareImageSize(sizeList[i], sizeList[j], "-", 2)
@@ -238,7 +231,7 @@ func sortSize(sizeList []string, i, j int) bool {
 	return false
 }
 
-// this function can sort the firewall_image_version format like: R81.10-335.883 && R81.10_rev1.0
+// versionFormat1 sorts the firewall_image_version format like: R81.10-335.883 && R81.10_rev1.0
 func versionFormat1(version1, version2, flag string) bool {
 	versionArray1 := strings.Split(version1, flag)
 	versionArray2 := strings.Split(version2, flag)
@@ -249,18 +242,18 @@ func versionFormat1(version1, version2, flag string) bool {
 	return compareVersion(reg.ReplaceAllString(versionArray1[0], ""), reg.ReplaceAllString(versionArray2[0], ""))
 }
 
-// this function can sort the firewall_image_version format like: PA-VM-10.1.0
+// versionFormat2 sorts the firewall_image_version format like: PA-VM-10.1.0
 func versionFormat2(version1, version2, flag string) bool {
 	versionArray1 := strings.Split(version1, flag)
 	versionArray2 := strings.Split(version2, flag)
 	return compareVersion(versionArray1[2], versionArray2[2])
 }
 
-// this function can sort the Semantic Version
+// compareVersion sorts the Semantic Version
 func compareVersion(version1, version2 string) bool {
 	v1, _ := version.NewVersion(version1)
 	v2, _ := version.NewVersion(version2)
-	return v1.LessThan(v2)
+	return v1.GreaterThan(v2)
 }
 
 func checkFirstCharacter(input string) string {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -235,8 +235,7 @@ func sortSize(sizeList []string, i, j int) bool {
 func compareCheckpointVersion(version1, version2, flag string) bool {
 	versionArray1 := strings.Split(version1, flag)
 	versionArray2 := strings.Split(version2, flag)
-	const DotHyphenNumberRegexp = "[^0-9.-]+"
-	reg := regexp.MustCompile(DotHyphenNumberRegexp)
+	reg := regexp.MustCompile("[^0-9.-]+")
 	if reg.ReplaceAllString(versionArray1[0], "") == reg.ReplaceAllString(versionArray2[0], "") {
 		return compareVersion(reg.ReplaceAllString(versionArray1[1], ""), reg.ReplaceAllString(versionArray2[1], ""))
 	}
@@ -259,8 +258,7 @@ func compareVersion(version1, version2 string) bool {
 
 // checkVersionFormat removes special characters, only keep dot, hyphen, alphanumerics in a version
 func checkVersionFormat(version string) string {
-	const DotHyphenAlphanumericsRegexp = "[^a-zA-Z0-9.-]+"
-	reg := regexp.MustCompile(DotHyphenAlphanumericsRegexp)
+	reg := regexp.MustCompile("[^a-zA-Z0-9.-]+")
 	version = reg.ReplaceAllString(version, "")
 	dotNumber := strings.Count(version, ".")
 	if dotNumber > 2 {
@@ -288,8 +286,7 @@ func removeAfterThirdDotValue(version string) string {
 func compareImageSize(imageSize1, imageSize2, flag string, indexFlag int) bool {
 	imageSizeArray1 := strings.Split(imageSize1, flag)
 	imageSizeArray2 := strings.Split(imageSize2, flag)
-	const NumberRegexp = "[^0-9]+"
-	reg := regexp.MustCompile(NumberRegexp)
+	reg := regexp.MustCompile("[^0-9]+")
 	for index := range imageSizeArray1 {
 		if index >= indexFlag {
 			imageSizeIndex1 := reg.ReplaceAllString(imageSizeArray1[index], "")

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
-	github.com/hashicorp/go-version v1.4.0 // indirect
+	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hcl/v2 v2.8.1 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.8.1 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
+github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=

--- a/go.sum
+++ b/go.sum
@@ -190,7 +190,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/vendor/github.com/hashicorp/go-version/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/go-version/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.4.0 (January 5, 2021)
+
+FEATURES:
+
+ - Introduce `MustConstraints()` ([#87](https://github.com/hashicorp/go-version/pull/87))
+ - `Constraints`: Introduce `Equals()` and `sort.Interface` methods ([#88](https://github.com/hashicorp/go-version/pull/88))
+
 # 1.3.0 (March 31, 2021)
 
 Please note that CHANGELOG.md does not exist in the source code prior to this release.

--- a/vendor/github.com/hashicorp/go-version/constraint.go
+++ b/vendor/github.com/hashicorp/go-version/constraint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -11,8 +12,13 @@ import (
 // ">= 1.0".
 type Constraint struct {
 	f        constraintFunc
+	op       operator
 	check    *Version
 	original string
+}
+
+func (c *Constraint) Equals(con *Constraint) bool {
+	return c.op == con.op && c.check.Equal(con.check)
 }
 
 // Constraints is a slice of constraints. We make a custom type so that
@@ -21,20 +27,25 @@ type Constraints []*Constraint
 
 type constraintFunc func(v, c *Version) bool
 
-var constraintOperators map[string]constraintFunc
+var constraintOperators map[string]constraintOperation
+
+type constraintOperation struct {
+	op operator
+	f  constraintFunc
+}
 
 var constraintRegexp *regexp.Regexp
 
 func init() {
-	constraintOperators = map[string]constraintFunc{
-		"":   constraintEqual,
-		"=":  constraintEqual,
-		"!=": constraintNotEqual,
-		">":  constraintGreaterThan,
-		"<":  constraintLessThan,
-		">=": constraintGreaterThanEqual,
-		"<=": constraintLessThanEqual,
-		"~>": constraintPessimistic,
+	constraintOperators = map[string]constraintOperation{
+		"":   {op: equal, f: constraintEqual},
+		"=":  {op: equal, f: constraintEqual},
+		"!=": {op: notEqual, f: constraintNotEqual},
+		">":  {op: greaterThan, f: constraintGreaterThan},
+		"<":  {op: lessThan, f: constraintLessThan},
+		">=": {op: greaterThanEqual, f: constraintGreaterThanEqual},
+		"<=": {op: lessThanEqual, f: constraintLessThanEqual},
+		"~>": {op: pessimistic, f: constraintPessimistic},
 	}
 
 	ops := make([]string, 0, len(constraintOperators))
@@ -66,6 +77,16 @@ func NewConstraint(v string) (Constraints, error) {
 	return Constraints(result), nil
 }
 
+// MustConstraints is a helper that wraps a call to a function
+// returning (Constraints, error) and panics if error is non-nil.
+func MustConstraints(c Constraints, err error) Constraints {
+	if err != nil {
+		panic(err)
+	}
+
+	return c
+}
+
 // Check tests if a version satisfies all the constraints.
 func (cs Constraints) Check(v *Version) bool {
 	for _, c := range cs {
@@ -75,6 +96,56 @@ func (cs Constraints) Check(v *Version) bool {
 	}
 
 	return true
+}
+
+// Equals compares Constraints with other Constraints
+// for equality. This may not represent logical equivalence
+// of compared constraints.
+// e.g. even though '>0.1,>0.2' is logically equivalent
+// to '>0.2' it is *NOT* treated as equal.
+//
+// Missing operator is treated as equal to '=', whitespaces
+// are ignored and constraints are sorted before comaparison.
+func (cs Constraints) Equals(c Constraints) bool {
+	if len(cs) != len(c) {
+		return false
+	}
+
+	// make copies to retain order of the original slices
+	left := make(Constraints, len(cs))
+	copy(left, cs)
+	sort.Stable(left)
+	right := make(Constraints, len(c))
+	copy(right, c)
+	sort.Stable(right)
+
+	// compare sorted slices
+	for i, con := range left {
+		if !con.Equals(right[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (cs Constraints) Len() int {
+	return len(cs)
+}
+
+func (cs Constraints) Less(i, j int) bool {
+	if cs[i].op < cs[j].op {
+		return true
+	}
+	if cs[i].op > cs[j].op {
+		return false
+	}
+
+	return cs[i].check.LessThan(cs[j].check)
+}
+
+func (cs Constraints) Swap(i, j int) {
+	cs[i], cs[j] = cs[j], cs[i]
 }
 
 // Returns the string format of the constraints
@@ -107,8 +178,11 @@ func parseSingle(v string) (*Constraint, error) {
 		return nil, err
 	}
 
+	cop := constraintOperators[matches[1]]
+
 	return &Constraint{
-		f:        constraintOperators[matches[1]],
+		f:        cop.f,
+		op:       cop.op,
 		check:    check,
 		original: v,
 	}, nil
@@ -137,6 +211,18 @@ func prereleaseCheck(v, c *Version) bool {
 //-------------------------------------------------------------------
 // Constraint functions
 //-------------------------------------------------------------------
+
+type operator rune
+
+const (
+	equal            operator = '='
+	notEqual         operator = '≠'
+	greaterThan      operator = '>'
+	lessThan         operator = '<'
+	greaterThanEqual operator = '≥'
+	lessThanEqual    operator = '≤'
+	pessimistic      operator = '~'
+)
 
 func constraintEqual(v, c *Version) bool {
 	return v.Equal(c)

--- a/vendor/github.com/hashicorp/go-version/version.go
+++ b/vendor/github.com/hashicorp/go-version/version.go
@@ -64,7 +64,6 @@ func newVersion(v string, pattern *regexp.Regexp) (*Version, error) {
 	}
 	segmentsStr := strings.Split(matches[1], ".")
 	segments := make([]int64, len(segmentsStr))
-	si := 0
 	for i, str := range segmentsStr {
 		val, err := strconv.ParseInt(str, 10, 64)
 		if err != nil {
@@ -72,8 +71,7 @@ func newVersion(v string, pattern *regexp.Regexp) (*Version, error) {
 				"Error parsing version: %s", err)
 		}
 
-		segments[i] = int64(val)
-		si++
+		segments[i] = val
 	}
 
 	// Even though we could support more than three segments, if we
@@ -92,7 +90,7 @@ func newVersion(v string, pattern *regexp.Regexp) (*Version, error) {
 		metadata: matches[10],
 		pre:      pre,
 		segments: segments,
-		si:       si,
+		si:       len(segmentsStr),
 		original: v,
 	}, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -110,7 +110,8 @@ github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-uuid v1.0.2
 ## explicit
 github.com/hashicorp/go-uuid
-# github.com/hashicorp/go-version v1.3.0
+# github.com/hashicorp/go-version v1.4.0
+## explicit
 github.com/hashicorp/go-version
 # github.com/hashicorp/hcl/v2 v2.8.1
 ## explicit


### PR DESCRIPTION
Sort lists in aviatrix_firewall_instance_images data source
fix:
sort the firewall_image_version list form latest to old
can sort version format example:
 firewall_image_version = [
                "10.2.0",
                "10.0.9",
                "10.0.8-h8",
                "10.0.7",
            ]
 firewall_image_version = [
                "9.1.2",
                "9.1.0-h3",
                "9.0.9-h1.xfr",
                "9.0.9.xfr",
            ]
 firewall_image_version = [
                "(7.0.5)",
                "(7.0.3)",
                "(6.4.8)",
                "(6.4.7)",
            ]
  firewall_image_version = [
                "R81.10-335.986",
                "R81-392.983",
                "R80.40-294.983",
            ]
  firewall_image_version = [
                "R81.10_rev1.1",
                "R81.10_rev1.0",
                "R81_rev1.2",
            ]
  firewall_image_version = [
                "PA-VM-10.2.0",
                "PA-VM-10.1.0",
                "PA-VM-10.0.9",
            ]
sort the firewall_size list 