### PR TITLE
AVX-51456: DNAT should also include "eth0" when updating s2c.

### DIFF
--- a/aviatrix/resource_aviatrix_site2cloud.go
+++ b/aviatrix/resource_aviatrix_site2cloud.go
@@ -1051,7 +1051,6 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 		editSite2cloud.CloudSubnetCidr = d.Get("local_subnet_cidr").(string)
 		editSite2cloud.CloudSubnetVirtual = d.Get("local_subnet_virtual").(string)
-		editSite2cloud.NetworkType = "1"
 		err := client.UpdateSite2Cloud(editSite2cloud)
 		if err != nil {
 			return fmt.Errorf("failed to update Site2Cloud local_subnet_cidr: %s", err)
@@ -1070,7 +1069,6 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 		editSite2cloud.CloudSubnetCidr = d.Get("local_subnet_cidr").(string)
 		editSite2cloud.CloudSubnetVirtual = d.Get("local_subnet_virtual").(string)
-		editSite2cloud.NetworkType = "1"
 		err := client.UpdateSite2Cloud(editSite2cloud)
 		if err != nil {
 			return fmt.Errorf("failed to update Site2Cloud local_subnet_virtual: %s", err)
@@ -1081,9 +1079,8 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 		if d.Get("custom_mapped").(bool) && d.Get("remote_subnet_cidr").(string) != "" {
 			return fmt.Errorf("'remote_subnet_cidr' is not valid when 'custom_mapped' is enabled")
 		}
-		editSite2cloud.CloudSubnetCidr = d.Get("remote_subnet_cidr").(string)
-		editSite2cloud.CloudSubnetVirtual = d.Get("remote_subnet_virtual").(string)
-		editSite2cloud.NetworkType = "2"
+		editSite2cloud.RemoteSubnet = d.Get("remote_subnet_cidr").(string)
+		editSite2cloud.RemoteSubnetVirtual = d.Get("remote_subnet_virtual").(string)
 		err := client.UpdateSite2Cloud(editSite2cloud)
 		if err != nil {
 			return fmt.Errorf("failed to update Site2Cloud remote_subnet_cidr: %s", err)
@@ -1100,9 +1097,8 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 		if d.Get("connection_type").(string) == "unmapped" && d.Get("remote_subnet_virtual").(string) != "" {
 			return fmt.Errorf("'remote_subnet_virtual' should be empty for connection type: ummapped")
 		}
-		editSite2cloud.CloudSubnetCidr = d.Get("remote_subnet_cidr").(string)
-		editSite2cloud.CloudSubnetVirtual = d.Get("remote_subnet_virtual").(string)
-		editSite2cloud.NetworkType = "2"
+		editSite2cloud.RemoteSubnet = d.Get("remote_subnet_cidr").(string)
+		editSite2cloud.RemoteSubnetVirtual = d.Get("remote_subnet_virtual").(string)
 		err := client.UpdateSite2Cloud(editSite2cloud)
 		if err != nil {
 			return fmt.Errorf("failed to update Site2Cloud remote_subnet_virtual: %s", err)
@@ -1191,7 +1187,6 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 			GwName:                        d.Get("primary_cloud_gateway_name").(string),
 			VpcID:                         d.Get("vpc_id").(string),
 			ConnName:                      d.Get("connection_name").(string),
-			NetworkType:                   "3",
 			RemoteSourceRealCIDRs:         getCSVFromStringList(d, "remote_source_real_cidrs"),
 			RemoteSourceVirtualCIDRs:      getCSVFromStringList(d, "remote_source_virtual_cidrs"),
 			RemoteDestinationRealCIDRs:    getCSVFromStringList(d, "remote_destination_real_cidrs"),

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -221,12 +221,13 @@ func DiffSuppressFuncNatInterface(k, old, new string, d *schema.ResourceData) bo
 	connectionKey := strings.Replace(k, "interface", "connection", 1)
 	connection := d.Get(connectionKey).(string)
 
-	// Check if the number of snat or dnat policies has not changed so that
-	// interface can be set when a policy is added. Without this check, the
-	// value for interface will be suppressed and interface = "" will
-	// be passed to the API even if interface = "eth0" in the configuration.
-	// TODO(AVX-54006): This should be fixed on the controller side inthe future
-	// so that this check is no longer necessary.
+	// If this is a "connection" based NAT, check if the number of SNAT or DNAT
+	// policies have changed. If they have, we set the interface to the default
+	// value of "eth0" and ensure that is sent in the request, otherwise it will
+	// be rejected.
+	// TODO(AVX-54006): The interface should not be required in this particular
+	// case.  This should be fixed on the controller side in the future so that
+	// this check is no longer necessary.
 	if !d.HasChange("snat_policy.#") && !d.HasChange("dnat_policy.#") && !(connection == "" || connection == "None") {
 		return old == "" && new == "eth0"
 	}

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -224,7 +224,7 @@ func DiffSuppressFuncNatInterface(k, old, new string, d *schema.ResourceData) bo
 	// Check if the number of snat policies has not changed so that interface can be set when a policy is added.
 	// Without this check, the value for interface will be suppressed and interface = "" will
 	// be passed to the API even if interface = "eth0" in the configuration.
-	if !d.HasChange("snat_policy.#") && !(connection == "" || connection == "None") {
+	if !d.HasChange("snat_policy.#") && !d.HasChange("dnat_policy.#") && !(connection == "" || connection == "None") {
 		return old == "" && new == "eth0"
 	}
 	return false

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -221,9 +221,12 @@ func DiffSuppressFuncNatInterface(k, old, new string, d *schema.ResourceData) bo
 	connectionKey := strings.Replace(k, "interface", "connection", 1)
 	connection := d.Get(connectionKey).(string)
 
-	// Check if the number of snat policies has not changed so that interface can be set when a policy is added.
-	// Without this check, the value for interface will be suppressed and interface = "" will
+	// Check if the number of snat or dnat policies has not changed so that
+	// interface can be set when a policy is added. Without this check, the
+	// value for interface will be suppressed and interface = "" will
 	// be passed to the API even if interface = "eth0" in the configuration.
+	// TODO(AVX-54006): This should be fixed on the controller side inthe future
+	// so that this check is no longer necessary.
 	if !d.HasChange("snat_policy.#") && !d.HasChange("dnat_policy.#") && !(connection == "" || connection == "None") {
 		return old == "" && new == "eth0"
 	}

--- a/goaviatrix/site2cloud.go
+++ b/goaviatrix/site2cloud.go
@@ -38,7 +38,6 @@ type Site2Cloud struct {
 	HAEnabled                     string   `form:"ha_enabled,omitempty" json:"ha_status,omitempty"`
 	PeerType                      string   `form:"peer_type,omitempty"`
 	SslServerPool                 string   `form:"ssl_server_pool,omitempty"`
-	NetworkType                   string   `form:"network_type,omitempty"`
 	CloudSubnetCidr               string   `form:"cloud_subnet_cidr,omitempty"`
 	RemoteCidr                    string   `form:"remote_cidr,omitempty"`
 	RemoteSubnetVirtual           string   `form:"virtual_remote_subnet_cidr,omitempty" json:"virtual_remote_subnet_cidr,omitempty"`
@@ -89,9 +88,10 @@ type EditSite2Cloud struct {
 	VpcID                         string `form:"vpc_id,omitempty"`
 	ConnName                      string `form:"conn_name"`
 	GwName                        string `form:"primary_cloud_gateway_name,omitempty"`
-	NetworkType                   string `form:"network_type,omitempty"`
 	CloudSubnetCidr               string `form:"cloud_subnet_cidr,omitempty"`
-	CloudSubnetVirtual            string `form:"cloud_subnet_virtual,omitempty"`
+	CloudSubnetVirtual            string `form:"cloud_virt_subnet,omitempty"`
+	RemoteSubnet                  string `form:"remote_cidr,omitempty"`
+	RemoteSubnetVirtual           string `form:"remote_virt_subnet,omitempty"`
 	RemoteSourceRealCIDRs         string `form:"remote_src_real_cidrs,omitempty"`
 	RemoteSourceVirtualCIDRs      string `form:"remote_src_virt_cidrs,omitempty"`
 	RemoteDestinationRealCIDRs    string `form:"remote_dst_real_cidrs,omitempty"`


### PR DESCRIPTION
This is a work-around for now, ideally we shouldn't need to send
any interface information whening using s2c connection in the SNAT/DNAT config.

Longer team goal with be to remove this workaround by adjusting the controller.