### PR TITLE
AVX-52894 - update documentation for LearnedCIDRApproval feature (#1975)

### DIFF
--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -332,12 +332,12 @@ The following arguments are supported:
 * `enable_skip_public_route_table_update` - (Optional) Skip programming VPC public route table. Default: false. Valid values: true or false. Available as of provider version R2.19+.
 * `enable_auto_advertise_s2c_cidrs` - (Optional) Auto Advertise Spoke Site2Cloud CIDRs. Default: false. Valid values: true or false. Available as of provider version R2.19+.
 
-### [Learned CIDRs Approval for BGP Spoke Gateway](https://docs.aviatrix.com/HowTos/transit_approval.html)
+### [Learned CIDRs Approval for BGP Spoke Gateway](https://docs.aviatrix.com/documentation/latest/building-your-network/transit-bgp-route-approval.html)
 
 -> **NOTE:** `enable_learned_cidrs_approval` can be set to true only if `learned_cidrs_approval_mode` is set to 'gateway'.
 
 * `enable_learned_cidrs_approval` - (Optional) Switch to enable/disable learned CIDR approval for BGP Spoke Gateway. Valid values: true, false. Default value: false.
-* `learned_cidrs_approval_mode` - (Optional) Learned CIDRs approval mode. Either "gateway" (approval on a per-gateway basis) or "connection" (approval on a per-connection basis). Only "gateway" is supported for BGP SPOKE Gateway. Default value: "gateway". Available as of provider version R2.21+.
+* `learned_cidrs_approval_mode` - (Optional) Learned CIDRs approval mode. Only "gateway" (approval on a per-gateway basis) is supported and only if BGP is enabled. Default value: "gateway". Available as of provider version R2.21+.
 * `approved_learned_cidrs` - (Optional) A set of approved learned CIDRs. Only valid when `enable_learned_cidrs_approval` is set to true. Example: ["10.250.0.0/16", "10.251.0.0/16"]. Available as of provider version R2.21+.
 
 ### [Monitor Gateway Subnets](https://docs.aviatrix.com/HowTos/gateway.html#monitor-gateway-subnet)

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -386,7 +386,7 @@ The following arguments are supported:
 * `excluded_advertised_spoke_routes` - (Optional) A list of comma-separated CIDRs to be advertised to on-prem as 'Excluded CIDR List'. When configured, it inspects all the advertised CIDRs from its spoke gateways and remove those included in the 'Excluded CIDR List'. Example: "10.4.0.0/16,10.5.0.0/16".
 * `customized_transit_vpc_routes` - (Optional) A list of CIDRs to be customized for the transit VPC routes. When configured, it will replace all learned routes in VPC routing tables, including RFC1918 and non-RFC1918 CIDRs. To be effective, `enable_advertise_transit_cidr` or firewall management access for a Transit FireNet gateway must be enabled. Example: ["10.0.0.0/16", "10.2.0.0/16"].
 
-### [Learned CIDRs Approval](https://docs.aviatrix.com/HowTos/transit_approval.html)
+### [Learned CIDRs Approval](https://docs.aviatrix.com/documentation/latest/building-your-network/transit-bgp-route-approval.html)
 
 -> **NOTE:** `enable_learned_cidrs_approval` can be set to true only if `learned_cidrs_approval_mode` is set to 'gateway'. If `learned_cidrs_approval_mode` is set to 'connection' then enabling learned CIDRs approval is handled within each individual connection resource.
 


### PR DESCRIPTION
# Context
Backport changes from master to 7.1 branch for upcoming TF 3.1.5 release

# Changes
- Update documentation to clear up conditions BGP spoke's Learned CIDR Approval feature
- Update feature links to Aviatrix doc site for both transit and spoke