### PR TITLE
AVX-32353: v2 API migration for fqdn related resources

### DIFF
--- a/aviatrix/resource_aviatrix_fqdn_global_config.go
+++ b/aviatrix/resource_aviatrix_fqdn_global_config.go
@@ -112,8 +112,11 @@ func resourceAviatrixFQDNGlobalConfigCreate(ctx context.Context, d *schema.Resou
 	}
 
 	if enableCustomNetworkFiltering {
-		configIpString := strings.Join(goaviatrix.ExpandStringList(d.Get("configured_ips").([]interface{})), ",")
-		err := client.SetFQDNCustomNetwork(ctx, configIpString)
+		var configIPs []string
+		for _, v := range d.Get("configured_ips").([]interface{}) {
+			configIPs = append(configIPs, v.(string))
+		}
+		err := client.SetFQDNCustomNetwork(ctx, configIPs)
 		if err != nil {
 			return diag.Errorf("failed to customize network filtering: %s", err)
 		}
@@ -248,8 +251,11 @@ func resourceAviatrixFQDNGlobalConfigUpdate(ctx context.Context, d *schema.Resou
 
 		if d.HasChanges("enable_custom_network_filtering", "configured_ips") {
 			if enableCustomNetworkFiltering {
-				configIpString := strings.Join(goaviatrix.ExpandStringList(d.Get("configured_ips").([]interface{})), ",")
-				err := client.SetFQDNCustomNetwork(ctx, configIpString)
+				var configIPs []string
+				for _, v := range d.Get("configured_ips").([]interface{}) {
+					configIPs = append(configIPs, v.(string))
+				}
+				err := client.SetFQDNCustomNetwork(ctx, configIPs)
 				if err != nil {
 					return diag.Errorf("failed to customize network filtering in update: %s", err)
 				}


### PR DESCRIPTION
This PR covers:
1. set_fqdn_filter_tag_domain_names
2. update_fqdn_filter_tag_source_ip_filters
3. update_fqdn_pass_through_cidrs
4. disable_fqdn_on_custom_networks