### PR TITLE
Add support for debugging provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,42 @@ $ make fmt
 $ make build13
 ```
 
+### 5. Debugging the provider
+To debug the provider in an IDE or with delve, start the provider with the following command:
+
+```sh
+$GOPATH/bin/terraform-provider-aviatrix -debug
+```
+
+Run the following command if you are using PowerShell:
+```sh
+"$env:GOROOT/bin/terraform-provider-aviatrix" -debug
+```
+
+The output of the provider will look like this:
+
+```
+{"@level":"debug","@message":"plugin address","@timestamp":"2024-06-20T11:59:55.493839+02:00","address":"/var/folders/sh/tf1ct6kd3vnfckhrtlkmrz200000gp/T/plugin3596224496","network":"unix"}
+Provider started. To attach Terraform CLI, set the TF_REATTACH_PROVIDERS environment variable with the following:
+
+	TF_REATTACH_PROVIDERS='{"AviatrixSystems/aviatrix":{"Protocol":"grpc","ProtocolVersion":5,"Pid":33330,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/sh/tf1ct6kd3vnfckhrtlkmrz200000gp/T/plugin3596224496"}}}'
+```
+
+Now attach your debugger to the running process and add breakpoints.
+
+Finally, start terraform using the active provider like this:
+
+```sh
+$ export TF_REATTACH_PROVIDERS='{"AviatrixSystems/aviatrix":{"Protocol":"grpc","ProtocolVersion":5,"Pid":33330,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/sh/tf1ct6kd3vnfckhrtlkmrz200000gp/T/plugin3596224496"}}}'
+$ terraform plan
+```
+
+Run the following command if you are using PowerShell:
+```sh
+$ $Env:TF_REATTACH_PROVIDERS = '{"AviatrixSystems/aviatrix":{"Protocol":"grpc","ProtocolVersion":5,"Pid":33509,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/sh/tf1ct6kd3vnfckhrtlkmrz200000gp/T/plugin3596224496"}}}'
+$ terraform plan
+```
+
 ---
 ## Legacy Instructions (kept for reference)
 **WARNING:** The following instructions are kept for legacy purposes. ONLY follow these instructions below IF you are trying to build an old version of the Aviatrix provider AND are using an old Terraform version (0.12)

--- a/main.go
+++ b/main.go
@@ -1,12 +1,23 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/aviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
+		Debug:        debug,
 		ProviderFunc: aviatrix.Provider,
-	})
+		ProviderAddr: "AviatrixSystems/aviatrix",
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
This PR extends the terraform provider so that it can be started locally with the command line argument `-debug`.
That way the terraform provider is started, and stays listening so that a developer can attach a debugger to it.
The provider will output an environment variable that has to be passed to terraform so that it will attach to this instead of starting the provider itself and attaching to it:

```
~/go/bin/terraform-provider-aviatrix -debug
{"@level":"debug","@message":"plugin address","@timestamp":"2024-06-20T12:20:41.676326+02:00","address":"/var/folders/sh/tf1ct6kd3vnfckhrtlkmrz200000gp/T/plugin154721530","network":"unix"}
Provider started. To attach Terraform CLI, set the TF_REATTACH_PROVIDERS environment variable with the following:

	TF_REATTACH_PROVIDERS='{"AviatrixSystems/aviatrix":{"Protocol":"grpc","ProtocolVersion":5,"Pid":35160,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/sh/tf1ct6kd3vnfckhrtlkmrz200000gp/T/plugin154721530"}}}'
```
Now attach the debugger to this process, or simply start the provider from an IDE with `-debug`.
Finally run terraform with this environment var:
```
export TF_REATTACH_PROVIDERS='{"AviatrixSystems/aviatrix":{"Protocol":"grpc","ProtocolVersion":5,"Pid":35160,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/sh/tf1ct6kd3vnfckhrtlkmrz200000gp/T/plugin154721530"}}}'
terraform apply
```

I had to set the ProviderAddr to `"AviatrixSystems/aviatrix"` so that `TF_REATTACH_PROVIDERS` contains the correct key `"AviatrixSystems/aviatrix"`, instead of the default `"provider"`.
With that value terraform would not find the correct connection configuration.
