### PR TITLE
AVX-22190: add 30s sleep for forced replacement in cloudn registration

### DIFF
--- a/aviatrix/resource_aviatrix_cloudn_registration.go
+++ b/aviatrix/resource_aviatrix_cloudn_registration.go
@@ -3,6 +3,7 @@ package aviatrix
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v2/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -221,6 +222,8 @@ func resourceAviatrixCloudnRegistrationDelete(ctx context.Context, d *schema.Res
 	if err != nil {
 		return diag.Errorf("failed to delete Aviatrix CloudN Registration: %v", err)
 	}
+
+	time.Sleep(30 * time.Second)
 
 	return nil
 }


### PR DESCRIPTION
There's no problem to only destroy the resource. However, in the case of forced replacement, the short interval between destroy and create will cause an issue. As suggested by Rui, added 30s sleep in the delete function.