### PR TITLE
AVX-39055: Deprecate Firenet Keep Alive via Firewall Lan option (#1830)

### DIFF
--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -56,9 +56,12 @@ func resourceAviatrixFireNet() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"5-Tuple", "2-Tuple"}, false),
 			},
 			"keep_alive_via_lan_interface_enabled": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Deprecated: "Option to enable/disable keep_alive_via_lan_interface will be removed in Aviatrix provider v3.2.0. As of provider v3.1.2, disabling keep_alive_via_lan_interface will NOT be allowed." +
+					"\n\nIf you have set 'keep_alive_via_lan_interface_enabled = true', no action is needed at this time. After you upgrade to Aviatrix provider v3.2.0, you can safely remove the 'keep_alive_via_lan_interface_enabled' attribute from your configuration." +
+					"\n\nIf you have set 'keep_alive_via_lan_interface_enabled = false', you must enable it before you can upgrade to Aviatrix provider v3.2.0.",
 				Description: "Enable Keep Alive via Firewall LAN Interface.",
 			},
 			"tgw_segmentation_for_egress_enabled": {

--- a/docs/resources/aviatrix_firenet.md
+++ b/docs/resources/aviatrix_firenet.md
@@ -61,7 +61,10 @@ The following arguments are supported:
 * `east_west_inspection_excluded_cidrs` - (Optional) Network List Excluded From East-West Inspection. CIDRs to be excluded from inspection. Type: Set(String). Available as of provider version R2.19.5+.
 * `tgw_segmentation_for_egress_enabled` - (Optional) Enable TGW segmentation for egress. Valid values: true or false. Default value: false. Available as of provider version R2.19+.
 * `hashing_algorithm` - (Optional) Hashing algorithm to load balance traffic across the firewall. Valid values: "2-Tuple", "5-Tuple". Default value: "5-Tuple".
+
 * `keep_alive_via_lan_interface_enabled` - (Optional) Enable Keep Alive via Firewall LAN Interface. Valid values: true or false. Default value: false. Available as of provider version R2.18.1+.
+
+~> **NOTE:** `keep_alive_via_lan_interface_enabled` - Option to enable/disable keep_alive_via_lan_interface will be removed in Aviatrix provider v3.2.0. As of provider v3.1.2, disabling keep_alive_via_lan_interface will NOT be allowed.
 
 The following arguments are deprecated:
 


### PR DESCRIPTION
* AVX-39055: Deprecate Firenet Keep Alive via Firewall Lan option
* Add deprecation message to markdown