### PR TITLE
[AVX-54473] Remove extra property arn for EKS clusters. Instead, use …

### DIFF
--- a/aviatrix/resource_aviatrix_kubernetes_cluster_test.go
+++ b/aviatrix/resource_aviatrix_kubernetes_cluster_test.go
@@ -108,19 +108,18 @@ func TestAccAviatrixKubernetesCluster_AWS_ARN(t *testing.T) {
 			{
 				Config: `
 					resource "aviatrix_kubernetes_cluster" "test" {
-						arn = "arn:aws:eks:us-west-2:123456789012:cluster/test-cluster-id"
+						cluster_id = "arn:aws:eks:us-west-2:123456789012:cluster/test-cluster-id"
 						use_csp_credentials = true
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAviatrixKubernetesClusterExists(resourceName, goaviatrix.KubernetesCluster{
-						ClusterId: "123456789012-us-west-2-test-cluster-id",
+						ClusterId: "arn:aws:eks:us-west-2:123456789012:cluster/test-cluster-id",
 						Credential: &goaviatrix.KubernetesCredential{
 							UseCspCredentials: true,
 						},
 					}),
-					resource.TestCheckResourceAttr(resourceName, "arn", "arn:aws:eks:us-west-2:123456789012:cluster/test-cluster-id"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_id", "123456789012-us-west-2-test-cluster-id"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", "arn:aws:eks:us-west-2:123456789012:cluster/test-cluster-id"),
 					resource.TestCheckResourceAttr(resourceName, "use_csp_credentials", "true"),
 				),
 			},

--- a/docs/resources/aviatrix_kubernetes_cluster.md
+++ b/docs/resources/aviatrix_kubernetes_cluster.md
@@ -19,7 +19,7 @@ This resource is available as of provider version R3.0+.
 ```hcl
 # Create an Aviatrix Kubernetes Cluster so that the controller allows building Aviatrix Smart Groups from an AWS EKS cluster
 resource "aviatrix_kubernetes_cluster" "rptest" {
-  arn                 = data.aws_eks_cluster.eks_cluster.arn
+  cluster_id          = data.aws_eks_cluster.eks_cluster.arn
   use_csp_credentials = true
 }
 
@@ -115,9 +115,7 @@ The following arguments are supported:
 
 ### Required
 
-* Exactly one of `cluster_id` or `arn` must be provided.
-  * `cluster_id` - (Optional) The ID of the Kubernetes cluster. If the cluster to be configured is an AKS cluster this should be the full resource ID of the AKS cluster. If the cluster is a custom built cluster this can be any unique identifier.
-  * `arn` - (Optional) The ARN of the Kubernetes cluster if the cluster to be configured is an AWS EKS cluster.
+* `cluster_id` - The ID of the Kubernetes cluster. If the cluster is an EKS cluster this should be the ARN of the EKS cluster. If the cluster to be configured is an AKS cluster this should be the full resource ID of the AKS cluster. If the cluster is a custom-built cluster this can be any unique identifier.
 
 ### Optional
 


### PR DESCRIPTION
…cluster_id.

After we simplified the resource id of Kubernetes clusters in CAI with https://github.com/AviatrixDev/cloud-asset-inventory/pull/678 there is no need anymore for a separate property `aviatrix_kubernetes_cluster.arn`.
Instead, the arn can just be passed to `aviatrix_kubernetes_cluster.cluster_id`.

This PR removes the property `arn`.