### PR TITLE
AVX-51277: Do not set bucket_name for config backup in Azure.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: ^1.21.7
+        go-version: ^1.21
       id: go
 
     - name: Check out code into the Go module directory
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.21.7
+          go-version: ^1.21
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: ^1.14
+        go-version: ^1.21.7
       id: go
 
     - name: Check out code into the Go module directory
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.14
+          go-version: ^1.21.7
         id: go
 
       - name: Check out code into the Go module directory
@@ -64,5 +64,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52
+          version: v1.55
           only-new-issues: true

--- a/goaviatrix/controller.go
+++ b/goaviatrix/controller.go
@@ -162,7 +162,7 @@ func (c *Client) EnableCloudnBackupConfig(cloudnBackupConfiguration *CloudnBacku
 		"region":     cloudnBackupConfiguration.BackupRegion,
 	}
 	// Azure has a set of different parameters that must be set.
-	if IsCloudType(cloudnBackupConfiguration.BackupCloudType, AzureArmRelatedCloudTypes)	{
+	if IsCloudType(cloudnBackupConfiguration.BackupCloudType, AzureArmRelatedCloudTypes) {
 		form["storage_name"] = cloudnBackupConfiguration.BackupStorageName
 		form["container_name"] = cloudnBackupConfiguration.BackupContainerName
 	} else {

--- a/goaviatrix/controller.go
+++ b/goaviatrix/controller.go
@@ -162,7 +162,7 @@ func (c *Client) EnableCloudnBackupConfig(cloudnBackupConfiguration *CloudnBacku
 		"region":     cloudnBackupConfiguration.BackupRegion,
 	}
 	// Azure has a set of different parameters that must be set.
-	if goaviatrix.IsCloudType(cloudnBackupConfiguration.BackupCloudType, goaviatrix.AzureArmRelatedCloudTypes)	{
+	if IsCloudType(cloudnBackupConfiguration.BackupCloudType, AzureArmRelatedCloudTypes)	{
 		form["storage_name"] = cloudnBackupConfiguration.BackupStorageName
 		form["container_name"] = cloudnBackupConfiguration.BackupContainerName
 	} else {

--- a/goaviatrix/controller.go
+++ b/goaviatrix/controller.go
@@ -155,15 +155,22 @@ func (c *Client) GetSecurityGroupManagementStatus() (*SecurityGroupInfo, error) 
 
 func (c *Client) EnableCloudnBackupConfig(cloudnBackupConfiguration *CloudnBackupConfiguration) error {
 	form := map[string]string{
-		"CID":            c.CID,
-		"action":         "enable_cloudn_backup_config",
-		"cloud_type":     strconv.Itoa(cloudnBackupConfiguration.BackupCloudType),
-		"acct_name":      cloudnBackupConfiguration.BackupAccountName,
-		"bucket_name":    cloudnBackupConfiguration.BackupBucketName,
-		"storage_name":   cloudnBackupConfiguration.BackupStorageName,
-		"container_name": cloudnBackupConfiguration.BackupContainerName,
-		"region":         cloudnBackupConfiguration.BackupRegion,
+		"CID":        c.CID,
+		"action":     "enable_cloudn_backup_config",
+		"cloud_type": strconv.Itoa(cloudnBackupConfiguration.BackupCloudType),
+		"acct_name":  cloudnBackupConfiguration.BackupAccountName,
+		"region":     cloudnBackupConfiguration.BackupRegion,
 	}
+	// Azure has a set of different parameters that must be set.
+	if cloudnBackupConfiguration.BackupCloudType == Azure ||
+		cloudnBackupConfiguration.BackupCloudType == AzureGov ||
+		cloudnBackupConfiguration.BackupCloudType == AzureChina {
+		form["storage_name"] = cloudnBackupConfiguration.BackupStorageName
+		form["container_name"] = cloudnBackupConfiguration.BackupContainerName
+	} else {
+		form["bucket_name"] = cloudnBackupConfiguration.BackupBucketName
+	}
+
 	if cloudnBackupConfiguration.MultipleBackups == "true" {
 		form["multiple_bkup"] = "true"
 	}

--- a/goaviatrix/controller.go
+++ b/goaviatrix/controller.go
@@ -162,9 +162,7 @@ func (c *Client) EnableCloudnBackupConfig(cloudnBackupConfiguration *CloudnBacku
 		"region":     cloudnBackupConfiguration.BackupRegion,
 	}
 	// Azure has a set of different parameters that must be set.
-	if cloudnBackupConfiguration.BackupCloudType == Azure ||
-		cloudnBackupConfiguration.BackupCloudType == AzureGov ||
-		cloudnBackupConfiguration.BackupCloudType == AzureChina {
+	if goaviatrix.IsCloudType(cloudnBackupConfiguration.BackupCloudType, goaviatrix.AzureArmRelatedCloudTypes)	{
 		form["storage_name"] = cloudnBackupConfiguration.BackupStorageName
 		form["container_name"] = cloudnBackupConfiguration.BackupContainerName
 	} else {


### PR DESCRIPTION
On the controller we have a bound validator that ensures that the `bucket_name` parameter is non-empty.  When we send a request to backup configuration for Azure, we use a set of different parameters and we do not set `bucket_name`. This causes validation to fail for Azure.