### PR TITLE
AVX-24724: remove check during import

### DIFF
--- a/aviatrix/resource_aviatrix_controller_security_group_management_config.go
+++ b/aviatrix/resource_aviatrix_controller_security_group_management_config.go
@@ -76,10 +76,6 @@ func resourceAviatrixControllerSecurityGroupManagementConfigCreate(d *schema.Res
 func resourceAviatrixControllerSecurityGroupManagementConfigRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 
-	if d.Id() != strings.Replace(client.ControllerIP, ".", "-", -1) {
-		return fmt.Errorf("ID: %s does not match controller IP. Please provide correct ID for importing", d.Id())
-	}
-
 	sgm, err := client.GetSecurityGroupManagementStatus()
 	if err != nil {
 		return fmt.Errorf("could not read Aviatrix Controller Security Group Management Status: %s", err)


### PR DESCRIPTION
This is a workaround for the issue described in the ticket. If we allow users to customize ID, in some situations there'll be diffs. It seems removing this check won't cause any issue. 