### PR TITLE
AVX054473 Kubernetes Smart Groups Backport 7.2

### DIFF
--- a/aviatrix/resource_aviatrix_smart_group.go
+++ b/aviatrix/resource_aviatrix_smart_group.go
@@ -12,7 +12,9 @@ import (
 )
 
 var (
-	k8sNameRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+	// dns1123FmtRe is a regular expression that matches dns label names according to rfc 1123.
+	// K8s resource names must adhere to this.
+	dns1123FmtRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 )
 
 func resourceAviatrixSmartGroup() *schema.Resource {
@@ -74,19 +76,19 @@ func resourceAviatrixSmartGroup() *schema.Resource {
 									"k8s_pod": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(k8sNameRe, "must be a valid Kubernetes Pod name"),
+										ValidateFunc: validation.StringMatch(dns1123FmtRe, "must be a valid Kubernetes Pod name"),
 										Description:  "Name of the Kubernetes Pod this expression matches.",
 									},
 									"k8s_service": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(k8sNameRe, "must be a valid Kubernetes Service name"),
+										ValidateFunc: validation.StringMatch(dns1123FmtRe, "must be a valid Kubernetes Service name"),
 										Description:  "Name of the Kubernetes Service this expression matches.",
 									},
 									"k8s_namespace": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(k8sNameRe, "must be a valid Kubernetes Namespace name"),
+										ValidateFunc: validation.StringMatch(dns1123FmtRe, "must be a valid Kubernetes Namespace name"),
 										Description:  "Name of the Kubernetes Namespace this expression matches.",
 									},
 									"res_id": {

--- a/docs/resources/aviatrix_smart_group.md
+++ b/docs/resources/aviatrix_smart_group.md
@@ -37,6 +37,20 @@ resource "aviatrix_smart_group" "test_smart_group_ip" {
     match_expressions {
       site = "site-test-0"
     }
+    
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = resource.aviatrix_kubernetes_cluster.test_cluster.cluster_id
+      k8s_namespace  = "testnamespace"
+      k8s_service    = "testservice"
+    }
+    
+    match_expressions {
+      type           = "k8s"
+      k8s_cluster_id = resource.aviatrix_kubernetes_cluster.test_cluster.cluster_id
+      k8s_namespace  = "testnamespace"
+      k8s_pod        = "testpod"
+    }
   }
 }
 ```
@@ -53,13 +67,23 @@ The following arguments are supported:
     * `cidr` - (Optional) - CIDR block or IP Address this expression matches. `cidr` cannot be used with any other filters in the same `match_expressions` block.
     * `fqdn` - (Optional) - FQDN address this expression matches. `fqdn` cannot be used with any other filters in the same `match_expressions` block.
     * `site` - (Optional) - Edge Site-ID this expression matches. `site` cannot be used with any other filters in the same `match_expressions` block.
-    * `type` - (Optional) - Type of resource this expression matches. Must be one of "vm", "vpc" or "subnet". `type` is required when `cidr`, `fqdn` and `site` are all not used.
+    * `type` - (Optional) - Type of resource this expression matches. Must be one of "vm", "vpc", "subnet" or "k8s". `type` is required when `cidr`, `fqdn` and `site` are all not used.
     * `res_id` - (Optional) - Resource ID this expression matches.
     * `account_id` - (Optional) - Account ID this expression matches.
     * `account_name` - (Optional) - Account name this expression matches.
     * `name` - (Optional) - Name this expression matches.
     * `region` - (Optional) - Region this expression matches.
     * `zone` - (Optional) - Zone this expression matches.
+    * `k8s_cluster_id` - (Optional) - Resource ID of the Kubernetes cluster this expression matches. The resource ID can be found in the `cluster_id` attribute of the `aviatrix_kubernetes_cluster` resource.
+      This property can only be used when `type` is set to "k8s".
+    * `k8s_namespace` - (Optional) - Kubernetes namespace this expression matches.
+      This property can only be used when `type` is set to "k8s".
+    * `k8s_service` - (Optional) - Kubernetes service name this expression matches.
+      This property can only be used when `type` is set to "k8s".
+      This property must not be used when `k8s_pod` is set.
+    * `k8s_pod` - (Optional) - Kubernetes pod name this expression matches. 
+      This property can only be used when `type` is set to "k8s".
+      This property must not be used when `k8s_service` is set.
     * `tags` - (Optional) - Map of tags this expression matches.
 
 ## Attribute Reference

--- a/goaviatrix/smart_group.go
+++ b/goaviatrix/smart_group.go
@@ -8,17 +8,21 @@ import (
 )
 
 type SmartGroupMatchExpression struct {
-	CIDR        string `json:"cidr,omitempty"`
-	FQDN        string `json:"fqdn,omitempty"`
-	Type        string `json:"type,omitempty"`
-	Site        string `json:"site,omitempty"`
-	ResId       string `json:"res_id,omitempty"`
-	AccountId   string `json:"account_id,omitempty"`
-	AccountName string `json:"account_name,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Region      string `json:"region,omitempty"`
-	Zone        string `json:"zone,omitempty"`
-	Tags        map[string]string
+	CIDR         string `json:"cidr,omitempty"`
+	FQDN         string `json:"fqdn,omitempty"`
+	Type         string `json:"type,omitempty"`
+	Site         string `json:"site,omitempty"`
+	ResId        string `json:"res_id,omitempty"`
+	AccountId    string `json:"account_id,omitempty"`
+	AccountName  string `json:"account_name,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Zone         string `json:"zone,omitempty"`
+	K8sService   string `json:"k8s_service,omitempty"`
+	K8sNamespace string `json:"k8s_namespace,omitempty"`
+	K8sClusterId string `json:"k8s_cluster_id,omitempty"`
+	K8sPodName   string `json:"k8s_pod,omitempty"`
+	Tags         map[string]string
 }
 
 type SmartGroupSelector struct {
@@ -63,6 +67,18 @@ func smartGroupFilterToMap(filter *SmartGroupMatchExpression) map[string]string 
 	}
 	if len(filter.Zone) > 0 {
 		filterMap["zone"] = filter.Zone
+	}
+	if len(filter.K8sClusterId) > 0 {
+		filterMap["k8s_cluster_id"] = filter.K8sClusterId
+	}
+	if len(filter.K8sNamespace) > 0 {
+		filterMap["k8s_namespace"] = filter.K8sNamespace
+	}
+	if len(filter.K8sService) > 0 {
+		filterMap["k8s_service"] = filter.K8sService
+	}
+	if len(filter.K8sPodName) > 0 {
+		filterMap["k8s_pod"] = filter.K8sPodName
 	}
 
 	if len(filter.Tags) > 0 {
@@ -150,16 +166,20 @@ func (c *Client) GetSmartGroup(ctx context.Context, uuid string) (*SmartGroup, e
 				filterMap := filterResult.All
 
 				filter := &SmartGroupMatchExpression{
-					CIDR:        filterMap["cidr"],
-					FQDN:        filterMap["fqdn"],
-					Type:        filterMap["type"],
-					Site:        filterMap["site"],
-					ResId:       filterMap["res_id"],
-					AccountId:   filterMap["account_id"],
-					AccountName: filterMap["account_name"],
-					Name:        filterMap["name"],
-					Region:      filterMap["region"],
-					Zone:        filterMap["zone"],
+					CIDR:         filterMap["cidr"],
+					FQDN:         filterMap["fqdn"],
+					Type:         filterMap["type"],
+					Site:         filterMap["site"],
+					ResId:        filterMap["res_id"],
+					AccountId:    filterMap["account_id"],
+					AccountName:  filterMap["account_name"],
+					Name:         filterMap["name"],
+					Region:       filterMap["region"],
+					Zone:         filterMap["zone"],
+					K8sClusterId: filterMap["k8s_cluster_id"],
+					K8sNamespace: filterMap["k8s_namespace"],
+					K8sService:   filterMap["k8s_service"],
+					K8sPodName:   filterMap["k8s_pod"],
 				}
 
 				tags := make(map[string]string)
@@ -231,16 +251,20 @@ func (c *Client) GetSmartGroups(ctx context.Context) ([]*SmartGroup, error) {
 				filterMap := filterResult.All
 
 				filter := &SmartGroupMatchExpression{
-					CIDR:        filterMap["cidr"],
-					FQDN:        filterMap["fqdn"],
-					Type:        filterMap["type"],
-					Site:        filterMap["site"],
-					ResId:       filterMap["res_id"],
-					AccountId:   filterMap["account_id"],
-					AccountName: filterMap["account_name"],
-					Name:        filterMap["name"],
-					Region:      filterMap["region"],
-					Zone:        filterMap["zone"],
+					CIDR:         filterMap["cidr"],
+					FQDN:         filterMap["fqdn"],
+					Type:         filterMap["type"],
+					Site:         filterMap["site"],
+					ResId:        filterMap["res_id"],
+					AccountId:    filterMap["account_id"],
+					AccountName:  filterMap["account_name"],
+					Name:         filterMap["name"],
+					Region:       filterMap["region"],
+					Zone:         filterMap["zone"],
+					K8sClusterId: filterMap["k8s_cluster_id"],
+					K8sNamespace: filterMap["k8s_namespace"],
+					K8sService:   filterMap["k8s_service"],
+					K8sPodName:   filterMap["k8s_pod"],
 				}
 
 				tags := make(map[string]string)


### PR DESCRIPTION
This PR is a backport of #1994 to UserConnect-7.2.

It adds support for the K8s smart group type which allows to select Kubernetes workloads for Smart Groups.