### PR TITLE
Move all Edge and CloudN resources and data sources under Edge category.

### DIFF
--- a/docs/data-sources/aviatrix_device_interfaces.md
+++ b/docs/data-sources/aviatrix_device_interfaces.md
@@ -1,9 +1,9 @@
 ---
-subcategory: "CloudN"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_device_interfaces"
 description: |-
-  Gets the WAN primary interfaces and IPs for a device.
+  Gets the WAN primary interfaces and IPs for a CloudN device.
 ---
 
 # aviatrix_device_interfaces

--- a/docs/data-sources/aviatrix_edge_gateway_wan_interface_discovery.md
+++ b/docs/data-sources/aviatrix_edge_gateway_wan_interface_discovery.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_gateway_wan_interface_discovery"
 description: |-

--- a/docs/resources/aviatrix_cloudn_registration.md
+++ b/docs/resources/aviatrix_cloudn_registration.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "CloudN"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_cloudn_registration"
 description: |-

--- a/docs/resources/aviatrix_cloudn_transit_gateway_attachment.md
+++ b/docs/resources/aviatrix_cloudn_transit_gateway_attachment.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "CloudN"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_cloudn_transit_gateway_attachment"
 description: |-

--- a/docs/resources/aviatrix_device_interface_config.md
+++ b/docs/resources/aviatrix_device_interface_config.md
@@ -1,9 +1,9 @@
 ---
-subcategory: "CloudN"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_device_interface_config"
 description: |-
-  Configures WAN primary interface and IP for a device.
+  Configures WAN primary interface and IP for a CloudN device.
 ---
 
 # aviatrix_device_interface_config

--- a/docs/resources/aviatrix_edge_csp.md
+++ b/docs/resources/aviatrix_edge_csp.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_csp"
 description: |- 

--- a/docs/resources/aviatrix_edge_csp_ha.md
+++ b/docs/resources/aviatrix_edge_csp_ha.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_csp_ha"
 description: |-

--- a/docs/resources/aviatrix_edge_equinix.md
+++ b/docs/resources/aviatrix_edge_equinix.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_equinix"
 description: |-

--- a/docs/resources/aviatrix_edge_equinix_ha.md
+++ b/docs/resources/aviatrix_edge_equinix_ha.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_equinix_ha"
 description: |-

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_gateway_selfmanaged"
 description: |-

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged_ha.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged_ha.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_gateway_selfmanaged_ha"
 description: |-

--- a/docs/resources/aviatrix_edge_neo.md
+++ b/docs/resources/aviatrix_edge_neo.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_neo"
 description: |-

--- a/docs/resources/aviatrix_edge_neo_device_onboarding.md
+++ b/docs/resources/aviatrix_edge_neo_device_onboarding.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_neo_device_onboarding"
 description: |-

--- a/docs/resources/aviatrix_edge_neo_ha.md
+++ b/docs/resources/aviatrix_edge_neo_ha.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_neo_ha"
 description: |-

--- a/docs/resources/aviatrix_edge_platform.md
+++ b/docs/resources/aviatrix_edge_platform.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_platform"
 description: |-

--- a/docs/resources/aviatrix_edge_platform_device_onboarding.md
+++ b/docs/resources/aviatrix_edge_platform_device_onboarding.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_platform_device_onboarding"
 description: |-

--- a/docs/resources/aviatrix_edge_platform_ha.md
+++ b/docs/resources/aviatrix_edge_platform_ha.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_platform_ha"
 description: |-

--- a/docs/resources/aviatrix_edge_spoke.md
+++ b/docs/resources/aviatrix_edge_spoke.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_spoke"
 description: |-

--- a/docs/resources/aviatrix_edge_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_edge_spoke_external_device_conn.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_spoke_external_device_conn"
 description: |-

--- a/docs/resources/aviatrix_edge_spoke_transit_attachment.md
+++ b/docs/resources/aviatrix_edge_spoke_transit_attachment.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_spoke_transit_attachment"
 description: |-

--- a/docs/resources/aviatrix_edge_vm_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_vm_selfmanaged.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_vm_selfmanaged"
 description: |-

--- a/docs/resources/aviatrix_edge_vm_selfmanaged_ha.md
+++ b/docs/resources/aviatrix_edge_vm_selfmanaged_ha.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_vm_selfmanaged_ha"
 description: |-

--- a/docs/resources/aviatrix_edge_zededa.md
+++ b/docs/resources/aviatrix_edge_zededa.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_zededa"
 description: |- 

--- a/docs/resources/aviatrix_edge_zededa_ha.md
+++ b/docs/resources/aviatrix_edge_zededa_ha.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Multi-Cloud Transit"
+subcategory: "Edge"
 layout: "aviatrix"
 page_title: "Aviatrix: aviatrix_edge_zededa_ha"
 description: |-


### PR DESCRIPTION
This reorganizes all Edge and CloudN resources and data sources to be under the Edge category. This improves navigation through our resources on the provider documentation page.