### PR TITLE
AVX-54473 Kubernetes smart groups Backport 7.2

### DIFF
--- a/aviatrix/resource_aviatrix_site2cloud.go
+++ b/aviatrix/resource_aviatrix_site2cloud.go
@@ -1051,7 +1051,6 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 		editSite2cloud.CloudSubnetCidr = d.Get("local_subnet_cidr").(string)
 		editSite2cloud.CloudSubnetVirtual = d.Get("local_subnet_virtual").(string)
-		editSite2cloud.NetworkType = "1"
 		err := client.UpdateSite2Cloud(editSite2cloud)
 		if err != nil {
 			return fmt.Errorf("failed to update Site2Cloud local_subnet_cidr: %s", err)
@@ -1070,7 +1069,6 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 		editSite2cloud.CloudSubnetCidr = d.Get("local_subnet_cidr").(string)
 		editSite2cloud.CloudSubnetVirtual = d.Get("local_subnet_virtual").(string)
-		editSite2cloud.NetworkType = "1"
 		err := client.UpdateSite2Cloud(editSite2cloud)
 		if err != nil {
 			return fmt.Errorf("failed to update Site2Cloud local_subnet_virtual: %s", err)
@@ -1081,9 +1079,8 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 		if d.Get("custom_mapped").(bool) && d.Get("remote_subnet_cidr").(string) != "" {
 			return fmt.Errorf("'remote_subnet_cidr' is not valid when 'custom_mapped' is enabled")
 		}
-		editSite2cloud.CloudSubnetCidr = d.Get("remote_subnet_cidr").(string)
-		editSite2cloud.CloudSubnetVirtual = d.Get("remote_subnet_virtual").(string)
-		editSite2cloud.NetworkType = "2"
+		editSite2cloud.RemoteSubnet = d.Get("remote_subnet_cidr").(string)
+		editSite2cloud.RemoteSubnetVirtual = d.Get("remote_subnet_virtual").(string)
 		err := client.UpdateSite2Cloud(editSite2cloud)
 		if err != nil {
 			return fmt.Errorf("failed to update Site2Cloud remote_subnet_cidr: %s", err)
@@ -1100,9 +1097,8 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 		if d.Get("connection_type").(string) == "unmapped" && d.Get("remote_subnet_virtual").(string) != "" {
 			return fmt.Errorf("'remote_subnet_virtual' should be empty for connection type: ummapped")
 		}
-		editSite2cloud.CloudSubnetCidr = d.Get("remote_subnet_cidr").(string)
-		editSite2cloud.CloudSubnetVirtual = d.Get("remote_subnet_virtual").(string)
-		editSite2cloud.NetworkType = "2"
+		editSite2cloud.RemoteSubnet = d.Get("remote_subnet_cidr").(string)
+		editSite2cloud.RemoteSubnetVirtual = d.Get("remote_subnet_virtual").(string)
 		err := client.UpdateSite2Cloud(editSite2cloud)
 		if err != nil {
 			return fmt.Errorf("failed to update Site2Cloud remote_subnet_virtual: %s", err)
@@ -1191,7 +1187,6 @@ func resourceAviatrixSite2CloudUpdate(d *schema.ResourceData, meta interface{}) 
 			GwName:                        d.Get("primary_cloud_gateway_name").(string),
 			VpcID:                         d.Get("vpc_id").(string),
 			ConnName:                      d.Get("connection_name").(string),
-			NetworkType:                   "3",
 			RemoteSourceRealCIDRs:         getCSVFromStringList(d, "remote_source_real_cidrs"),
 			RemoteSourceVirtualCIDRs:      getCSVFromStringList(d, "remote_source_virtual_cidrs"),
 			RemoteDestinationRealCIDRs:    getCSVFromStringList(d, "remote_destination_real_cidrs"),

--- a/aviatrix/resource_aviatrix_smart_group.go
+++ b/aviatrix/resource_aviatrix_smart_group.go
@@ -12,7 +12,9 @@ import (
 )
 
 var (
-	k8sNameRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+	// dns1123FmtRe is a regular expression that matches dns label names according to rfc 1123.
+	// K8s resource names must adhere to this.
+	dns1123FmtRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 )
 
 func resourceAviatrixSmartGroup() *schema.Resource {
@@ -74,19 +76,19 @@ func resourceAviatrixSmartGroup() *schema.Resource {
 									"k8s_pod": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(k8sNameRe, "must be a valid Kubernetes Pod name"),
+										ValidateFunc: validation.StringMatch(dns1123FmtRe, "must be a valid Kubernetes Pod name"),
 										Description:  "Name of the Kubernetes Pod this expression matches.",
 									},
 									"k8s_service": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(k8sNameRe, "must be a valid Kubernetes Service name"),
+										ValidateFunc: validation.StringMatch(dns1123FmtRe, "must be a valid Kubernetes Service name"),
 										Description:  "Name of the Kubernetes Service this expression matches.",
 									},
 									"k8s_namespace": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(k8sNameRe, "must be a valid Kubernetes Namespace name"),
+										ValidateFunc: validation.StringMatch(dns1123FmtRe, "must be a valid Kubernetes Namespace name"),
 										Description:  "Name of the Kubernetes Namespace this expression matches.",
 									},
 									"res_id": {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -221,10 +221,14 @@ func DiffSuppressFuncNatInterface(k, old, new string, d *schema.ResourceData) bo
 	connectionKey := strings.Replace(k, "interface", "connection", 1)
 	connection := d.Get(connectionKey).(string)
 
-	// Check if the number of snat policies has not changed so that interface can be set when a policy is added.
-	// Without this check, the value for interface will be suppressed and interface = "" will
-	// be passed to the API even if interface = "eth0" in the configuration.
-	if !d.HasChange("snat_policy.#") && !(connection == "" || connection == "None") {
+	// If this is a "connection" based NAT, check if the number of SNAT or DNAT
+	// policies have changed. If they have, we set the interface to the default
+	// value of "eth0" and ensure that is sent in the request, otherwise it will
+	// be rejected.
+	// TODO(AVX-54006): The interface should not be required in this particular
+	// case.  This should be fixed on the controller side in the future so that
+	// this check is no longer necessary.
+	if !d.HasChange("snat_policy.#") && !d.HasChange("dnat_policy.#") && !(connection == "" || connection == "None") {
 		return old == "" && new == "eth0"
 	}
 	return false

--- a/docs/resources/aviatrix_smart_group.md
+++ b/docs/resources/aviatrix_smart_group.md
@@ -37,6 +37,20 @@ resource "aviatrix_smart_group" "test_smart_group_ip" {
     match_expressions {
       site = "site-test-0"
     }
+    
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = resource.aviatrix_kubernetes_cluster.test_cluster.cluster_id
+      k8s_namespace  = "testnamespace"
+      k8s_service    = "testservice"
+    }
+    
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = resource.aviatrix_kubernetes_cluster.test_cluster.cluster_id
+      k8s_namespace  = "testnamespace"
+      k8s_pod        = "testpod"
+    }
   }
 }
 ```
@@ -53,13 +67,23 @@ The following arguments are supported:
     * `cidr` - (Optional) - CIDR block or IP Address this expression matches. `cidr` cannot be used with any other filters in the same `match_expressions` block.
     * `fqdn` - (Optional) - FQDN address this expression matches. `fqdn` cannot be used with any other filters in the same `match_expressions` block.
     * `site` - (Optional) - Edge Site-ID this expression matches. `site` cannot be used with any other filters in the same `match_expressions` block.
-    * `type` - (Optional) - Type of resource this expression matches. Must be one of "vm", "vpc" or "subnet". `type` is required when `cidr`, `fqdn` and `site` are all not used.
+    * `type` - (Optional) - Type of resource this expression matches. Must be one of "vm", "vpc", "subnet" or "k8s". `type` is required when `cidr`, `fqdn` and `site` are all not used.
     * `res_id` - (Optional) - Resource ID this expression matches.
     * `account_id` - (Optional) - Account ID this expression matches.
     * `account_name` - (Optional) - Account name this expression matches.
     * `name` - (Optional) - Name this expression matches.
     * `region` - (Optional) - Region this expression matches.
     * `zone` - (Optional) - Zone this expression matches.
+    * `k8s_cluster_id` - (Optional) - Resource ID of the Kubernetes cluster this expression matches. The resource ID can be found in the `cluster_id` attribute of the `aviatrix_kubernetes_cluster` resource.
+      This property can only be used when `type` is set to "k8s".
+    * `k8s_namespace` - (Optional) - Kubernetes namespace this expression matches.
+      This property can only be used when `type` is set to "k8s".
+    * `k8s_service` - (Optional) - Kubernetes service name this expression matches.
+      This property can only be used when `type` is set to "k8s".
+      This property must not be used when `k8s_pod` is set.
+    * `k8s_pod` - (Optional) - Kubernetes pod name this expression matches. 
+      This property can only be used when `type` is set to "k8s".
+      This property must not be used when `k8s_service` is set.
     * `tags` - (Optional) - Map of tags this expression matches.
 
 ## Attribute Reference

--- a/goaviatrix/site2cloud.go
+++ b/goaviatrix/site2cloud.go
@@ -38,7 +38,6 @@ type Site2Cloud struct {
 	HAEnabled                     string   `form:"ha_enabled,omitempty" json:"ha_status,omitempty"`
 	PeerType                      string   `form:"peer_type,omitempty"`
 	SslServerPool                 string   `form:"ssl_server_pool,omitempty"`
-	NetworkType                   string   `form:"network_type,omitempty"`
 	CloudSubnetCidr               string   `form:"cloud_subnet_cidr,omitempty"`
 	RemoteCidr                    string   `form:"remote_cidr,omitempty"`
 	RemoteSubnetVirtual           string   `form:"virtual_remote_subnet_cidr,omitempty" json:"virtual_remote_subnet_cidr,omitempty"`
@@ -89,9 +88,10 @@ type EditSite2Cloud struct {
 	VpcID                         string `form:"vpc_id,omitempty"`
 	ConnName                      string `form:"conn_name"`
 	GwName                        string `form:"primary_cloud_gateway_name,omitempty"`
-	NetworkType                   string `form:"network_type,omitempty"`
 	CloudSubnetCidr               string `form:"cloud_subnet_cidr,omitempty"`
-	CloudSubnetVirtual            string `form:"cloud_subnet_virtual,omitempty"`
+	CloudSubnetVirtual            string `form:"cloud_virt_subnet,omitempty"`
+	RemoteSubnet                  string `form:"remote_cidr,omitempty"`
+	RemoteSubnetVirtual           string `form:"remote_virt_subnet,omitempty"`
 	RemoteSourceRealCIDRs         string `form:"remote_src_real_cidrs,omitempty"`
 	RemoteSourceVirtualCIDRs      string `form:"remote_src_virt_cidrs,omitempty"`
 	RemoteDestinationRealCIDRs    string `form:"remote_dst_real_cidrs,omitempty"`

--- a/goaviatrix/smart_group.go
+++ b/goaviatrix/smart_group.go
@@ -8,17 +8,21 @@ import (
 )
 
 type SmartGroupMatchExpression struct {
-	CIDR        string `json:"cidr,omitempty"`
-	FQDN        string `json:"fqdn,omitempty"`
-	Type        string `json:"type,omitempty"`
-	Site        string `json:"site,omitempty"`
-	ResId       string `json:"res_id,omitempty"`
-	AccountId   string `json:"account_id,omitempty"`
-	AccountName string `json:"account_name,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Region      string `json:"region,omitempty"`
-	Zone        string `json:"zone,omitempty"`
-	Tags        map[string]string
+	CIDR         string `json:"cidr,omitempty"`
+	FQDN         string `json:"fqdn,omitempty"`
+	Type         string `json:"type,omitempty"`
+	Site         string `json:"site,omitempty"`
+	ResId        string `json:"res_id,omitempty"`
+	AccountId    string `json:"account_id,omitempty"`
+	AccountName  string `json:"account_name,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Zone         string `json:"zone,omitempty"`
+	K8sService   string `json:"k8s_service,omitempty"`
+	K8sNamespace string `json:"k8s_namespace,omitempty"`
+	K8sClusterId string `json:"k8s_cluster_id,omitempty"`
+	K8sPodName   string `json:"k8s_pod,omitempty"`
+	Tags         map[string]string
 }
 
 type SmartGroupSelector struct {
@@ -63,6 +67,18 @@ func smartGroupFilterToMap(filter *SmartGroupMatchExpression) map[string]string 
 	}
 	if len(filter.Zone) > 0 {
 		filterMap["zone"] = filter.Zone
+	}
+	if len(filter.K8sClusterId) > 0 {
+		filterMap["k8s_cluster_id"] = filter.K8sClusterId
+	}
+	if len(filter.K8sNamespace) > 0 {
+		filterMap["k8s_namespace"] = filter.K8sNamespace
+	}
+	if len(filter.K8sService) > 0 {
+		filterMap["k8s_service"] = filter.K8sService
+	}
+	if len(filter.K8sPodName) > 0 {
+		filterMap["k8s_pod"] = filter.K8sPodName
 	}
 
 	if len(filter.Tags) > 0 {
@@ -150,16 +166,20 @@ func (c *Client) GetSmartGroup(ctx context.Context, uuid string) (*SmartGroup, e
 				filterMap := filterResult.All
 
 				filter := &SmartGroupMatchExpression{
-					CIDR:        filterMap["cidr"],
-					FQDN:        filterMap["fqdn"],
-					Type:        filterMap["type"],
-					Site:        filterMap["site"],
-					ResId:       filterMap["res_id"],
-					AccountId:   filterMap["account_id"],
-					AccountName: filterMap["account_name"],
-					Name:        filterMap["name"],
-					Region:      filterMap["region"],
-					Zone:        filterMap["zone"],
+					CIDR:         filterMap["cidr"],
+					FQDN:         filterMap["fqdn"],
+					Type:         filterMap["type"],
+					Site:         filterMap["site"],
+					ResId:        filterMap["res_id"],
+					AccountId:    filterMap["account_id"],
+					AccountName:  filterMap["account_name"],
+					Name:         filterMap["name"],
+					Region:       filterMap["region"],
+					Zone:         filterMap["zone"],
+					K8sClusterId: filterMap["k8s_cluster_id"],
+					K8sNamespace: filterMap["k8s_namespace"],
+					K8sService:   filterMap["k8s_service"],
+					K8sPodName:   filterMap["k8s_pod"],
 				}
 
 				tags := make(map[string]string)
@@ -231,16 +251,20 @@ func (c *Client) GetSmartGroups(ctx context.Context) ([]*SmartGroup, error) {
 				filterMap := filterResult.All
 
 				filter := &SmartGroupMatchExpression{
-					CIDR:        filterMap["cidr"],
-					FQDN:        filterMap["fqdn"],
-					Type:        filterMap["type"],
-					Site:        filterMap["site"],
-					ResId:       filterMap["res_id"],
-					AccountId:   filterMap["account_id"],
-					AccountName: filterMap["account_name"],
-					Name:        filterMap["name"],
-					Region:      filterMap["region"],
-					Zone:        filterMap["zone"],
+					CIDR:         filterMap["cidr"],
+					FQDN:         filterMap["fqdn"],
+					Type:         filterMap["type"],
+					Site:         filterMap["site"],
+					ResId:        filterMap["res_id"],
+					AccountId:    filterMap["account_id"],
+					AccountName:  filterMap["account_name"],
+					Name:         filterMap["name"],
+					Region:       filterMap["region"],
+					Zone:         filterMap["zone"],
+					K8sClusterId: filterMap["k8s_cluster_id"],
+					K8sNamespace: filterMap["k8s_namespace"],
+					K8sService:   filterMap["k8s_service"],
+					K8sPodName:   filterMap["k8s_pod"],
 				}
 
 				tags := make(map[string]string)


### PR DESCRIPTION
This PR is a backport of #1994 to UserConnect-7.2.

It adds support for the K8s smart group type which allows to select Kubernetes workloads for Smart Groups.