### PR TITLE
AVX-53924: Add SmartGroup support for S2C and external Group

### DIFF
--- a/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
@@ -183,7 +183,7 @@ func marshalDistributedFirewallingPolicyListInput(d *schema.ResourceData) (*goav
 			distributedFirewallingPolicy.Watch = watch.(bool)
 		}
 
-		if mapContains(policy, "port_ranges") {
+		if goaviatrix.MapContains(policy, "port_ranges") {
 			if distributedFirewallingPolicy.Protocol == "ICMP" {
 				return nil, fmt.Errorf("%q must not be set when %q is %q", "port_ranges", "protocol", "ICMP")
 			}

--- a/aviatrix/resource_aviatrix_smart_group.go
+++ b/aviatrix/resource_aviatrix_smart_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -15,8 +16,10 @@ var (
 	// dns1123FmtRe is a regular expression that matches dns label names according to rfc 1123.
 	// K8s resource names must adhere to this.
 	dns1123FmtRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
-	nonTagKeys   = []string{goaviatrix.ExternalKey, goaviatrix.S2CKey, goaviatrix.CidrKey, goaviatrix.FqdnKey}
-	typeKeys     = []string{goaviatrix.TypeKey, goaviatrix.ResIdKey, goaviatrix.AccountIdKey, goaviatrix.AccountNameKey, goaviatrix.NameKey, goaviatrix.RegionKey, goaviatrix.ZoneKey, goaviatrix.TagsPrefix}
+	// nonTagKeys are the selector key names that don't expect a "tags" key in the selector
+	nonTagKeys = []string{goaviatrix.ExternalKey, goaviatrix.S2CKey, goaviatrix.CidrKey, goaviatrix.FqdnKey}
+	// tagKeys are the selector key names that are associated with a type-based selector. This set of keys should be disjoint from the nonTagKeys
+	tagKeys = []string{goaviatrix.TypeKey, goaviatrix.ResIdKey, goaviatrix.AccountIdKey, goaviatrix.AccountNameKey, goaviatrix.NameKey, goaviatrix.RegionKey, goaviatrix.ZoneKey, goaviatrix.TagsPrefix}
 )
 
 func resourceAviatrixSmartGroup() *schema.Resource {
@@ -173,13 +176,16 @@ func marshalSmartGroupInput(d *schema.ResourceData) (*goaviatrix.SmartGroup, err
 		selectorInfo := selectorInterface.(map[string]interface{})
 		var filter *goaviatrix.SmartGroupMatchExpression
 
+		// Handle the case of the non-tag selector
 		if matchingKey, ok := goaviatrix.MapContainsOneOfKeys(selectorInfo, nonTagKeys); ok {
-			if matchingType, okType := goaviatrix.MapContainsOneOfKeys(selectorInfo, typeKeys); okType {
+			// Error if both the tagged and non-tagged selectors are present together
+			if matchingType, okType := goaviatrix.MapContainsOneOfKeys(selectorInfo, tagKeys); okType {
 				return nil, fmt.Errorf("%q must be empty when %q is set", matchingType, matchingKey)
 			}
 
 			filter = goaviatrix.NewSmartGroupMatchExpression(selectorInfo)
 			if matchingKey == goaviatrix.ExternalKey {
+				// build a map out of the external arguments
 				if extArgsMap, ok := selectorInfo[goaviatrix.ExtArgsPrefix]; ok {
 					extArgs := make(map[string]string)
 					for key, value := range extArgsMap.(map[string]interface{}) {
@@ -188,10 +194,10 @@ func marshalSmartGroupInput(d *schema.ResourceData) (*goaviatrix.SmartGroup, err
 					filter.ExtArgs = extArgs
 				}
 			}
+		} else if !goaviatrix.MapContains(selectorInfo, goaviatrix.TypeKey) {
+			return nil, fmt.Errorf("%q is required when %q are all empty", goaviatrix.TypeKey, strings.Join(nonTagKeys, ", "))
 		} else {
-			if !goaviatrix.MapContains(selectorInfo, goaviatrix.TypeKey) {
-				return nil, fmt.Errorf("%q is required when %q, %q and %q are all empty", "type", "cidr", "fqdn", "site")
-			}
+			// No non-tagged keys only tagged keys
 			filter = goaviatrix.NewSmartGroupMatchExpression(selectorInfo)
 			if tagsMap, ok := selectorInfo[goaviatrix.TagsPrefix]; ok {
 				tags := make(map[string]string)
@@ -255,7 +261,7 @@ func resourceAviatrixSmartGroupRead(ctx context.Context, d *schema.ResourceData,
 	var expressions []interface{}
 
 	for _, filter := range smartGroup.Selector.Expressions {
-		filterMap := goaviatrix.SmartGroupFilterToMapMapped(filter)
+		filterMap := goaviatrix.SmartGroupFilterToResource(filter)
 		expressions = append(expressions, filterMap)
 	}
 

--- a/aviatrix/resource_aviatrix_smart_group_test.go
+++ b/aviatrix/resource_aviatrix_smart_group_test.go
@@ -216,7 +216,7 @@ func TestAccAviatrixSmartGroup_s2c(t *testing.T) {
 		CheckDestroy: testAccSmartGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSmartGroupK8s(),
+				Config: testAccSmartGroupS2C(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSmartGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "s2c-test-smart-group"),
@@ -234,12 +234,26 @@ func TestAccAviatrixSmartGroup_s2c(t *testing.T) {
 	})
 }
 
-func TestAccAviatrixSmartGroup_exteranl_threat(t *testing.T) {
+func testAccSmartGroupS2C() string {
+	return `
+resource "aviatrix_smart_group" "s2c" {
+	name = "s2c-test-smart-group"
+
+	selector {
+		match_expressions {
+			s2c           = "test-mapped-s2c"
+		}
+	}
+}
+`
+}
+
+func TestAccAviatrixSmartGroup_external_threat(t *testing.T) {
 	skipAcc := os.Getenv("SKIP_SMART_GROUP")
 	if skipAcc == "yes" {
 		t.Skip("Skipping Smart Group test as SKIP_SMART_GROUP is set")
 	}
-	resourceName := "aviatrix_smart_group.threat"
+	resourceName := "aviatrix_smart_group.external_threat"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -249,7 +263,7 @@ func TestAccAviatrixSmartGroup_exteranl_threat(t *testing.T) {
 		CheckDestroy: testAccSmartGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSmartGroupK8s(),
+				Config: testAccSmartGroupExternalThreat(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSmartGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "threat-test-smart-group"),
@@ -267,12 +281,26 @@ func TestAccAviatrixSmartGroup_exteranl_threat(t *testing.T) {
 	})
 }
 
-func TestAccAviatrixSmartGroup_exteranl_geo(t *testing.T) {
+func testAccSmartGroupExternalThreat() string {
+	return `
+resource "aviatrix_smart_group" "external_threat" {
+	name = "threat-test-smart-group"
+
+	selector {
+		match_expressions {
+			external           = "threatiq"
+		}
+	}
+}
+`
+}
+
+func TestAccAviatrixSmartGroup_external_geo(t *testing.T) {
 	skipAcc := os.Getenv("SKIP_SMART_GROUP")
 	if skipAcc == "yes" {
 		t.Skip("Skipping Smart Group test as SKIP_SMART_GROUP is set")
 	}
-	resourceName := "aviatrix_smart_group.geo"
+	resourceName := "aviatrix_smart_group.external_geo"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -282,14 +310,16 @@ func TestAccAviatrixSmartGroup_exteranl_geo(t *testing.T) {
 		CheckDestroy: testAccSmartGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSmartGroupK8s(),
+				Config: testAccSmartGroupExternalGeo(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSmartGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "geo-test-smart-group"),
 					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
 					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.0.external", "geo"),
-					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.1.coutry_os_code", "FR"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.0.ext_args.country_iso_code", "FR"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.1.external", "geo"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.1.ext_args.country_iso_code", "RU"),
 				),
 			},
 			{
@@ -299,6 +329,29 @@ func TestAccAviatrixSmartGroup_exteranl_geo(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccSmartGroupExternalGeo() string {
+	return `
+resource "aviatrix_smart_group" "external_geo" {
+	name = "geo-test-smart-group"
+
+	selector {
+		match_expressions {
+			external           = "geo"
+			ext_args = {
+				country_iso_code   = "FR"
+			}
+		}
+		match_expressions {
+			external           = "geo"
+			ext_args = {
+				country_iso_code   = "RU"
+			}
+		}
+	}
+}
+`
 }
 
 func testAccCheckSmartGroupExists(name string) resource.TestCheckFunc {

--- a/aviatrix/resource_aviatrix_smart_group_test.go
+++ b/aviatrix/resource_aviatrix_smart_group_test.go
@@ -201,6 +201,106 @@ func TestAccAviatrixSmartGroup_reject_bad_k8s_names(t *testing.T) {
 	})
 }
 
+func TestAccAviatrixSmartGroup_s2c(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_SMART_GROUP")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Smart Group test as SKIP_SMART_GROUP is set")
+	}
+	resourceName := "aviatrix_smart_group.s2c"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProvidersVersionValidation,
+		CheckDestroy: testAccSmartGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSmartGroupK8s(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSmartGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "s2c-test-smart-group"),
+					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.0.s2c", "test-mapped-s2c"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAviatrixSmartGroup_exteranl_threat(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_SMART_GROUP")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Smart Group test as SKIP_SMART_GROUP is set")
+	}
+	resourceName := "aviatrix_smart_group.threat"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProvidersVersionValidation,
+		CheckDestroy: testAccSmartGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSmartGroupK8s(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSmartGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "threat-test-smart-group"),
+					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.0.external", "threatiq"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAviatrixSmartGroup_exteranl_geo(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_SMART_GROUP")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Smart Group test as SKIP_SMART_GROUP is set")
+	}
+	resourceName := "aviatrix_smart_group.geo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProvidersVersionValidation,
+		CheckDestroy: testAccSmartGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSmartGroupK8s(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSmartGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "geo-test-smart-group"),
+					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.0.external", "geo"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.1.coutry_os_code", "FR"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckSmartGroupExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]

--- a/aviatrix/resource_aviatrix_web_group.go
+++ b/aviatrix/resource_aviatrix_web_group.go
@@ -78,7 +78,7 @@ func marshalWebGroupInput(d *schema.ResourceData) (*goaviatrix.WebGroup, error) 
 		selectorInfo := selectorInterface.(map[string]interface{})
 		var filter *goaviatrix.WebGroupMatchExpression
 
-		if mapContains(selectorInfo, "snifilter") && mapContains(selectorInfo, "urlfilter") {
+		if goaviatrix.MapContains(selectorInfo, "snifilter") && goaviatrix.MapContains(selectorInfo, "urlfilter") {
 			return nil, fmt.Errorf("snifilter and urlfilter can't be set at the same time under the same match_expressions")
 		}
 

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -361,22 +360,4 @@ func compareImageSize(imageSize1, imageSize2, flag string, indexFlag int) bool {
 		}
 	}
 	return false
-}
-
-func mapContains(m map[string]interface{}, key string) bool {
-	val, exists := m[key]
-	if !exists {
-		return false
-	}
-
-	switch v := val.(type) {
-	case string:
-		return len(v) > 0
-	case map[string]interface{}:
-		return len(v) > 0
-	case []interface{}:
-		return len(v) > 0
-	default:
-		return !reflect.ValueOf(val).IsZero()
-	}
 }

--- a/docs/resources/aviatrix_smart_group.md
+++ b/docs/resources/aviatrix_smart_group.md
@@ -51,6 +51,14 @@ resource "aviatrix_smart_group" "test_smart_group_ip" {
       k8s_namespace  = "testnamespace"
       k8s_pod        = "testpod"
     }
+
+    match_expressions {
+      s2c = "remote-site-name"
+    }
+
+    match_expressions {
+      external = "External_ID"
+    }
   }
 }
 ```

--- a/docs/resources/aviatrix_smart_group.md
+++ b/docs/resources/aviatrix_smart_group.md
@@ -58,6 +58,10 @@ resource "aviatrix_smart_group" "test_smart_group_ip" {
 
     match_expressions {
       external = "External_ID"
+      ext_args = {
+        external_ID_specific_field1 = "value1"
+        external_ID_specific_field2 = "value2"
+      } 
     }
   }
 }
@@ -92,6 +96,9 @@ The following arguments are supported:
     * `k8s_pod` - (Optional) - Kubernetes pod name this expression matches. 
       This property can only be used when `type` is set to "k8s".
       This property must not be used when `k8s_service` is set.
+    * `s2c` - (Optional) - Name of the remote site. Represents the CIDRs associated with the remote site.
+    * `external` - (Optional) - Specifies an external feed, currently either "geo" or "threatiq".
+    * `ext_args` - (Optional) - Map of the arguments associated with the external feed such as "country_iso_code" for the "geo" feed.
     * `tags` - (Optional) - Map of tags this expression matches.
 
 ## Attribute Reference

--- a/goaviatrix/utils.go
+++ b/goaviatrix/utils.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -283,4 +284,31 @@ func getStringSet(d *schema.ResourceData, k string) []string {
 		sl = append(sl, v.(string))
 	}
 	return sl
+}
+
+func MapContains(m map[string]interface{}, key string) bool {
+	val, exists := m[key]
+	if !exists {
+		return false
+	}
+
+	switch v := val.(type) {
+	case string:
+		return len(v) > 0
+	case map[string]interface{}:
+		return len(v) > 0
+	case []interface{}:
+		return len(v) > 0
+	default:
+		return !reflect.ValueOf(val).IsZero()
+	}
+}
+
+func MapContainsOneOfKeys(m map[string]interface{}, keys []string) (string, bool) {
+	for _, key := range keys {
+		if MapContains(m, key) {
+			return key, true
+		}
+	}
+	return "", false
 }

--- a/goaviatrix/utils.go
+++ b/goaviatrix/utils.go
@@ -286,6 +286,7 @@ func getStringSet(d *schema.ResourceData, k string) []string {
 	return sl
 }
 
+// MapContains returns true if the key parameter has an entry in the m map
 func MapContains(m map[string]interface{}, key string) bool {
 	val, exists := m[key]
 	if !exists {
@@ -304,6 +305,9 @@ func MapContains(m map[string]interface{}, key string) bool {
 	}
 }
 
+// MapContainsOneOfKeys tests if any of the values in the keys parameter has an
+// entry in the m map. If a key is found in the map, the first key found is returned
+// along with the value true.  Otherwise an empty string and false are retured
 func MapContainsOneOfKeys(m map[string]interface{}, keys []string) (string, bool) {
 	for _, key := range keys {
 		if MapContains(m, key) {

--- a/goaviatrix/utils.go
+++ b/goaviatrix/utils.go
@@ -304,15 +304,3 @@ func MapContains(m map[string]interface{}, key string) bool {
 		return !reflect.ValueOf(val).IsZero()
 	}
 }
-
-// MapContainsOneOfKeys tests if any of the values in the keys parameter has an
-// entry in the m map. If a key is found in the map, the first key found is returned
-// along with the value true.  Otherwise an empty string and false are retured
-func MapContainsOneOfKeys(m map[string]interface{}, keys []string) (string, bool) {
-	for _, key := range keys {
-		if MapContains(m, key) {
-			return key, true
-		}
-	}
-	return "", false
-}

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -65,11 +65,4 @@ func TestMapContains(t *testing.T) {
 	matchKey, found := MapContainsOneOfKeys(testMap, testKeys)
 	assert.True(t, found)
 	assert.Equal(t, "one", matchKey)
-
-	_, found = MapContainsOneOfKeys(testMap, []string{"random1, random2"})
-	assert.False(t, found)
-
-	matchKey, found = MapContainsOneOfKeys(testMap, []string{"random1, random2", "three"})
-	assert.True(t, found)
-	assert.Equal(t, "three", matchKey)
 }

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -2,6 +2,8 @@ package goaviatrix
 
 import "testing"
 
+import "github.com/stretchr/testify/assert"
+
 func TestValidateASN(t *testing.T) {
 	tt := []struct {
 		Name        string
@@ -47,4 +49,25 @@ func TestValidateASN(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMapContains(t *testing.T) {
+	testMap := make(map[string]interface{})
+	testKeys := []string{"one", "two", "three"}
+	for _, key := range testKeys {
+		testMap[key] = key
+	}
+	assert.True(t, MapContains(testMap, "one"))
+	assert.False(t, MapContains(testMap, "Random"))
+
+	matchKey, found := MapContainsOneOfKeys(testMap, testKeys)
+	assert.True(t, found)
+	assert.Equal(t, "one", matchKey)
+
+	_, found = MapContainsOneOfKeys(testMap, []string{"random1, random2"})
+	assert.False(t, found)
+
+	matchKey, found = MapContainsOneOfKeys(testMap, []string{"random1, random2", "three"})
+	assert.True(t, found)
+	assert.Equal(t, "three", matchKey)
 }

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -1,8 +1,10 @@
 package goaviatrix
 
-import "testing"
+import (
+	"testing"
 
-import "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestValidateASN(t *testing.T) {
 	tt := []struct {

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -61,8 +61,4 @@ func TestMapContains(t *testing.T) {
 	}
 	assert.True(t, MapContains(testMap, "one"))
 	assert.False(t, MapContains(testMap, "Random"))
-
-	matchKey, found := MapContainsOneOfKeys(testMap, testKeys)
-	assert.True(t, found)
-	assert.Equal(t, "one", matchKey)
 }


### PR DESCRIPTION
Adding support for the "s2c" and "external" selectors in the smart_group resource.  Also did some clean up to eliminate some cut-n-paste logic and replace duplicated strings with constants.

Added unit tests which seem to be run by the acceptance tests.

Ran manually locally by augmenting the terraform of one of my end-to-end tests to verify that the new group forms are being created.