### PR TITLE
AVX-34468: upgrade form package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/AviatrixSystems/terraform-provider-aviatrix/v3
 go 1.18
 
 require (
-	github.com/ajg/form v1.5.1
+	github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0
 	github.com/sirupsen/logrus v1.7.0
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
 )
 
 require (
@@ -48,7 +49,6 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
-github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1 h1:8Qzi+0Uch1VJvdrOhJ8U8FqoPLbUdETPgMqGJ6DSMSQ=
+github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=

--- a/vendor/github.com/ajg/form/encode.go
+++ b/vendor/github.com/ajg/form/encode.go
@@ -66,9 +66,13 @@ func (e Encoder) Encode(dst interface{}) error {
 }
 
 // EncodeToString encodes dst as a form and returns it as a string.
-func EncodeToString(dst interface{}) (string, error) {
+func EncodeToString(dst interface{}, needEmptyValue ...bool) (string, error) {
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, false)
+	z := false
+	if len(needEmptyValue) != 0 {
+		z = needEmptyValue[0]
+	}
+	n, err := encodeToNode(v, z)
 	if err != nil {
 		return "", err
 	}
@@ -77,9 +81,13 @@ func EncodeToString(dst interface{}) (string, error) {
 }
 
 // EncodeToValues encodes dst as a form and returns it as Values.
-func EncodeToValues(dst interface{}) (url.Values, error) {
+func EncodeToValues(dst interface{}, needEmptyValue ...bool) (url.Values, error) {
 	v := reflect.ValueOf(dst)
-	n, err := encodeToNode(v, false)
+	z := false
+	if len(needEmptyValue) != 0 {
+		z = needEmptyValue[0]
+	}
+	n, err := encodeToNode(v, z)
 	if err != nil {
 		return nil, err
 	}
@@ -260,15 +268,23 @@ func canIndexOrdinally(v reflect.Value) bool {
 	return false
 }
 
-func fieldInfo(f reflect.StructField) (k string, oe bool) {
+func fieldInfo(f reflect.StructField, tagName ...string) (k string, oe bool) {
+	_tagName := "form"
+	if len(tagName) > 0 {
+		_tagName = tagName[0]
+	}
 	if f.PkgPath != "" { // Skip private fields.
 		return omittedKey, oe
 	}
 
 	k = f.Name
-	tag := f.Tag.Get("form")
+	tag := f.Tag.Get(_tagName)
 	if tag == "" {
-		return k, oe
+		if len(tagName) == 0 && _tagName != "json" {
+			return fieldInfo(f, "json") // using json as secondary
+		} else {
+			return k, oe
+		}
 	}
 
 	ps := strings.SplitN(tag, ",", 2)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/agext/levenshtein v1.2.3
 ## explicit
 github.com/agext/levenshtein
-# github.com/ajg/form v1.5.1
+# github.com/ajg/form v1.5.2-0.20200323032839-9aeb3cf462e1
 ## explicit
 github.com/ajg/form
 # github.com/apparentlymart/go-cidr v1.1.0


### PR DESCRIPTION
The old form package will parse false boolean value to an empty string, which is ok for V1 API but not for V2 API. The newer package fixed the issue.