### PR TITLE
AVX-24164: Fix stateful firewall

### DIFF
--- a/docs/resources/aviatrix_firewall.md
+++ b/docs/resources/aviatrix_firewall.md
@@ -81,7 +81,7 @@ The following arguments are supported:
 * `base_policy` - (Optional) New base policy. Valid Values: "allow-all", "deny-all". Default value: "deny-all"
 * `base_log_enabled` - (Optional) Indicates whether enable logging or not. Valid Values: true, false. Default value: false.
 * `manage_firewall_policies` - (Optional) Enable to manage firewall policies via in-line rules. If false, policies must be managed using `aviatrix_firewall_policy` resources. Default: true. Valid values: true, false. Available in provider version R2.17+.
-* `policy` - (Optional) New access policy for the gateway. Seven fields are required for each policy item: `src_ip`, `dst_ip`, `protocol`, `port`, `action`, `log_enabled` and `description`. No duplicate rules(with same `src_ip`, `dst_ip`, `protocol` and `port`) are allowed 
+* `policy` - (Optional) New access policy for the gateway. Seven fields are required for each policy item: `src_ip`, `dst_ip`, `protocol`, `port`, `action`, `log_enabled` and `description`. No duplicate rules (with same `src_ip`, `dst_ip`, `protocol` and `port`) are allowed.
   * `src_ip` - (Required) Source address, a valid IPv4 address or tag name such "HR" or "marketing" etc. Example: "10.30.0.0/16". The **aviatrix_firewall_tag** resource should be created prior to using the tag name.
   * `dst_ip` - (Required) Destination address, a valid IPv4 address or tag name such "HR" or "marketing" etc. Example: "10.30.0.0/16". The **aviatrix_firewall_tag** resource should be created prior to using the tag name.
   * `protocol`- (Optional): Valid values: "all", "tcp", "udp", "icmp", "sctp", "rdp", "dccp". Default value: "all".

--- a/docs/resources/aviatrix_firewall.md
+++ b/docs/resources/aviatrix_firewall.md
@@ -24,9 +24,56 @@ resource "aviatrix_firewall" "stateful_firewall_1" {
 }
 ```
 
-## Argument Reference
+```hcl
+# Create an Aviatrix Firewall with in-line rules
+resource "aviatrix_firewall" "stateful_firewall_1" {
+  gw_name          = "gateway-1"
+  base_policy      = "allow-all"
+  base_log_enabled = true
 
-!> **WARNING:** Attribute `policy` has been deprecated as of provider version R2.18.1+ and will not receive further updates. Please set `manage_firewall_policies` to false, and use the standalone `aviatrix_firewall_policy` resource instead.
+  policy {
+    protocol    = "all"
+    src_ip      = "10.17.0.224/32"
+    log_enabled = true
+    dst_ip      = "10.12.0.172/32"
+    action      = "force-drop"
+    port        = "0:65535"
+    description = "first_policy"
+  }
+
+  policy {
+    protocol    = "tcp"
+    src_ip      = "10.16.0.224/32"
+    log_enabled = false
+    dst_ip      = "10.12.1.172/32"
+    action      = "force-drop"
+    port        = "325"
+    description = "second_policy"
+  }
+
+  policy {
+    protocol    = "udp"
+    src_ip      = "10.14.0.225/32"
+    log_enabled = false
+    dst_ip      = "10.13.1.173/32"
+    action      = "deny"
+    port        = "325"
+    description = "third_policy"
+  }
+  
+  policy {
+    protocol    = "tcp"
+    src_ip      = aviatrix_firewall_tag.test.firewall_tag
+    log_enabled = false
+    dst_ip      = "10.13.1.173/32"
+    action      = "deny"
+    port        = "325"
+    description = "fourth_policy"
+  }
+}
+```
+
+## Argument Reference
 
 The following arguments are supported:
 
@@ -34,11 +81,11 @@ The following arguments are supported:
 * `base_policy` - (Optional) New base policy. Valid Values: "allow-all", "deny-all". Default value: "deny-all"
 * `base_log_enabled` - (Optional) Indicates whether enable logging or not. Valid Values: true, false. Default value: false.
 * `manage_firewall_policies` - (Optional) Enable to manage firewall policies via in-line rules. If false, policies must be managed using `aviatrix_firewall_policy` resources. Default: true. Valid values: true, false. Available in provider version R2.17+.
-* `policy` - (Optional) New access policy for the gateway. Type: String (valid JSON). Seven fields are required for each policy item: `src_ip`, `dst_ip`, `protocol`, `port`, `allow_deny`, `log_enabled` and `description`.
-  * `src_ip` - (Required) CIDRs separated by comma or tag names such "HR" or "marketing" etc. Example: "10.30.0.0/16,10.45.0.0/20". The **aviatrix_firewall_tag** resource should be created prior to using the tag name.
-  * `dst_ip` - (Required) CIDRs separated by comma or tag names such "HR" or "marketing" etc. Example: "10.30.0.0/16,10.45.0.0/20". The **aviatrix_firewall_tag** resource should be created prior to using the tag name.
-  * `protocol`- (Optional): "all", "tcp", "udp", "icmp", "sctp", "rdp", "dccp".
-  * `port` - (Required) a single port or a range of port numbers. Example: "25", "25:1024".
+* `policy` - (Optional) New access policy for the gateway. Seven fields are required for each policy item: `src_ip`, `dst_ip`, `protocol`, `port`, `action`, `log_enabled` and `description`. No duplicate rules(with same `src_ip`, `dst_ip`, `protocol` and `port`) are allowed 
+  * `src_ip` - (Required) Source address, a valid IPv4 address or tag name such "HR" or "marketing" etc. Example: "10.30.0.0/16". The **aviatrix_firewall_tag** resource should be created prior to using the tag name.
+  * `dst_ip` - (Required) Destination address, a valid IPv4 address or tag name such "HR" or "marketing" etc. Example: "10.30.0.0/16". The **aviatrix_firewall_tag** resource should be created prior to using the tag name.
+  * `protocol`- (Optional): Valid values: "all", "tcp", "udp", "icmp", "sctp", "rdp", "dccp". Default value: "all".
+  * `port` - (Required) A single port or a range of port numbers. Example: "25", "25:1024".
   * `action`- (Required) Valid values: "allow", "deny" and "force-drop" (in stateful firewall rule to allow immediate packet dropping on established sessions).
   * `log_enabled`- (Optional) Valid values: true, false. Default value: false.
   * `description`- (Optional) Description of the policy. Example: "This is policy no.1".


### PR DESCRIPTION
The order of the rules in Policy matters:
1. "force-drop" rules need to be ahead of other rules since they will be created ahead of other rules.
2. no duplicate rules (with same "src_ip", "dst_ip", "protocol" and "port") are allowed.
3. adding a new rule into a position in the Policy list will insert the rule in the position.
4. fix editing the base policy and base logging at the same time.
5. reset base policy and base logging to default values in destroy.
6. delete deprecation message for Policy.