### PR TITLE
AVX-24069: add support for conn as path prepend for bgpspoke transit atch

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -225,6 +225,9 @@ func resourceAviatrixSpokeTransitAttachmentRead(d *schema.ResourceData, meta int
 				return fmt.Errorf("could not set transit_prepend_as_path: %v", err)
 			}
 		}
+	} else {
+		d.Set("spoke_prepend_as_path", nil)
+		d.Set("transit_prepend_as_path", nil)
 	}
 
 	d.SetId(attachment.SpokeGwName + "~" + attachment.TransitGwName)

--- a/docs/resources/aviatrix_spoke_transit_attachment.md
+++ b/docs/resources/aviatrix_spoke_transit_attachment.md
@@ -37,8 +37,15 @@ The following arguments are supported:
 * `transit_gw_name` - (Required) Name of the transit gateway to attach the spoke gateway to.
 
 ### Advanced Options
-* `route_tables` - (Optional) Advanced option. Learned routes will be propagated to these route tables. Example: ["rtb-212ff547","rtb-04539787"].
+* `route_tables` - (Optional) Learned routes will be propagated to these route tables. Example: ["rtb-212ff547","rtb-04539787"].
+* `spoke_prepend_as_path` - (Optional) Connection based AS Path Prepend. Valid only for BGP connection. Can only use the gateway's own local AS number, repeated up to 25 times. Applies on spoke_gateway_name. Available as of provider version R2.23+.
+* `transit_prepend_as_path` - (Optional) Connection based AS Path Prepend. Valid only for BGP connection. Can only use the gateway's own local AS number, repeated up to 25 times. Applies on transit_gateway_name. Available as of provider version R2.23+.
 
+## Attribute Reference
+
+In addition to all arguments above, the following attribute is exported:
+
+* `spoke_bgp_enabled` - Indicates whether the spoke gateway is BGP enabled or not.
 
 ## Import
 

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -259,6 +259,7 @@ type GatewayDetail struct {
 	RouteTables                  []string      `json:"spoke_rtb_list,omitempty"`
 	CustomizedTransitVpcRoutes   []string      `json:"customized_transit_vpc_cidrs"`
 	BundleVpcInfo                BundleVpcInfo `json:"bundle_vpc_info"`
+	BgpEnabled                   bool          `json:"bgp_enabled"`
 }
 
 type BundleVpcInfo struct {

--- a/goaviatrix/spoke_transit_attachment.go
+++ b/goaviatrix/spoke_transit_attachment.go
@@ -8,11 +8,14 @@ import (
 )
 
 type SpokeTransitAttachment struct {
-	Action        string `form:"action,omitempty"`
-	CID           string `form:"CID,omitempty"`
-	SpokeGwName   string `form:"spoke_gw,omitempty"`
-	TransitGwName string `form:"transit_gw,omitempty"`
-	RouteTables   string `form:"route_table_list,omitempty"`
+	Action               string `form:"action,omitempty"`
+	CID                  string `form:"CID,omitempty"`
+	SpokeGwName          string `form:"spoke_gw,omitempty"`
+	TransitGwName        string `form:"transit_gw,omitempty"`
+	RouteTables          string `form:"route_table_list,omitempty"`
+	SpokeBgpEnabled      bool
+	SpokePrependAsPath   []string
+	TransitPrependAsPath []string
 }
 
 func (c *Client) CreateSpokeTransitAttachment(spokeTransitAttachment *SpokeTransitAttachment) error {
@@ -50,6 +53,7 @@ func (c *Client) GetSpokeTransitAttachment(spokeTransitAttachment *SpokeTransitA
 	if data.Results.GwName == spokeTransitAttachment.SpokeGwName {
 		if data.Results.TransitGwName == spokeTransitAttachment.TransitGwName || data.Results.EgressTransitGwName == spokeTransitAttachment.TransitGwName {
 			spokeTransitAttachment.RouteTables = strings.Join(data.Results.RouteTables, ",")
+			spokeTransitAttachment.SpokeBgpEnabled = data.Results.BgpEnabled
 			return spokeTransitAttachment, nil
 		}
 	}


### PR DESCRIPTION
This is a feature for 6.8.

The `route_tables` option is not working for BGPSpoke now, but backend suggested leaving it there. Once backend change is in, it will work.