### PR TITLE
R2.22.0 documentation (#1286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Please follow the guide [here](https://registry.terraform.io/providers/AviatrixS
 to support the renaming from security domain to network domain. Resources and attributes whose name includes security domain will be deprecated in future releases.
 Please follow the guide [here](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/guides/migrating_from_security_domain_to_network_domain) for migration
 3. Updated the ``vpc_id`` attribute for **aviatrix_gateway**, **aviatrix_spoke_gateway**, **aviatrix_transit_gateway** and **aviatrix_vpc** created in GCP to include the project id:
-  - New format: "vpc-gcp-test~-~project-id"
+  - New format: ``"<vpc_name>~-~<project_id>"``
 4. Added support for ``insane_mode`` for **aviatrix_gateway**, **aviatrix_spoke_gateway**, and **aviatrix_transit_gateway** created in AWS China
 5. Sorted the lists of ``firewall_image_version`` and ``firewall_size`` in data source **aviatrix_firewall_instance_images**
 

--- a/docs/guides/feature-changelist-v2.md
+++ b/docs/guides/feature-changelist-v2.md
@@ -22,7 +22,7 @@ We **highly** recommend customers that are starting to adopt Terraform to manage
 
 ---
 
-``Last updated: R2.21.2 (UserConnect-6.6.5544)``
+``Last updated: R2.22.0 (UserConnect-6.7)``
 
 
 ---
@@ -288,4 +288,26 @@ Note there are standalone resources already in place to be used and one only nee
 ## R2.21.2 (UserConnect-6.6.5544)
 | Diff | Resource       | Attribute         | Action Required?           |
 |:----:|----------------|:-----------------:|----------------------------|
-|(changed) | gateway, spoke_gateway, transit_gateway, firenet, firewall_instance, site2cloud, transit_external_device_conn, spoke_external_device_conn, transit_cloudn_conn, vpn_user  | `vpc_id` | **Yes**; any of the listed resources built on OCI that references the `name` attribute from the **aviatrix_vpc** resource, should be changed to the `vpc_id` attribute. Running ``terraform refresh`` after this config change is made, will rectify any deltas in the state. This change was made to standardize the behavior between all CSPs (clouds). |
+|(changed) | gateway <br> spoke_gateway <br> transit_gateway <br> firenet <br> firewall_instance <br> site2cloud <br> transit_external_device_conn <br> spoke_external_device_conn <br> transit_cloudn_conn <br> vpn_user  | `vpc_id` | **Yes**; any of the listed resources built on OCI that references the `name` attribute from the **aviatrix_vpc** resource, should be changed to the `vpc_id` attribute. Running ``terraform refresh`` after this config change is made, will rectify any deltas in the state. This change was made to standardize the behavior between all CSPs (clouds). |
+
+
+## R2.22.0 (UserConnect-6.7)
+### Resource Renaming
+| Diff | Resource       | New Resource Name | Action Required?           |
+|:----:|----------------|:-----------------:|----------------------------|
+|(deprecated) | aviatrix_aws_tgw_security_domain  | aviatrix_aws_tgw_network_domain  | **Yes**; **aws_tgw_security_domain** will be deprecated and replaced with **aws_tgw_network_domain**. It will be kept for now for backward compatibility and will be removed in the future. Please use **aws_tgw_network_domain** instead <br><br> You will need to remove any pre-existing **aws_tgw_security_domain** resources from the statefile, update your .tf files to **aws_tgw_network_domain**, as well as any attributes (and corresponding values) as necessary, and ``terraform import`` as **aviatrix_aws_tgw_network_domain** <br>|
+|(deprecated) | segmentation_security_domain | segmentation_network_domain | **Yes**; please see above for details or follow the guide [here](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/guides/migrating_from_security_domain_to_network_domain) for migration steps |
+|(deprecated) | segmentation_security_domain_association | segmentation_network_domain_association | **Yes**; please see above |
+|(deprecated) | segmentation_security_domain_connection_policy | segmentation_network_domain_connection_policy | **Yes**; please see above |
+
+### Attribute Renaming
+| Diff | Resource       | Attribute         | Action Required?           |
+|:----:|----------------|:-----------------:|----------------------------|
+|(changed) | aws_tgw_connect <br> aws_tgw_directconnect <br> aws_tgw_vpc_attachment | security_domain_name | **Yes**; renamed to ``network_domain_name``. Please follow the guide [here](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/guides/migrating_from_security_domain_to_network_domain) for migration steps |
+
+### Misc.
+| Diff | Resource       | Attribute         | Action Required?           |
+|:----:|----------------|:-----------------:|----------------------------|
+|(changed) | gateway <br> spoke_gateway <br> transit_gateway <br> vpc | vpc_id | **No**; the attribute value for these resources created in GCP now include the project ID. The new format is `<vpc_name>~-~<project_id>`; if some resources referenced the `vpc_id` and concatenated the project ID, it is no longer necessary |
+|(deprecated) | device_registration <br> device_tag <br> device_transit_gateway_attachment <br> device_aws_tgw_attachment <br> device_virtual_wan_attachment | -- | **Yes**; these resources are removed from Terraform as CloudWAN is no longer a supported feature |
+|(deprecated) | cloudn_transit_gateway_attachment | enable_dead_peer_detection <br> enable_learned_cidrs_approval <br> approved_cirs | **Yes**; these attributes are no longer supported in this resource. They can be safely removed from .tf config |

--- a/docs/guides/release-compatibility.md
+++ b/docs/guides/release-compatibility.md
@@ -15,7 +15,7 @@ Quick at-a-glance access to Aviatrix Terraform provider's release compatibility 
 
 ---
 
-``Last updated: R2.21.2 (UserConnect-6.6.5544)``
+``Last updated: R2.22.0 (UserConnect-6.7)``
 
 
 ---
@@ -23,13 +23,14 @@ Quick at-a-glance access to Aviatrix Terraform provider's release compatibility 
 
 | Terraform Version (v) | Aviatrix Provider Version (R) |   Supported Controller Version   |
 | :-------------------: | :---------------------------: | :------------------------------: |
-|      0.12 - 1.0       |            2.21.2             |       UserConnect-6.6.5544       |
-|      0.12 - 1.0       |         2.21.1-6.6.ga         |       UserConnect-6.6.5404       |
-|      0.12 - 1.0       |         2.21.0-6.6.ga         |         UserConnect-6.6          |
-|      0.12 - 1.0       |            2.20.3             |       UserConnect-6.5.2721       |
-|      0.12 - 1.0       |            2.20.2             |       UserConnect-6.5.2608       |
-|      0.12 - 1.0       |            2.20.1             |       UserConnect-6.5.2608       |
-|      0.12 - 1.0       |             2.20              |         UserConnect-6.5          |
+|          1.0          |            2.22.0             |         UserConnect-6.7          |
+|          1.0          |            2.21.2             |       UserConnect-6.6.5544       |
+|          1.0          |         2.21.1-6.6.ga         |       UserConnect-6.6.5404       |
+|          1.0          |         2.21.0-6.6.ga         |         UserConnect-6.6          |
+|          1.0          |            2.20.3             |       UserConnect-6.5.2721       |
+|          1.0          |            2.20.2             |       UserConnect-6.5.2608       |
+|          1.0          |            2.20.1             |       UserConnect-6.5.2608       |
+|          1.0          |            2.20.0             |         UserConnect-6.5          |
 |      0.12 - 1.0       |            2.19.5             |       UserConnect-6.4.2776       |
 |      0.12 - 0.15      |            2.19.4             |       UserConnect-6.4.2672       |
 |      0.12 - 0.15      |            2.19.3             |       UserConnect-6.4.2672       |
@@ -46,7 +47,7 @@ Quick at-a-glance access to Aviatrix Terraform provider's release compatibility 
 |         0.12          |            2.16.1             |         UserConnect-6.1          |
 |         0.12          |            2.16.0             |         UserConnect-6.1          |
 |         0.12          |            2.15.1             |         UserConnect-6.0          |
-|         0.12          |             2.15              | **UserConnect-6.0 <sup>3</sup>** |
+|         0.12          |            2.15.0             | **UserConnect-6.0 <sup>3</sup>** |
 |         0.12          |            2.14.1             |       UserConnect-5.4.1232       |
 |         0.12          |             2.14              |       UserConnect-5.4.1201       |
 |         0.12          |             2.13              |       UserConnect-5.4.1074       |

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -12,10 +12,71 @@ Track all Aviatrix Terraform provider's releases. New resources, features, and b
 
 ---
 
-``Last updated: R2.21.2 (UserConnect-6.6.5544)``
+``Last updated: R2.22.0 (UserConnect-6.7)``
 
 
 ---
+
+## 2.22.0
+### Notes:
+- Release date: ???
+- Supported Controller version: **UserConnect-6.7.1158**
+- Supported Terraform version: **v1.x**
+
+### Features:
+#### Gateway
+1. Implemented support for setting rx queue size in **aviatrix_gateway**, **aviatrix_spoke_gateway** and **aviatrix_transit_gateway** with the following new attribute:
+  - ``rx_queue_size``
+
+#### Multi-Cloud Transit:
+1. Implemented support for modifying BGP connection's MD5 signature in **aviatrix_spoke_external_device_conn** and **aviatrix_transit_external_device_conn**:
+  - ``bgp_md5_key``
+  - ``backup_bgp_md5_key``
+
+#### CloudN
+1. Implemented a new resource to support Edge as a CaaG:
+  - **aviatrix_edge_caag**
+2. Implemented a new data source to get the list of device WAN interfaces:
+  - **aviatrix_device_interfaces**
+
+### Enhancements:
+1. Implemented new resources to support the renaming from security domain to network domain. Resources and attributes whose name include "security_domain" will be deprecated in future releases.
+Please follow the guide [here](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/guides/migrating_from_security_domain_to_network_domain) for migration:
+  - **aviatrix_aws_tgw_network_domain**
+  - **aviatrix_segmentation_network_domain**
+  - **aviatrix_segmentation_network_domain_association**
+  - **aviatrix_segmentation_network_domain_connection_policy**
+2. Renamed the attribute ``security_domain_name`` to ``network_domain_name`` in resources **aviatrix_aws_tgw_connect**, **aviatrix_aws_tgw_directconnect** and **aviatrix_aws_tgw_vpc_attachment**
+to support the renaming from security domain to network domain. Resources and attributes whose name includes security domain will be deprecated in future releases.
+Please follow the guide [here](https://registry.terraform.io/providers/AviatrixSystems/aviatrix/latest/docs/guides/migrating_from_security_domain_to_network_domain) for migration
+3. Updated the ``vpc_id`` attribute for **aviatrix_gateway**, **aviatrix_spoke_gateway**, **aviatrix_transit_gateway** and **aviatrix_vpc** created in GCP to include the project id:
+  - New format: ``"<vpc_name>~-~<project_id>"``
+4. Added support for ``insane_mode`` for **aviatrix_gateway**, **aviatrix_spoke_gateway**, and **aviatrix_transit_gateway** created in AWS China
+5. Sorted the lists of ``firewall_image_version`` and ``firewall_size`` in data source **aviatrix_firewall_instance_images**
+
+### Bug Fixes:
+1. Fixed issue where the forced replacement of the resource **aviatrix_cloudn_registration** errors out
+2. Fixed issue where the creation of the resource **aviatrix_aws_tgw_vpc_attachment** errors out
+3. Fixed issue where ``interface`` attribute in **aviatrix_snat** and **aviatrix_dnat** ``policy`` could not be set when using policy-based connections
+4. Fixed issue with **aviatrix_transit_gateway_peering** creation when using gateways that do not exist
+
+### Preview Features:
+1. Implemented new resources to support micro-segmentation:
+  - **aviatrix_app_domain**
+  - **aviatrix_microseg_policy_list**
+
+### Deprecations
+1. Deprecated support for CloudWAN. The following resources are removed:
+  - **aviatrix_device_registration**
+  - **aviatrix_device_tag**
+  - **aviatrix_device_transit_gateway_attachment**
+  - **aviatrix_device_aws_tgw_attachment**
+  - **aviatrix_device_virtual_wan_attachment**
+2. Removed support for the following attributes from the resource **aviatrix_cloudn_transit_gateway_attachment**:
+  - ``enable_dead_peer_detection``
+  - ``enable_learned_cidrs_approval``
+  - ``approved_cidrs``
+
 
 ## 2.21.2
 ### Notes:

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -269,7 +269,7 @@ The following arguments are supported:
 * `bgp_ecmp` - (Optional) Enable Equal Cost Multi Path (ECMP) routing for the next hop. Default value: false.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: "50".
-* `spoke_bgp_manual_advertise_cidrs` - (Optional) Intended CIDR list to be advertised to external BGP router. Empty string is not valid. Example: "10.2.0.0/16,10.4.0.0/16".
+* `spoke_bgp_manual_advertise_cidrs` - (Optional) Intended CIDR list to be advertised to external BGP router. Empty list is not valid. Example: ["10.2.0.0/16", "10.4.0.0/16"].
 * `enable_active_standby` - (Optional) Enables [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby). Available only with HA enabled. Valid values: true, false. Default value: false.
 * `enable_active_standby_preemptive` - (Optional) Enables Preemptive Mode for Active-Standby. Available only with BGP enabled, HA enabled and Active-Standby enabled. Valid values: true, false. Default value: false.
 * `local_as_number` - (Optional) Changes the Aviatrix Spoke Gateway ASN number before you setup Aviatrix Spoke Gateway connection configurations.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -324,8 +324,8 @@ The following arguments are supported:
 * `connected_transit` - (Optional) Specify Connected Transit status. If enabled, it allows spokes to run traffics to other spokes via transit gateway. Valid values: true, false. Default value: false.
 * `enable_advertise_transit_cidr` - (Optional) Switch to enable/disable advertise transit VPC network CIDR for a VGW connection. Available as of R2.6. **NOTE: If previously enabled through vgw_conn resource prior to provider version R2.6, please see notes [here](#cidr-advertising).**
 * `bgp_manual_spoke_advertise_cidrs` - (Optional) Intended CIDR list to be advertised to external BGP router. Example: "10.2.0.0/16,10.4.0.0/16". Available as of R2.6. **NOTE: If previously enabled through vgw_conn resource prior to provider version R2.6, please see notes [here](#cidr-advertising).**
-* `enable_hybrid_connection` - (Optional) Sign of readiness for TGW connection. Only supported for AWS, AWSGov, AWSChina, AWS Top Secret and AWS Secret. Example: false.
-* `enable_firenet` - (Optional) Sign of readiness for FireNet connection. Valid values: true, false. Default value: false. **NOTE: If previously using an older provider version R2.5 where attribute name was `enable_firenet_interfaces`, please see notes [here](#enable_firenet-1).**
+* `enable_hybrid_connection` - (Optional) Sign of readiness for AWS TGW connection. Only supported for AWS, AWSGov, AWSChina, AWS Top Secret and AWS Secret. Example: false.
+* `enable_firenet` - (Optional) Set to true to use gateway for legacy [AWS TGW-based FireNet](https://docs.aviatrix.com/HowTos/firewall_network_faq.html) connection. Valid values: true, false. Default value: false. **NOTE: If previously using an older provider version R2.5 where attribute name was `enable_firenet_interfaces`, please see notes [here](#enable_firenet-1).**
 * `enable_transit_summarize_cidr_to_tgw` - (Optional) Enable summarize CIDR to TGW. Valid values: true, false. Default value: false.
 * `enable_active_standby` - (Optional) Enables [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby). Available only with HA enabled. Valid values: true, false. Default value: false. Available in provider version R2.17.1+.
 * `enable_active_standby_preemptive` - (Optional) Enables Preemptive Mode for Active-Standby. Available only with BGP enabled, HA enabled and Active-Standby enabled. Valid values: true, false. Default value: false.
@@ -340,7 +340,7 @@ The following arguments are supported:
 
 -> **NOTE:** Enabling FireNet will automatically enable hybrid connection. If `enable_firenet` is set to true, please set `enable_hybrid_connection` to true in the respective **aviatrix_transit_gateway** as well.
 
-* `enable_transit_firenet` - (Optional) Sign of readiness for [Transit FireNet](https://docs.aviatrix.com/HowTos/transit_firenet_faq.html) connection. Valid values: true, false. Default value: false. Available in provider version R2.12+.
+* `enable_transit_firenet` - (Optional) Set to true to use gateway for [Transit FireNet](https://docs.aviatrix.com/HowTos/transit_firenet_faq.html) connection. Valid values: true, false. Default value: false. Available in provider version R2.12+.
 * `lan_vpc_id` - (Optional) LAN VPC ID. Only valid when enabling Transit FireNet on GCP. Available as of provider version R2.18.1+.
 * `lan_private_subnet` - (Optional) LAN Private Subnet. Only valid when enabling Transit FireNet on GCP. Available as of provider version R2.18.1+.
 * `enable_egress_transit_firenet` - (Optional) Enable [Egress Transit FireNet](https://docs.aviatrix.com/HowTos/transit_firenet_workflow.html#b-enable-transit-firenet-on-aviatrix-egress-transit-gateway). Valid values: true, false. Default value: false. Available in provider version R2.16.3+.


### PR DESCRIPTION
* Update release notes

* Update changelist (deprecations, changes)

* Update release-compat chart to support only 1.0

* Fix spoke doc attribute: wrong data type

* (AVX-22545) Update transit doc to clarify TGW vs Transit FireNet