### PR TITLE
AVX-50899: fqdn_lan_interface is not needed for firenet fqdn association

### DIFF
--- a/aviatrix/data_source_aviatrix_gateway.go
+++ b/aviatrix/data_source_aviatrix_gateway.go
@@ -789,16 +789,13 @@ func dataSourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) err
 			d.Set("renegotiation_interval", -1)
 		}
 
-		fqdnGatewayLanInterface := fmt.Sprintf("av-nic-%s_eth1", gw.GwName)
 		fqdnLanCidr, ok := gw.ArmFqdnLanCidr[gw.GwName]
 		if ok && goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) {
-			d.Set("fqdn_lan_interface", fqdnGatewayLanInterface)
 			d.Set("fqdn_lan_cidr", fqdnLanCidr)
 		} else if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.GCPRelatedCloudTypes) {
 			d.Set("fqdn_lan_vpc_id", gw.BundleVpcInfo.LAN.VpcID)
 			d.Set("fqdn_lan_cidr", strings.Split(gw.BundleVpcInfo.LAN.Subnet, "~~")[0])
 		} else {
-			d.Set("fqdn_lan_interface", "")
 			d.Set("fqdn_lan_cidr", "")
 		}
 

--- a/aviatrix/resource_aviatrix_firewall_instance_association.go
+++ b/aviatrix/resource_aviatrix_firewall_instance_association.go
@@ -211,11 +211,7 @@ func resourceAviatrixFirewallInstanceAssociationRead(d *schema.ResourceData, met
 	if instanceInfo.VendorType == "Aviatrix FQDN Gateway" {
 		d.Set("vendor_type", "fqdn_gateway")
 		d.Set("firewall_name", "")
-		if strings.HasPrefix(instanceInfo.LanInterface, "eni-") || fireNetDetail.CloudType == strconv.Itoa(goaviatrix.GCP) {
-			d.Set("lan_interface", "")
-		} else {
-			d.Set("lan_interface", instanceInfo.LanInterface)
-		}
+		d.Set("lan_interface", "")
 		d.Set("management_interface", "")
 		d.Set("egress_interface", "")
 	} else {

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1496,16 +1496,13 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("setting 'monitor_exclude_list' to state: %v", err)
 	}
 
-	fqdnGatewayLanInterface := fmt.Sprintf("av-nic-%s_eth1", gw.GwName)
 	fqdnLanCidr, ok := gw.ArmFqdnLanCidr[gw.GwName]
 	if ok && goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) {
-		d.Set("fqdn_lan_interface", fqdnGatewayLanInterface)
 		d.Set("fqdn_lan_cidr", fqdnLanCidr)
 	} else if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.GCPRelatedCloudTypes) {
 		d.Set("fqdn_lan_vpc_id", gw.BundleVpcInfo.LAN.VpcID)
 		d.Set("fqdn_lan_cidr", strings.Split(gw.BundleVpcInfo.LAN.Subnet, "~~")[0])
 	} else {
-		d.Set("fqdn_lan_interface", "")
 		d.Set("fqdn_lan_cidr", "")
 	}
 


### PR DESCRIPTION
### Issue
After create Firenet FQDN association, reapply same config, will cause destroy and reapply due to fqdn_lan_interface change
```
aviatrix_firewall_instance_association.arm_fqdn_gw_association[0] must be replaced
-/+ resource "aviatrix_firewall_instance_association" "arm_fqdn_gw_association" {
      ~ id              = "arm-transit-firenet-vnet:rg-av-arm-transit-firenet-vnet-817240:228a1824-5210-4398-97bb-f7bf5900da65~~arm-transit-firenet-gateway~~arm-fqdn-transit-firenet-gw" -> (known after apply)
      ~ lan_interface   = "av-nic-arm-fqdn-transit-firenet-gw_eth-fqdnlan0" -> "av-nic-arm-fqdn-transit-firenet-gw_eth1" # forces replacement
        # (5 unchanged attributes hidden)
    }
```

### RCA
`av-nic-arm-fqdn-transit-firenet-gw_eth1` is from avixtrix_gateway resource, however, this value is hard-coded in terraform code, not from controller API response.
`av-nic-arm-fqdn-transit-firenet-gw_eth-fqdnlan0` is from Firenet resouce, which is returned from controller API response.
These 2 values mismatch.

### Fix
For Firenet FQDN gateway, this `fqdn_lan_interface` is not used at all. Controller/copilot UI doesn't use it as well. Only controller backend use it internally.
Therefore, set it to empty value and remove from terraform logic.