### PR TITLE
AVX-49421: Cache the results of list accounts instead of making n calls

### DIFF
--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -133,8 +133,6 @@ func (c *Client) CreateOCIAccount(account *Account) error {
 	return c.PostFileAPI(params, files, DuplicateBasicCheck)
 }
 
-
-
 func (c *Client) ListAccounts() ([]Account, error) {
 	// If cached accounts are recent enough, return them
 	c.cacheMutex.Lock()

--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -133,18 +134,40 @@ func (c *Client) CreateOCIAccount(account *Account) error {
 	return c.PostFileAPI(params, files, DuplicateBasicCheck)
 }
 
-func (c *Client) GetAccount(account *Account) (*Account, error) {
+
+
+func (c *Client) ListAccounts() ([]Account, error) {
+	// If cached accounts are recent enough, return them
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
+	if c.cachedAccounts != nil {
+		return c.cachedAccounts, nil
+	}
+
+	// Otherwise, fetch from the backend
+
 	form := map[string]string{
 		"CID":    c.CID,
 		"action": "list_accounts",
 	}
-
 	var resp AccountListResp
 	err := c.GetAPI(&resp, form["action"], form, BasicCheck)
 	if err != nil {
 		return nil, err
 	}
-	accList := resp.Results.AccountList
+	accounts := resp.Results.AccountList
+
+	// Cache the result
+	c.cachedAccounts = accounts
+
+	return accounts, nil
+}
+
+func (c *Client) GetAccount(account *Account) (*Account, error) {
+	accList, err := c.ListAccounts()
+	if err != nil {
+		return nil, err
+	}
 	for i := range accList {
 		if accList[i].AccountName == account.AccountName {
 			log.Infof("Found Aviatrix Account %s", account.AccountName)

--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/goaviatrix/account_test.go
+++ b/goaviatrix/account_test.go
@@ -1,0 +1,85 @@
+package goaviatrix
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+// MockRoundTripper is a mock implementation of http.RoundTripper.
+type MockRoundTripper struct {
+	// Response to return for the HTTP request.
+	Response *http.Response
+	// Error to return for the HTTP request.
+	Err error
+	// CallCount to track how many times RoundTrip is called.
+	CallCount int
+}
+
+// RoundTrip executes a single HTTP transaction and returns a mock response.
+func (m *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.CallCount++
+	return m.Response, m.Err
+}
+
+// Helper function to create a mock HTTP client.
+func NewMockHTTPClient(mockResponse *http.Response, err error) *http.Client {
+	return &http.Client{
+		Transport: &MockRoundTripper{
+			Response: mockResponse,
+			Err:      err,
+		},
+	}
+}
+
+func TestListAccountsCallCount(t *testing.T) {
+	// Create a mock response with the correct JSON structure.
+	mockResponse := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: ioutil.NopCloser(bytes.NewBufferString(`
+		{
+			"return": true,
+			"results": {
+				"account_list": [
+					{
+						"account_name": "test-account"
+					}
+				]
+			},
+			"reason": ""
+		}`)),
+		Header: make(http.Header),
+	}
+	mockResponse.Header.Set("Content-Type", "application/json")
+
+	mockHTTPClient := NewMockHTTPClient(mockResponse, nil)
+
+	client := &Client{
+		HTTPClient: mockHTTPClient,
+		CID:        "mockCID",
+	}
+
+	// Call GetAccount twice to simulate ListAccounts being called twice.
+	account := &Account{AccountName: "test-account"}
+	_, err := client.GetAccount(account)
+	if err != nil {
+		t.Fatalf("unexpected error on first call: %v", err)
+	}
+
+	_, err = client.GetAccount(account)
+	if err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+
+	// Retrieve the mock round tripper to check call count.
+	roundTripper, ok := client.HTTPClient.Transport.(*MockRoundTripper)
+	if !ok {
+		t.Fatalf("failed to assert client.Transport as *MockRoundTripper")
+	}
+
+	// Check that ListAccounts (via the HTTP client) was called once.
+	if roundTripper.CallCount != 1 {
+		t.Fatalf("expected 1 ListAccounts call to make an HTTP round trip, got %d", roundTripper.CallCount)
+	}
+}

--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -61,7 +61,6 @@ type Client struct {
 	baseURL          string
 	IgnoreTagsConfig *IgnoreTagsConfig
 	cachedAccounts   []Account
-	cacheTimestamp   time.Time
 	cacheMutex       sync.Mutex
 }
 

--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ajg/form"
@@ -59,6 +60,9 @@ type Client struct {
 	ControllerIP     string
 	baseURL          string
 	IgnoreTagsConfig *IgnoreTagsConfig
+	cachedAccounts   []Account
+	cacheTimestamp   time.Time
+	cacheMutex       sync.Mutex
 }
 
 type GetApiTokenResp struct {


### PR DESCRIPTION
Currently we call list_accounts for every account, iterate through those results to find a specific account and return that reuslt. This can result in hundreds of calls if the customer has hundreds of accounts.

Instead, cache the results of the list_accounts call and use that to populate all accounts.

Tested with ~600 accounts and this brings us from ~35 minutes to about 30 to 15 seconds.