### PR TITLE
AVX-56220: Fix various issues with the account creation logic.

### DIFF
--- a/aviatrix/data_source_aviatrix_vpc.go
+++ b/aviatrix/data_source_aviatrix_vpc.go
@@ -240,10 +240,7 @@ func dataSourceAviatrixVpcRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		var subscriptionId string
-		if acc != nil {
-			subscriptionId = acc.ArmSubscriptionId
-		}
+		subscriptionId := acc.ArmSubscriptionId
 
 		var resourceGroup string
 		if vC.ResourceGroup != "" {

--- a/aviatrix/resource_aviatrix_account_unit_test.go
+++ b/aviatrix/resource_aviatrix_account_unit_test.go
@@ -84,9 +84,9 @@ func TestResourceAviatrixAccountDelete_WhenDeleteAccountFails(t *testing.T) {
 
 func TestResourceAviatrixAccountRead_AccountWithAudit(t *testing.T) {
 	client := &goaviatrix.ClientInterfaceMock{
-		GetAccountFunc: func(account *goaviatrix.Account) (*goaviatrix.Account, error) {
+		GetAccountFunc: func(account *goaviatrix.Account) (goaviatrix.Account, error) {
 			assert.Equal(t, "unit_test_account", account.AccountName)
-			return &goaviatrix.Account{
+			return goaviatrix.Account{
 				AccountName:      "unit_test_account",
 				CloudType:        goaviatrix.AWS,
 				AwsAccountNumber: "123456789012",

--- a/aviatrix/resource_aviatrix_vpc.go
+++ b/aviatrix/resource_aviatrix_vpc.go
@@ -427,10 +427,7 @@ func resourceAviatrixVpcRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		var subscriptionId string
-		if acc != nil {
-			subscriptionId = acc.ArmSubscriptionId
-		}
+		subscriptionId := acc.ArmSubscriptionId
 
 		var resourceGroup string
 		if vC.ResourceGroup != "" {

--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -140,7 +140,7 @@ func (c *Client) InvalidateCache() {
 }
 
 func (c *Client) ListAccounts() ([]Account, error) {
-	// If cached accounts are recent enough, return them
+	// If we have cached accounts, return them.
 	c.cacheMutex.Lock()
 	defer c.cacheMutex.Unlock()
 	if c.cachedAccounts != nil {
@@ -148,7 +148,6 @@ func (c *Client) ListAccounts() ([]Account, error) {
 	}
 
 	// Otherwise, fetch from the backend
-
 	form := map[string]string{
 		"CID":    c.CID,
 		"action": "list_accounts",
@@ -158,27 +157,31 @@ func (c *Client) ListAccounts() ([]Account, error) {
 	if err != nil {
 		return nil, err
 	}
-	accounts := resp.Results.AccountList
+	c.cachedAccounts = resp.Results.AccountList
 
-	// Cache the result
-	c.cachedAccounts = accounts
-
-	return accounts, nil
+	return c.cachedAccounts, nil
 }
 
-func (c *Client) GetAccount(account *Account) (*Account, error) {
+// GetAccount returns the account from the cache. We return an account object
+// instead of a pointer to ensure that the caller receives a copy of the
+// account data rather than a reference to the cached object. This helps avoid
+// potential issues with unintended modifications to the cached account data by
+// the caller.
+func (c *Client) GetAccount(account *Account) (Account, error) {
 	accList, err := c.ListAccounts()
 	if err != nil {
-		return nil, err
+		return Account{}, err
 	}
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
 	for i := range accList {
 		if accList[i].AccountName == account.AccountName {
 			log.Infof("Found Aviatrix Account %s", account.AccountName)
-			return &accList[i], nil
+			return accList[i], nil
 		}
 	}
 	log.Errorf("Couldn't find Aviatrix account %s", account.AccountName)
-	return nil, ErrNotFound
+	return Account{}, ErrNotFound
 }
 
 func (c *Client) UpdateAccount(account *Account) error {

--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -46,7 +46,7 @@ type APIRequest struct {
 //go:generate moq -rm -out client_mock.go . ClientInterface
 type ClientInterface interface {
 	DeleteAccount(account *Account) error
-	GetAccount(account *Account) (*Account, error)
+	GetAccount(account *Account) (Account, error)
 	AuditAccount(ctx context.Context, account *Account) error
 	InvalidateCache()
 }

--- a/goaviatrix/client_mock.go
+++ b/goaviatrix/client_mock.go
@@ -24,7 +24,7 @@ var _ ClientInterface = &ClientInterfaceMock{}
 //			DeleteAccountFunc: func(account *Account) error {
 //				panic("mock out the DeleteAccount method")
 //			},
-//			GetAccountFunc: func(account *Account) (*Account, error) {
+//			GetAccountFunc: func(account *Account) (Account, error) {
 //				panic("mock out the GetAccount method")
 //			},
 //		}
@@ -41,7 +41,7 @@ type ClientInterfaceMock struct {
 	DeleteAccountFunc func(account *Account) error
 
 	// GetAccountFunc mocks the GetAccount method.
-	GetAccountFunc func(account *Account) (*Account, error)
+	GetAccountFunc func(account *Account) (Account, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -140,7 +140,7 @@ func (mock *ClientInterfaceMock) DeleteAccountCalls() []struct {
 }
 
 // GetAccount calls GetAccountFunc.
-func (mock *ClientInterfaceMock) GetAccount(account *Account) (*Account, error) {
+func (mock *ClientInterfaceMock) GetAccount(account *Account) (Account, error) {
 	if mock.GetAccountFunc == nil {
 		panic("ClientInterfaceMock.GetAccountFunc: method is nil but ClientInterface.GetAccount was just called")
 	}


### PR DESCRIPTION
- Make sure we lock the cache when iterating through the accounts.
- Return a copy of the account not a pointer.                                                                                                                                                                                       
- Don't defer read in the creation of an account before we perform a  `SetId`.
- Perform the invalidate explicitly after success.                                                                                                                                                                                                                                                                                                  
- Always perform a read back on success.                                                                                                                                                                                                                                                                                                            
- Fix other related files as a result of returning a copy of an account.                                                                                                                                                                                                                                                                            
- Removes now unused `resourceAviatrixAccountReadIfRequired` function.  