### PR TITLE
AVX-34278: Fix aws peering force replace issue

### DIFF
--- a/aviatrix/resource_aviatrix_aws_peer.go
+++ b/aviatrix/resource_aviatrix_aws_peer.go
@@ -56,20 +56,28 @@ func resourceAviatrixAWSPeer() *schema.Resource {
 				Description: "Region of AWS cloud.",
 			},
 			"rtb_list1": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
-				Description: "List of Route table IDs of VPC1.",
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: goaviatrix.ValidateRtbId,
+				},
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncRtbList1,
+				Description:      "List of Route table IDs of VPC1.",
 			},
 			"rtb_list2": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
-				Description: "List of Route table IDs of VPC2.",
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: goaviatrix.ValidateRtbId,
+				},
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncRtbList2,
+				Description:      "List of Route table IDs of VPC2.",
 			},
 		},
 	}
@@ -152,8 +160,6 @@ func resourceAviatrixAWSPeerRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("account_name2", ap.AccountName2)
 		d.Set("vpc_reg1", ap.Region1)
 		d.Set("vpc_reg2", ap.Region2)
-		log.Printf("zjin00: ap.RtbList1 is %v", ap.RtbList1)
-		log.Printf("zjin01: ap.RtbList1 is %v", strings.Split(ap.RtbList1, ","))
 
 		if err := d.Set("rtb_list1", strings.Split(ap.RtbList1, ",")); err != nil {
 			log.Printf("[WARN] Error setting rtb_list1 for (%s): %s", d.Id(), err)

--- a/docs/resources/aviatrix_aws_peer.md
+++ b/docs/resources/aviatrix_aws_peer.md
@@ -44,9 +44,10 @@ The following arguments are supported:
 * `rtb_list1` - (Optional) List of Route table IDs of VPC1. Example: ["rtb-abcd1234", "rtb-wxyz5678"].
 * `rtb_list2` - (Optional) List of Route table IDs of VPC2. Example: ["rtb-abcd1234", "rtb-wxyz5678"].
 
-~> **NOTE:** For attributes `rtb_list1` and `rtb_list2`, only valid route table ID with prefix "rtb-" is supported and
-"all" is no longer supported since 3.0.1+. If an **aviatrix_aws_peer** resource is created with provider 3.0.0- and any
-`rtb_list1` or `rtb_list2` was set as ["all"], it will need to be updated to list of valid route table IDs.
+~> **NOTE:** For attributes `rtb_list1` and `rtb_list2`, only valid route table IDs with prefix "rtb-" are supported.
+Therefore, "all" will no longer be supported as a valid input as of 3.0.1 onward. If an **aviatrix_aws_peer** resource
+was created with provider 3.0.0- and any `rtb_list1` or `rtb_list2` was set as ["all"], it will need to be updated to
+a list of valid route table IDs.
 
 ## Import
 

--- a/docs/resources/aviatrix_aws_peer.md
+++ b/docs/resources/aviatrix_aws_peer.md
@@ -44,6 +44,10 @@ The following arguments are supported:
 * `rtb_list1` - (Optional) List of Route table IDs of VPC1. Example: ["rtb-abcd1234", "rtb-wxyz5678"].
 * `rtb_list2` - (Optional) List of Route table IDs of VPC2. Example: ["rtb-abcd1234", "rtb-wxyz5678"].
 
+~> **NOTE:** For attributes `rtb_list1` and `rtb_list2`, only valid route table ID with prefix "rtb-" is supported and
+"all" is no longer supported since 3.0.1+. If an **aviatrix_aws_peer** resource is created with provider 3.0.0- and any
+`rtb_list1` or `rtb_list2` was set as ["all"], it will need to be updated to list of valid route table IDs.
+
 ## Import
 
 **aws_peer** can be imported using the `vpc_id1` and `vpc_id2`, e.g.

--- a/docs/resources/aviatrix_aws_peer.md
+++ b/docs/resources/aviatrix_aws_peer.md
@@ -45,8 +45,8 @@ The following arguments are supported:
 * `rtb_list2` - (Optional) List of Route table IDs of VPC2. Example: ["rtb-abcd1234", "rtb-wxyz5678"].
 
 ~> **NOTE:** For attributes `rtb_list1` and `rtb_list2`, only valid route table IDs with prefix "rtb-" are supported.
-Therefore, "all" will no longer be supported as a valid input as of 3.0.1 onward. If an **aviatrix_aws_peer** resource
-was created with provider 3.0.0- and any `rtb_list1` or `rtb_list2` was set as ["all"], it will need to be updated to
+Therefore, "all" will no longer be supported as a valid input as of 3.0.2 onward. If an **aviatrix_aws_peer** resource
+was created with provider 3.0.1- and any `rtb_list1` or `rtb_list2` was set as ["all"], it will need to be updated to
 a list of valid route table IDs.
 
 ## Import

--- a/goaviatrix/utils.go
+++ b/goaviatrix/utils.go
@@ -258,3 +258,18 @@ func ValidateAttachedVPCsForCustomizedRoutes(a, b [][]string) ([][]string, [][]s
 func IsCloudType(cloudType, compare int) bool {
 	return cloudType&compare != 0
 }
+
+func ValidateRtbId(val interface{}, key string) (warns []string, errs []error) {
+	v, ok := val.(string)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be of type string", key))
+		return
+	}
+
+	if !strings.HasPrefix(v, "rtb-") {
+		errs = append(errs, fmt.Errorf("%q must has a prefix 'rtb-', got: %s", key, val))
+		return
+	}
+
+	return warns, errs
+}


### PR DESCRIPTION
1. Ignore the order of route tables in rtb_list1 and rtb_list2 since the order does not matter;
2. Remove support of value ["all"] for rtb_list1 and rtb_list2.