### PR TITLE
AVX-36418 Deprecating bandwidth attribute in interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@
 
 ### Deprecations
 1. Deprecated ``http_access`` in **aviatrix_controller_config**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
-2. Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
+2. Deprecated ``bandwidth`` in WAN/LAN/MGMT interfaces in the following resources. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
+  - **aviatrix_edge_csp**
+  - **aviatrix_edge_csp_ha**
+  - **aviatrix_edge_equinix**
+  - **aviatrix_edge_equinix_ha**
+  - **aviatrix_edge_neo**
+  - **aviatrix_edge_neo_ha**
+  - **aviatrix_edge_platform**
+  - **aviatrix_edge_platform_ha**
+  - **aviatrix_edge_zededa**
+  - **aviatrix_edge_zededa_ha**
 
 
 ## 3.1.4 (January 11, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Deprecations
 1. Deprecated ``http_access`` in **aviatrix_controller_config**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
+2. Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
 
 
 ## 3.1.4 (January 11, 2024)

--- a/aviatrix/resource_aviatrix_edge_csp.go
+++ b/aviatrix/resource_aviatrix_edge_csp.go
@@ -250,6 +250,7 @@ func resourceAviatrixEdgeCSP() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_csp_ha.go
+++ b/aviatrix/resource_aviatrix_edge_csp_ha.go
@@ -54,6 +54,7 @@ func resourceAviatrixEdgeCSPHa() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_equinix.go
+++ b/aviatrix/resource_aviatrix_edge_equinix.go
@@ -215,6 +215,7 @@ func resourceAviatrixEdgeEquinix() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_equinix_ha.go
+++ b/aviatrix/resource_aviatrix_edge_equinix_ha.go
@@ -58,6 +58,7 @@ func resourceAviatrixEdgeEquinixHa() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_neo.go
+++ b/aviatrix/resource_aviatrix_edge_neo.go
@@ -244,6 +244,7 @@ func resourceAviatrixEdgeNEO() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_neo_ha.go
+++ b/aviatrix/resource_aviatrix_edge_neo_ha.go
@@ -54,6 +54,7 @@ func resourceAviatrixEdgeNEOHa() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -244,6 +244,7 @@ func resourceAviatrixEdgePlatform() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_platform_ha.go
+++ b/aviatrix/resource_aviatrix_edge_platform_ha.go
@@ -54,6 +54,7 @@ func resourceAviatrixEdgePlatformHa() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_zededa.go
+++ b/aviatrix/resource_aviatrix_edge_zededa.go
@@ -250,6 +250,7 @@ func resourceAviatrixEdgeZededa() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_edge_zededa_ha.go
+++ b/aviatrix/resource_aviatrix_edge_zededa_ha.go
@@ -54,6 +54,7 @@ func resourceAviatrixEdgeZededaHa() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.",
+							Deprecated:  "Bandwidth will be removed in a future release.",
 						},
 						"enable_dhcp": {
 							Type:        schema.TypeBool,

--- a/docs/resources/aviatrix_edge_csp.md
+++ b/docs/resources/aviatrix_edge_csp.md
@@ -64,7 +64,7 @@ The following arguments are supported:
 * `interfaces` - (Required) WAN/LAN/MANAGEMENT interfaces.
   * `name` - (Required) Interface name.
   * `type` - (Required) Type. Valid values: WAN, LAN, or MANAGEMENT.
-  * `bandwidth` - (Optional) The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s.
+  * `bandwidth` - (Optional) The rate of data can be moved through the interface, requires an integer value. Unit is in Mb/s. 
   * `enable_dhcp` - (Optional) Enable DHCP. Valid values: true, false. Default value: false.
   * `wan_public_ip` - (Optional) WAN public IP.
   * `ip_address` - (Optional) Interface static IP address.
@@ -124,3 +124,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_csp.test gw_name
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_csp_ha.md
+++ b/docs/resources/aviatrix_edge_csp_ha.md
@@ -74,3 +74,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_csp_ha.test primary_gw_name-hagw
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_equinix.md
+++ b/docs/resources/aviatrix_edge_equinix.md
@@ -113,3 +113,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_equinix.test gw_name
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_equinix_ha.md
+++ b/docs/resources/aviatrix_edge_equinix_ha.md
@@ -79,3 +79,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_equinix_ha.test primary_gw_name-hagw
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_neo.md
+++ b/docs/resources/aviatrix_edge_neo.md
@@ -126,3 +126,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_equinix.test gw_name
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_neo_ha.md
+++ b/docs/resources/aviatrix_edge_neo_ha.md
@@ -81,3 +81,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_neo_ha.test primary_gw_name-hagw
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_platform.md
+++ b/docs/resources/aviatrix_edge_platform.md
@@ -124,3 +124,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_platform.test gw_name
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_platform_ha.md
+++ b/docs/resources/aviatrix_edge_platform_ha.md
@@ -79,3 +79,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_platform_ha.test primary_gw_name-hagw
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_zededa.md
+++ b/docs/resources/aviatrix_edge_zededa.md
@@ -122,3 +122,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_zededa.test gw_name
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/docs/resources/aviatrix_edge_zededa_ha.md
+++ b/docs/resources/aviatrix_edge_zededa_ha.md
@@ -72,3 +72,6 @@ In addition to all arguments above, the following attribute is exported:
 ```
 $ terraform import aviatrix_edge_zededa_ha.test primary_gw_name-hagw
 ```
+
+## Deprecations
+* Deprecated ``bandwidth`` in **WAN/LAN/MGMT interfaces**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.


### PR DESCRIPTION
Fix - [AVX-36148](https://aviatrix.atlassian.net/browse/AVX-36418)

Marking the bandwidth attribute as deprecated in interfaces. This feature was never fully implemented so it will be removed in the future releases.
