### PR TITLE
[Backport To UserConnect-7.1] AVX-51501: remove the http_access configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## 3.1.4 (Unreleased)
+## 3.1.5 (Unreleased)
+###
+- Supported Controller version: **UserConnect-TBD**
+- Supported Terraform version: **v1.x**
+
+### Deprecations
+1. Deprecated ``http_access`` in **aviatrix_controller_config**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
+
+
+## 3.1.4 (January 11, 2024)
 ### Notes:
 - Supported Controller version: **UserConnect-7.1.3006**
 - Supported Terraform version: **v1.x**

--- a/aviatrix/resource_aviatrix_controller_config_test.go
+++ b/aviatrix/resource_aviatrix_controller_config_test.go
@@ -37,7 +37,6 @@ func TestAccAviatrixControllerConfig_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckControllerConfigExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "fqdn_exception_rule", "false"),
-					resource.TestCheckResourceAttr(resourceName, "http_access", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enable_vpc_dns_server", "true"),
 				),
 			},
@@ -63,7 +62,6 @@ resource "aviatrix_account" "test_account" {
 }
 resource "aviatrix_controller_config" "test_controller_config" {
 	fqdn_exception_rule   = false
-	http_access           = true
 	enable_vpc_dns_server = true
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"))
@@ -90,16 +88,9 @@ func testAccCheckControllerConfigExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckControllerConfigDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*goaviatrix.Client)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aviatrix_controller_config" {
 			continue
-		}
-
-		_, err := client.GetHttpAccessEnabled()
-		if err != nil {
-			return fmt.Errorf("could not retrieve Http Access Status due to err: %v", err)
 		}
 	}
 

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -16,9 +16,18 @@ Track all Aviatrix Terraform provider's releases. New resources, features, and b
 
 ---
 
+## 3.1.5 (TBD, 2024)
+###
+- Supported Controller version: **UserConnect-TBD**
+- Supported Terraform version: **v1.x**
+
+### Deprecations
+1. Deprecated ``http_access`` in **aviatrix_controller_config**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
+
+
 ## 3.1.4
 ### Notes:
-- Release date: **(10 Jan 2023)**
+- Release date: **(11 Jan 2024)**
 - Supported Controller version: **UserConnect-7.1.3006**
 - Supported Terraform version: **v1.x**
 

--- a/docs/resources/aviatrix_controller_config.md
+++ b/docs/resources/aviatrix_controller_config.md
@@ -15,14 +15,12 @@ The **aviatrix_controller_config** resource allows management of an Aviatrix Con
 ```hcl
 # Create an Aviatrix Controller Config
 resource "aviatrix_controller_config" "test_controller_config" {
-  http_access         = true
   fqdn_exception_rule = false
 }
 ```
 ```hcl
 # Create an Aviatrix Controller Config with Controller Upgrade Without Upgrading Gateways
 resource "aviatrix_controller_config" "test_controller_config" {
-  http_access             = true
   fqdn_exception_rule     = false
   target_version          = "latest"
   manage_gateway_upgrades = false
@@ -31,7 +29,6 @@ resource "aviatrix_controller_config" "test_controller_config" {
 ```hcl
 # Create an Aviatrix Controller Config with Controller Upgrade + Upgrade All Gateways
 resource "aviatrix_controller_config" "test_controller_config" {
-  http_access         = true
   fqdn_exception_rule = false
   target_version      = "latest"
 }
@@ -73,7 +70,6 @@ The following arguments are supported:
 * `manage_gateway_upgrades` - (Optional) If true, aviatrix_controller_config will upgrade all gateways when target_version is set. If false, only the controller will be upgraded when target_version is set. In that case gateway upgrades should be handled in each gateway resource individually using the software_version and image_version attributes. Type: boolean. Default: true. Available as of provider version R2.20.0+.
 
 ### Security Options
-* `http_access` - (Optional) Switch for HTTP access. Valid values: true, false. Default value: false.
 * `fqdn_exception_rule` - (Optional) Enable/disable packets without an SNI field to pass through gateway(s). Valid values: true, false. Default value: true. For more information on this setting, please see [here](https://docs.aviatrix.com/HowTos/FQDN_Whitelists_Ref_Design.html#exception-rule)
 * `aws_guard_duty_scanning_interval` - (Optional) Configure the AWS Guard Duty scanning interval. Valid values: 5, 10, 15, 30 or 60. Default value: 60. Available as of provider version R2.18+.
 

--- a/goaviatrix/controller.go
+++ b/goaviatrix/controller.go
@@ -59,38 +59,6 @@ type ResourceCounts struct {
 	Count int    `json:"Count"`
 }
 
-func (c *Client) EnableHttpAccess() error {
-	form := map[string]string{
-		"CID":       c.CID,
-		"action":    "config_http_access",
-		"operation": "enable",
-	}
-	return c.PostAPI(form["action"], form, BasicCheck)
-}
-
-func (c *Client) DisableHttpAccess() error {
-	form := map[string]string{
-		"CID":       c.CID,
-		"action":    "config_http_access",
-		"operation": "disable",
-	}
-	return c.PostAPI(form["action"], form, BasicCheck)
-}
-
-func (c *Client) GetHttpAccessEnabled() (string, error) {
-	var data ControllerHttpAccessResp
-	form := map[string]string{
-		"CID":       c.CID,
-		"action":    "config_http_access",
-		"operation": "get",
-	}
-	err := c.GetAPI(&data, form["action"], form, BasicCheck)
-	if err != nil {
-		return "", err
-	}
-	return data.Result, nil
-}
-
 func (c *Client) EnableExceptionRule() error {
 	form := map[string]string{
 		"CID":    c.CID,


### PR DESCRIPTION

The controller "http_access" API hasn't worked correctly since at least 7.0, so remove the implementation and mark it as deprecated.

Signed-off-by: James Peach <jpeach@aviatrix.com>
(cherry picked from commit 7d8fba6d699b6e7b8c7f83f82385fda16cce2de4)