### PR TITLE
AVX-56220: Invalidate account cache after CRUD operations (#2025) [Backport-UserConnect-7.2]

### DIFF
--- a/aviatrix/resource_aviatrix_account.go
+++ b/aviatrix/resource_aviatrix_account.go
@@ -435,7 +435,7 @@ func resourceAviatrixAccount() *schema.Resource {
 
 func resourceAviatrixAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*goaviatrix.Client)
-
+	defer client.InvalidateCache()
 	account := &goaviatrix.Account{
 		AccountName:                           d.Get("account_name").(string),
 		CloudType:                             d.Get("cloud_type").(int),
@@ -969,7 +969,7 @@ func resourceAviatrixAccountRead(ctx context.Context, d *schema.ResourceData, me
 
 func resourceAviatrixAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*goaviatrix.Client)
-
+	defer client.InvalidateCache()
 	account := &goaviatrix.Account{
 		AccountName:                           d.Get("account_name").(string),
 		CloudType:                             d.Get("cloud_type").(int),
@@ -1244,7 +1244,6 @@ func resourceAviatrixAccountUpdate(ctx context.Context, d *schema.ResourceData, 
 			}
 		}
 	}
-
 	d.Partial(false)
 	return resourceAviatrixAccountRead(ctx, d, meta)
 }
@@ -1257,12 +1256,11 @@ func resourceAviatrixAccountDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[INFO] Deleting Aviatrix account: %#v", account)
-
+	defer client.InvalidateCache()
 	err := client.DeleteAccount(account)
 	if err != nil {
 		return diag.Errorf("failed to delete Aviatrix Account: %s", err)
 	}
-
 	return nil
 }
 

--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -218,6 +218,12 @@ func (c *Client) CreateAWSSAccount(account *Account) error {
 	return c.PostFileAPI(params, files, DuplicateBasicCheck)
 }
 
+func (c *Client) InvalidateCache() {
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
+	c.cachedAccounts = nil
+}
+
 func (c *Client) ListAccounts() ([]Account, error) {
 	// If cached accounts are recent enough, return them
 	c.cacheMutex.Lock()

--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -48,6 +48,7 @@ type ClientInterface interface {
 	DeleteAccount(account *Account) error
 	GetAccount(account *Account) (*Account, error)
 	AuditAccount(ctx context.Context, account *Account) error
+	InvalidateCache()
 }
 
 // Client for accessing the Aviatrix Controller

--- a/goaviatrix/client_mock.go
+++ b/goaviatrix/client_mock.go
@@ -86,6 +86,9 @@ func (mock *ClientInterfaceMock) AuditAccount(ctx context.Context, account *Acco
 	return mock.AuditAccountFunc(ctx, account)
 }
 
+func (mock *ClientInterfaceMock) InvalidateCache() {
+}
+
 // AuditAccountCalls gets all the calls that were made to AuditAccount.
 // Check the length with:
 //


### PR DESCRIPTION
After create, delete or update, invalidate the cache.
Backport of #2025