### PR TITLE
AVX-37596: Fix body not shown in error when json decode fails

### DIFF
--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -413,9 +413,9 @@ func checkAPIResp(resp *http.Response, action string, checkFunc CheckAPIResponse
 	if err != nil {
 		return fmt.Errorf("reading response body %q failed: %v", action, err)
 	}
-
-	if err = json.NewDecoder(&b).Decode(&data); err != nil {
-		return fmt.Errorf("json Decode %q failed: %v\n Body: %s", action, err, b.String())
+	body := b.String()
+	if err = json.Unmarshal([]byte(body), &data); err != nil {
+		return fmt.Errorf("json Decode %q failed: %v\n Body: %s", action, err, body)
 	}
 
 	return checkFunc(action, "Post", data.Reason, data.Return)


### PR DESCRIPTION
With the current code, after the JSON Unmarshal fails, the bytes.Buffer is already empty because json.Decode has read it all. So in the error we never actually show what the body was. So we get errors like 
```
│ Error: json Decode "append_stateful_firewall_rules" failed: invalid character '<' looking for beginning of value
│  Body:
```

But it should be
```
│ Error: json Decode "append_stateful_firewall_rules" failed: invalid character '<' looking for beginning of value
│  Body: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
│ <html><head>
│ <title>400 Bad Request</title>
│ </head><body>
│ <h1>Bad Request</h1>
│ <p>Your browser sent a request that this server could not understand.<br />
│ </p>
│ </body></html>
```