### PR TITLE
There should have no space in front and after equal "=" sign.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,9 +75,9 @@ provider "aviatrix" {}
 **Usage:**
 
 ```sh
-$ export AVIATRIX_CONTROLLER_IP = "1.2.3.4"
-$ export AVIATRIX_USERNAME = "admin"
-$ export AVIATRIX_PASSWORD = "password"
+$ export AVIATRIX_CONTROLLER_IP="1.2.3.4"
+$ export AVIATRIX_USERNAME="admin"
+$ export AVIATRIX_PASSWORD="password"
 $ terraform plan
 ```
 


### PR DESCRIPTION
In bash, having space around equal sign will error:  bash: export: `=': not a valid identifier
In zsh, having space around equal sign will error: zsh: bad assignment