### PR TITLE
Add GCP and OCI file content authentication

### DIFF
--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -43,7 +43,7 @@ type Account struct {
 	OciUserID                             string `form:"oci_user_id" json:"oci_user_id,omitempty"`
 	OciCompartmentID                      string `form:"oci_compartment_id" json:"oci_compartment_id,omitempty"`
 	OciApiPrivateKeyFilePath              string `form:"oci_api_key_path" json:"oci_api_private_key_filepath,omitempty"`
-	OciApiPrivateKey                      string `form:"oci_api_key" json:"oci_api_private_key,omitempty"`
+	OciApiPrivateKey                      string `form:"oci_oci_api_private_key" json:"oci_api_private_key,omitempty"`
 	AzuregovSubscriptionId                string `form:"azure_gov_subscription_id,omitempty" json:"arm_gov_subscription_id,omitempty"`
 	AzuregovApplicationEndpoint           string `form:"azure_gov_application_endpoint,omitempty" json:"arm_gov_ad_tenant_id,omitempty"`
 	AzuregovApplicationClientId           string `form:"azure_gov_application_client_id,omitempty" json:"arm_gov_ad_client_id,omitempty"`
@@ -160,7 +160,8 @@ func (c *Client) CreateOCIAccount(account *Account) error {
 			Path:           account.OciApiPrivateKeyFilePath,
 			ParamName:      "oci_api_key",
 			UseFileContent: account.OciApiPrivateKey != "",
-			FileContent:    account.OciApiPrivateKey,
+			FileContent:    strings.TrimSpace(account.OciApiPrivateKey), // Trim space is needed to remove the newline at the end of the file. An error is thrown if the file has a newline at the end.
+			FileName:       "aviatrix-oci.pem",
 		},
 	}
 

--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -37,7 +37,7 @@ type Account struct {
 	ProjectCredentialsFilename            string `form:"filename,omitempty"` //Applies for both GCP and OCI
 	ProjectCredentialsContents            string `form:"contents,omitempty"` //Applies for both GCP and OCI
 	GcloudProjectCredentialsFilepathLocal string `form:"gcloud_project_credentials_local,omitempty"`
-	GcloudProjectCredentialsLocal         string `form:"gcloud_project_local,omitempty"`
+	GcloudProjectCredentialsContents      string `form:"gcloud_project_credentials_contents,omitempty"`
 	GcloudProjectName                     string `form:"gcloud_project_name,omitempty" json:"project,omitempty"`
 	OciTenancyID                          string `form:"oci_tenancy_id" json:"oci_tenancy_id,omitempty"`
 	OciUserID                             string `form:"oci_user_id" json:"oci_user_id,omitempty"`
@@ -114,7 +114,7 @@ func (c *Client) CreateAccount(account *Account) error {
 	return c.PostAPI(account.Action, account, DuplicateBasicCheck)
 }
 
-// Create an OCI account and if the file content is passed, it takes precedence over the file path.
+// Create an GCP account and if the file content is passed, it takes precedence over the file path.
 //
 // If both the file path and file content, the file content will be used.
 func (c *Client) CreateGCPAccount(account *Account) error {
@@ -131,8 +131,9 @@ func (c *Client) CreateGCPAccount(account *Account) error {
 		{
 			Path:           account.GcloudProjectCredentialsFilepathLocal,
 			ParamName:      "gcloud_project_credentials",
-			UseFileContent: account.GcloudProjectCredentialsLocal != "",
-			FileContent:    account.GcloudProjectCredentialsLocal,
+			UseFileContent: account.GcloudProjectCredentialsContents != "",
+			FileContent:    account.GcloudProjectCredentialsContents,
+			FileName:       "aviatrix-gcp.json",
 		},
 	}
 
@@ -269,8 +270,10 @@ func (c *Client) UpdateGCPAccount(account *Account) error {
 
 	files := []File{
 		{
-			Path:      account.GcloudProjectCredentialsFilepathLocal,
-			ParamName: "gcloud_project_credentials",
+			Path:           account.GcloudProjectCredentialsFilepathLocal,
+			ParamName:      "gcloud_project_credentials",
+			UseFileContent: account.GcloudProjectCredentialsContents != "",
+			FileContent:    account.GcloudProjectCredentialsContents,
 		},
 	}
 

--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -274,6 +274,7 @@ func (c *Client) UpdateGCPAccount(account *Account) error {
 			ParamName:      "gcloud_project_credentials",
 			UseFileContent: account.GcloudProjectCredentialsContents != "",
 			FileContent:    account.GcloudProjectCredentialsContents,
+			FileName:       "aviatrix-gcp.json",
 		},
 	}
 

--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -37,11 +37,13 @@ type Account struct {
 	ProjectCredentialsFilename            string `form:"filename,omitempty"` //Applies for both GCP and OCI
 	ProjectCredentialsContents            string `form:"contents,omitempty"` //Applies for both GCP and OCI
 	GcloudProjectCredentialsFilepathLocal string `form:"gcloud_project_credentials_local,omitempty"`
+	GcloudProjectCredentialsLocal         string `form:"gcloud_project_local,omitempty"`
 	GcloudProjectName                     string `form:"gcloud_project_name,omitempty" json:"project,omitempty"`
 	OciTenancyID                          string `form:"oci_tenancy_id" json:"oci_tenancy_id,omitempty"`
 	OciUserID                             string `form:"oci_user_id" json:"oci_user_id,omitempty"`
 	OciCompartmentID                      string `form:"oci_compartment_id" json:"oci_compartment_id,omitempty"`
 	OciApiPrivateKeyFilePath              string `form:"oci_api_key_path" json:"oci_api_private_key_filepath,omitempty"`
+	OciApiPrivateKey                      string `form:"oci_api_key" json:"oci_api_private_key,omitempty"`
 	AzuregovSubscriptionId                string `form:"azure_gov_subscription_id,omitempty" json:"arm_gov_subscription_id,omitempty"`
 	AzuregovApplicationEndpoint           string `form:"azure_gov_application_endpoint,omitempty" json:"arm_gov_ad_tenant_id,omitempty"`
 	AzuregovApplicationClientId           string `form:"azure_gov_application_client_id,omitempty" json:"arm_gov_ad_client_id,omitempty"`
@@ -112,6 +114,9 @@ func (c *Client) CreateAccount(account *Account) error {
 	return c.PostAPI(account.Action, account, DuplicateBasicCheck)
 }
 
+// Create an OCI account and if the file content is passed, it takes precedence over the file path.
+//
+// If both the file path and file content, the file content will be used.
 func (c *Client) CreateGCPAccount(account *Account) error {
 	params := map[string]string{
 		"CID":                 c.CID,
@@ -124,14 +129,19 @@ func (c *Client) CreateGCPAccount(account *Account) error {
 
 	files := []File{
 		{
-			Path:      account.GcloudProjectCredentialsFilepathLocal,
-			ParamName: "gcloud_project_credentials",
+			Path:           account.GcloudProjectCredentialsFilepathLocal,
+			ParamName:      "gcloud_project_credentials",
+			UseFileContent: account.GcloudProjectCredentialsLocal != "",
+			FileContent:    account.GcloudProjectCredentialsLocal,
 		},
 	}
 
 	return c.PostFileAPI(params, files, DuplicateBasicCheck)
 }
 
+// Create an OCI account and if the file content is passed, it takes precedence over the file path.
+//
+// If both the file path and file content, the file content will be used.
 func (c *Client) CreateOCIAccount(account *Account) error {
 	params := map[string]string{
 		"CID":                c.CID,
@@ -146,8 +156,10 @@ func (c *Client) CreateOCIAccount(account *Account) error {
 
 	files := []File{
 		{
-			Path:      account.OciApiPrivateKeyFilePath,
-			ParamName: "oci_api_key",
+			Path:           account.OciApiPrivateKeyFilePath,
+			ParamName:      "oci_api_key",
+			UseFileContent: account.OciApiPrivateKey != "",
+			FileContent:    account.OciApiPrivateKey,
 		},
 	}
 


### PR DESCRIPTION
*What?*
- Add ability to pass the content of the credentials instead of local files for GCP and OCI auth.
- Add additional parameters for the user to pass the credential content.

*Why?*
- Users might need to store the credentials in a remote storage instead of their local machines, this feature would allow users to store their GCP and OCI credentials in a remote storage, but able to reference the content of the file credentials.
- Adding the additional parameters allows the user to either pass the local file name or the content of the credentials file. If a user passes both the local file name and the content of the credentials, the content of the credentials file will take precedence and be used during authentication.

*Testing*
- Tested passing the OCI credentials.
   - ![Screenshot 2023-11-12 at 10 05 31 PM](https://github.com/AviatrixSystems/terraform-provider-aviatrix/assets/65043605/2853dd29-5ef1-434c-8d2e-9d8b05dc924d)
- Tested passing the GCP credentials.
    - ![Screenshot 2023-11-13 at 12 41 01 AM](https://github.com/AviatrixSystems/terraform-provider-aviatrix/assets/65043605/304fb87b-5e56-45e4-b432-cf024ab5fa2f)
- Tested passing no OCI and GCP credentials.
   - ![Screenshot 2023-11-13 at 1 25 47 AM](https://github.com/AviatrixSystems/terraform-provider-aviatrix/assets/65043605/00e9135b-bd55-43b6-981e-af86b53eaae8)
