### PR TITLE
AVX-52621 Updating the interface ordering and documentation for transit resource

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
@@ -114,7 +114,7 @@ func resourceAviatrixEdgeSpokeTransitAttachment() *schema.Resource {
 			"dst_wan_interfaces": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Destination WAN interface for edge gateways where the peering terminates, comma separated",
+				Description: "Destination WAN interface for edge gateways where the peering terminates",
 			},
 		},
 	}

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -752,26 +752,6 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 					},
 				},
 			},
-			"eip_map": {
-				Type: schema.TypeMap,
-				Elem: &schema.Schema{
-					Type: schema.TypeList,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"private_ip": {
-								Type:     schema.TypeString,
-								Required: true,
-							},
-							"public_ip": {
-								Type:     schema.TypeString,
-								Required: true,
-							},
-						},
-					},
-				},
-				Optional:    true,
-				Description: "Map of interfaces containing the private IP to public IP EIP assignment",
-			},
 			"peer_backup_port": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1929,10 +1929,32 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 				return fmt.Errorf("could not set interfaces into state: %v", err)
 			}
 		}
-		if gw.PeerBackupPort != "" && gw.ConnectionType != "" {
-			d.Set("peer_backup_port", gw.PeerBackupPort)
-			d.Set("connection_type", gw.ConnectionType)
+		if gw.HaGw.GwSize == "" {
+			d.Set("ha_availability_domain", "")
+			d.Set("ha_azure_eip_name_resource_group", "")
+			d.Set("ha_cloud_instance_id", "")
+			d.Set("ha_eip", "")
+			d.Set("ha_fault_domain", "")
+			d.Set("ha_gw_name", "")
+			d.Set("ha_gw_size", "")
+			d.Set("ha_image_version", "")
+			d.Set("ha_insane_mode_az", "")
+			d.Set("ha_lan_interface_cidr", "")
+			d.Set("ha_oob_availability_zone", "")
+			d.Set("ha_oob_management_subnet", "")
+			d.Set("ha_private_ip", "")
+			d.Set("ha_security_group_id", "")
+			d.Set("ha_software_version", "")
+			d.Set("ha_subnet", "")
+			d.Set("ha_zone", "")
+			d.Set("ha_public_ip", "")
+			d.Set("ha_private_mode_subnet_zone", "")
+			return nil
 		}
+		d.Set("ha_gw_size", gw.HaGw.GwSize)
+		d.Set("ha_gw_name", gw.HaGw.GwName)
+		d.Set("peer_backup_port", gw.HaGw.PeerBackupPort)
+		d.Set("connection_type", gw.HaGw.ConnectionType)
 	} else {
 		d.Set("enable_encrypt_volume", gw.EnableEncryptVolume)
 		d.Set("eip", gw.PublicIP)
@@ -3728,6 +3750,7 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 	//If HA is enabled, delete HA GW first.
 	haSubnet := d.Get("ha_subnet").(string)
 	haZone := d.Get("ha_zone").(string)
+
 	if haSubnet != "" || haZone != "" {
 		gateway.GwName += "-hagw"
 

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -798,14 +798,14 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			if val, exists := ifaceInfo["name"]; exists && val != nil {
 				ifaceName, ok = val.(string)
 				if !ok {
-					return fmt.Errorf("name is not a string")
+					return fmt.Errorf("interface name is not a string")
 				}
 			}
 			// Check and set 'type'
 			if val, exists := ifaceInfo["type"]; exists && val != nil {
 				ifaceType, ok = val.(string)
 				if !ok {
-					return fmt.Errorf("type is not a string")
+					return fmt.Errorf("interface type is not a string")
 				}
 			}
 			// Check and set 'gateway_ip'
@@ -1903,7 +1903,6 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 					interfaceDict["secondary_private_cidr_list"] = secondaryCIDRs
 				}
 				interfaces = append(interfaces, interfaceDict)
-				log.Printf("[TRACE] Interface Dictionary %s: %#v", intf.Name, interfaceDict)
 			}
 			if err = d.Set("interfaces", interfaces); err != nil {
 				return fmt.Errorf("could not set interfaces into state: %v", err)

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -718,8 +718,8 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							Description:  "Interface type. Valid values are 'WAN', 'LAN' or 'MANAGEMENT'.",
-							ValidateFunc: validation.StringInSlice([]string{"WAN", "LAN", "MANAGEMENT"}, false),
+							Description:  "Interface type. Valid values are 'WAN' or 'MANAGEMENT'.",
+							ValidateFunc: validation.StringInSlice([]string{"WAN", "MANAGEMENT"}, false),
 						},
 						"gateway_ip": {
 							Type:        schema.TypeString,

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -710,7 +710,7 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Description: "A list of WAN/Management interfaces, each represented as a map.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"ifname": {
+						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "Interface name, e.g., 'eth0', 'eth1'.",
@@ -726,7 +726,7 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 							Optional:    true,
 							Description: "The gateway IP address associated with this interface.",
 						},
-						"ipaddr": {
+						"ip_address": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The static IP address assigned to this interface.",
@@ -794,8 +794,8 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			var ifaceName, ifaceType, ifaceGatewayIP, ifaceIP, ifacePublicIP string
 			var ifaceDHCP bool
 			var secondaryCIDRs []string
-			// Check and set 'ifname'
-			if val, exists := ifaceInfo["ifname"]; exists && val != nil {
+			// Check and set 'interface name'
+			if val, exists := ifaceInfo["name"]; exists && val != nil {
 				ifaceName, ok = val.(string)
 				if !ok {
 					return fmt.Errorf("ifname is not a string")
@@ -815,8 +815,8 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 					return fmt.Errorf("gateway_ip is not a string")
 				}
 			}
-			// Check and set 'ipaddr'
-			if val, exists := ifaceInfo["ipaddr"]; exists && val != nil {
+			// Check and set 'ip_address'
+			if val, exists := ifaceInfo["ip_address"]; exists && val != nil {
 				ifaceIP, ok = val.(string)
 				if !ok {
 					return fmt.Errorf("ipaddr is not a string")
@@ -853,12 +853,12 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				}
 			}
 			ifaceData := goaviatrix.EdgeTransitInterface{
-				IfName:         ifaceName,
+				Name:           ifaceName,
 				Type:           ifaceType,
 				GatewayIp:      ifaceGatewayIP,
 				PublicIp:       ifacePublicIP,
 				Dhcp:           ifaceDHCP,
-				IpAddr:         ifaceIP,
+				IpAddress:      ifaceIP,
 				SecondaryCIDRs: secondaryCIDRs,
 			}
 			gateway.InterfaceList = append(gateway.InterfaceList, ifaceData)
@@ -1878,7 +1878,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 			var interfaces []map[string]interface{}
 			for _, intf := range gw.Interfaces {
 				interfaceDict := make(map[string]interface{})
-				interfaceDict["ifname"] = intf.IfName
+				interfaceDict["name"] = intf.Name
 				interfaceDict["type"] = intf.Type
 				if intf.PublicIp != "" {
 					interfaceDict["public_ip"] = intf.PublicIp
@@ -1886,8 +1886,8 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 				if intf.Dhcp {
 					interfaceDict["dhcp"] = intf.Dhcp
 				}
-				if intf.IpAddr != "" {
-					interfaceDict["ipaddr"] = intf.IpAddr
+				if intf.IpAddress != "" {
+					interfaceDict["ip_address"] = intf.IpAddress
 				}
 				if intf.GatewayIp != "" {
 					interfaceDict["gateway_ip"] = intf.GatewayIp

--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -157,12 +157,12 @@ func resourceAviatrixTransitGatewayPeering() *schema.Resource {
 			"src_wan_interfaces": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Source WAN interface for edge gateways where the peering originates, comma separated",
+				Description: "Source WAN interface for edge gateways where the peering originates",
 			},
 			"dst_wan_interfaces": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Destination WAN interface for edge gateways where the peering terminates, comma separated",
+				Description: "Destination WAN interface for edge gateways where the peering terminates",
 			},
 		},
 	}

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -360,4 +361,33 @@ func compareImageSize(imageSize1, imageSize2, flag string, indexFlag int) bool {
 		}
 	}
 	return false
+}
+
+// Define the interface order including eth0, eth1, eth2, eth3, eth4
+var interfaceOrder = []string{"eth0", "eth1", "eth2", "eth3", "eth4"}
+
+// Create a mapping of each type to its index in the interface order
+func createOrderMap(order []string) map[string]int {
+	orderMap := make(map[string]int)
+	for i, value := range order {
+		orderMap[value] = i
+	}
+	return orderMap
+}
+
+// Sorting function that uses the interface order
+func sortInterfacesByCustomOrder(interfaces []goaviatrix.EdgeTransitInterface) []goaviatrix.EdgeTransitInterface {
+	orderMap := createOrderMap(interfaceOrder)
+	sort.SliceStable(interfaces, func(i, j int) bool {
+		iIndex, iExists := orderMap[interfaces[i].Name]
+		jIndex, jExists := orderMap[interfaces[j].Name]
+		if !iExists {
+			iIndex = len(orderMap)
+		}
+		if !jExists {
+			jIndex = len(orderMap)
+		}
+		return iIndex < jIndex
+	})
+	return interfaces
 }

--- a/docs/resources/aviatrix_edge_spoke_transit_attachment.md
+++ b/docs/resources/aviatrix_edge_spoke_transit_attachment.md
@@ -22,13 +22,13 @@ resource "aviatrix_edge_spoke_transit_attachment" "test_attachment" {
 ```hcl
 # Create an Aviatrix Edge as a Spoke to Edge as a Transit Attachment
 resource "aviatrix_edge_spoke_transit_attachment" "test_attachment_2" {
-  spoke_gw_name   = "e2e-edge-spoke-1"
-  transit_gw_name = "test-edge-transit-1"
+  spoke_gw_name               = "e2e-edge-spoke-1"
+  transit_gw_name             = "test-edge-transit-1"
   enable_over_private_network = true
-  enable_jumbo_frame = false
-  enable_insane_mode = true
-  dst_wan_interfaces = "eth1"
-  edge_wan_interfaces = ["eth0"]
+  enable_jumbo_frame          = false
+  enable_insane_mode          = true
+  dst_wan_interfaces          = "eth1"
+  edge_wan_interfaces         = ["eth0"]
 }
 ```
 
@@ -52,7 +52,7 @@ The following arguments are supported:
 * `number_of_retries` - (Optional) Number of retries. Default value: 0.
 * `retry_interval` - (Optional) Retry interval in seconds. Default value: 300.
 * `edge_wan_interfaces` - (Optional) Set of Edge WAN interfaces.
-* `dst_wan_interfaces` - (Optional) Destination WAN interface for edge gateways where the peering terminates. Required only for edge as a transit attachment. These values are comma separated. 
+* `dst_wan_interfaces` - (Optional) Destination WAN interface for edge gateways where the peering terminates. Required only for edge as a transit attachment.
 
 ## Import
 

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -302,34 +302,34 @@ resource "aviatrix_transit_gateway" "test-edge-transit-1" {
     device_id = "b23fd92a-32be-4ae0-9741-a2d12161c177"
     site_id = "site-3"
     interfaces {
-        gateway_ip = "192.168.20.1"
-        ifname     = "eth0"
-        ipaddr    = "192.168.20.11/24"
-        type       = "WAN"
+        gateway_ip    = "192.168.20.1"
+        name          = "eth0"
+        ip_address    = "192.168.20.11/24"
+        type          = "WAN"
     }
     interfaces {
-        gateway_ip = "192.168.21.1"
-        ifname     = "eth1"
-        ipaddr    = "192.168.21.11/24"
-        type       = "WAN"
+        gateway_ip                  = "192.168.21.1"
+        name                        = "eth1"
+        ip_address                  = "192.168.21.11/24"
+        type                        = "WAN"
         secondary_private_cidr_list = ["192.168.21.16/29"]
     }
     interfaces {
         dhcp   = true
-        ifname = "eth2"
+        name = "eth2"
         type   = "MANAGEMENT"
     }
     interfaces {
-        gateway_ip                  = "192.168.22.1"
-        ifname                      = "eth3"
-        ipaddr                     = "192.168.22.11/24"
-        type                        = "WAN"
+        gateway_ip   = "192.168.22.1"
+        name         = "eth3"
+        ip_address   = "192.168.22.11/24"
+        type         = "WAN"
     }
     interfaces {
-        gateway_ip                  = "192.168.23.1"
-        ifname                      = "eth4"
-        ipaddr                     = "192.168.23.11/24"
-        type                        = "WAN"
+        gateway_ip   = "192.168.23.1"
+        name         = "eth4"
+        ip_address   = "192.168.23.11/24"
+        type         = "WAN"
     }
 }
 ```
@@ -346,34 +346,34 @@ resource "aviatrix_transit_gateway" "test-edge-transit-1-hagw" {
     peer_backup_port = "eth1"
     connection_type = "private"
     interfaces {
-        gateway_ip = "192.168.20.1"
-        ifname     = "eth0"
-        ipaddr    = "192.168.20.12/24"
-        type       = "WAN"
+        gateway_ip  = "192.168.20.1"
+        name        = "eth0"
+        ip_address  = "192.168.20.12/24"
+        type        = "WAN"
     }
     interfaces {
-        gateway_ip = "192.168.21.1"
-        ifname     = "eth1"
-        ipaddr    = "192.168.21.12/24"
-        type       = "WAN"
+        gateway_ip                  = "192.168.21.1"
+        name                        = "eth1"
+        ip_address                  = "192.168.21.12/24"
+        type                        = "WAN"
         secondary_private_cidr_list = ["192.168.21.32/29"]
     }
     interfaces {
-        dhcp   = true
-        ifname = "eth2"
-        type   = "MANAGEMENT"
+        dhcp    = true
+        name    = "eth2"
+        type    = "MANAGEMENT"
     }
     interfaces {
-        gateway_ip                  = "192.168.22.1"
-        ifname                      = "eth3"
-        ipaddr                     = "192.168.22.12/24"
-        type                        = "WAN"
+        gateway_ip   = "192.168.22.1"
+        name         = "eth3"
+        ip_address   = "192.168.22.12/24"
+        type         = "WAN"
     }
     interfaces {
-        gateway_ip                  = "192.168.23.1"
-        ifname                      = "eth4"
-        ipaddr                     = "192.168.23.12/24"
-        type                        = "WAN"
+        gateway_ip   = "192.168.23.1"
+        name         = "eth4"
+        ip_address   = "192.168.23.12/24"
+        type         = "WAN"
     }
 }
 ```

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -406,7 +406,7 @@ The following arguments are supported:
   * `ip_address` - (Optional) The static IP address assigned to this interface.
   * `public_ip` - (Optional) The public IP address associated with this interface.
   * `dhcp` - (Optional) Whether DHCP is enabled on this interface. Set the value to true or false. Applicable to only 'MANAGEMENT' type interface.
-  * `secondary_private_cidr_list` - (Optional) A list of secondary private CIDR blocks associated with this interface. The values are coma separated.
+  * `secondary_private_cidr_list` - (Optional) A list of secondary private CIDR blocks associated with this interface.
 
 
 ### HA

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -399,7 +399,14 @@ The following arguments are supported:
 * `availability_domain` - (Optional) Availability domain. Required and valid only for OCI. Available as of provider version R2.19.3.
 * `fault_domain` - (Optional) Fault domain. Required and valid only for OCI. Available as of provider version R2.19.3.
 * `site_id` - (Optional) Site id for the EAT gateway. Required and valid only for edge transit gateways AEP and Equinix.
-* `interfaces` - (Optional) A list of WAN/Management interfaces, each represented as a map. Required and valid only for edge transit gateways AEP and Equinix.
+* `interfaces` - (Optional) A list of WAN/Management interfaces, each represented as a map. Required and valid only for edge transit gateways AEP and Equinix. Each interface has the following attributes:
+  * `name` - (Required) Interface name e.g. eth0, eth1, eh2 etc.
+  * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
+  * `gateway_ip` - (Optional) The gateway IP address associated with this interface.
+  * `ip_address` - (Optional) The static IP address assigned to this interface.
+  * `public_ip` - (Optional) The public IP address associated with this interface.
+  * `dhcp` - (Optional) Whether DHCP is enabled on this interface. Set the value to true or false. Applicable to only 'MANAGEMENT' type interface.
+  * `secondary_private_cidr_list` - (Optional) A list of secondary private CIDR blocks associated with this interface. The values are coma separated.
 
 
 ### HA

--- a/docs/resources/aviatrix_transit_gateway_peering.md
+++ b/docs/resources/aviatrix_transit_gateway_peering.md
@@ -36,13 +36,13 @@ resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering" {
 ```hcl
 # Create an Aviatrix Edge Transit Gateway Peering
 resource "aviatrix_transit_gateway_peering" "test_edge_transit_gateway_peering" {
-  transit_gateway_name1                       = "test-edge-transit-1"
-  transit_gateway_name2                       = "test-edge-transit-2"
-  over_private_network         = true
-  jumbo_frame = false
-  insane_mode = true
-  src_wan_interfaces = "eth1"
-  dst_wan_interfaces = "eth1"
+  transit_gateway_name1   = "test-edge-transit-1"
+  transit_gateway_name2   = "test-edge-transit-2"
+  over_private_network    = true
+  jumbo_frame             = false
+  insane_mode             = true
+  src_wan_interfaces      = "eth1"
+  dst_wan_interfaces      = "eth1"
 }
 ```
 
@@ -69,8 +69,8 @@ The following arguments are supported:
 * `over_private_network` - (Optional) This underlay connects over the private network for peering with Edge Transit. Required only for edge transit attachments.
 * `jumbo_frame` - (Optional) Enable jumbo frame for over private peering with Edge Transit. Required only for edge transit attachments.
 * `insane_mode` - (Optional) Enable HPE mode for peering with Edge Transit. Required only for edge transit attachments.
-* `src_wan_interfaces` - (Optional) Source WAN interface for edge gateways where the peering originates. These values are comma seperated. Required only for edge transit attachments.
-* `dst_wan_interfaces` - (Optional) Destination WAN interface for edge gateways where teh peering terminates.These values are comma seperated. Required only for edge transit attachments.
+* `src_wan_interfaces` - (Optional) Source WAN interface for edge gateways where the peering originates. Required only for edge transit attachments.
+* `dst_wan_interfaces` - (Optional) Destination WAN interface for edge gateways where the peering terminates. Required only for edge transit attachments.
 
   
 ~> **NOTE:** `enable_single_tunnel_mode` is only valid when `enable_peering_over_private_network` is set to `true`. Private Transit Gateway Peering with Single-Tunnel Mode expands the existing Insane Mode Transit Gateway Peering Over Private Network to apply it to single IPSec tunnel. One use case is for low speed encryption between cloud networks.

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -223,7 +223,6 @@ type Gateway struct {
 	SiteID                          string                              `json:"site_id,omitempty"`
 	EIPMap                          string                              `json:"eip_map,omitempty"`
 	Interfaces                      []EdgeTransitInterface              `json:"interfaces,omitempty"`
-	InterfaceMapping                string                              `json:"interface_mapping,omitempty"`
 	PeerBackupPort                  string                              `json:"peer_backup_port,omitempty"`
 	ConnectionType                  string                              `json:"connection_type,omitempty"`
 }

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -223,8 +223,6 @@ type Gateway struct {
 	SiteID                          string                              `json:"site_id,omitempty"`
 	EIPMap                          string                              `json:"eip_map,omitempty"`
 	Interfaces                      []EdgeTransitInterface              `json:"interfaces,omitempty"`
-	PeerBackupPort                  string                              `json:"peer_backup_port,omitempty"`
-	ConnectionType                  string                              `json:"connection_type,omitempty"`
 }
 
 type HaGateway struct {

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -221,7 +221,6 @@ type Gateway struct {
 	EnableGlobalVpc                 bool                                `json:"global_vpc,omitempty"`
 	DeviceID                        string                              `json:"device_id,omitempty"`
 	SiteID                          string                              `json:"site_id,omitempty"`
-	EIPMap                          string                              `json:"eip_map,omitempty"`
 	Interfaces                      []EdgeTransitInterface              `json:"interfaces,omitempty"`
 }
 

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -12,18 +12,18 @@ type TransitHaGateway struct {
 	PrimaryGwName         string `json:"primary_gw_name"`
 	GwName                string `json:"ha_gw_name"`
 	GwSize                string `json:"gw_size"`
-	Subnet                string `json:"gw_subnet"`
-	VpcRegion             string `json:"region"`
-	Zone                  string `json:"zone"`
-	AvailabilityDomain    string `json:"availability_domain"`
-	FaultDomain           string `json:"fault_domain"`
-	BgpLanVpcId           string `json:"bgp_lan_vpc"`
-	BgpLanSubnet          string `json:"bgp_lan_specify_subnet"`
+	Subnet                string `json:"gw_subnet,omitempty"`
+	VpcRegion             string `json:"region,omitempty"`
+	Zone                  string `json:"zone,omitempty"`
+	AvailabilityDomain    string `json:"availability_domain,omitempty"`
+	FaultDomain           string `json:"fault_domain,omitempty"`
+	BgpLanVpcId           string `json:"bgp_lan_vpc,omitempty"`
+	BgpLanSubnet          string `json:"bgp_lan_specify_subnet,omitempty"`
 	Eip                   string `json:"eip,omitempty"`
 	InsaneMode            string `json:"insane_mode"`
-	TagList               string `json:"tag_string"`
-	TagJson               string `json:"tag_json"`
-	AutoGenHaGwName       string `json:"autogen_hagw_name"`
+	TagList               string `json:"tag_string,omitempty"`
+	TagJson               string `json:"tag_json,omitempty"`
+	AutoGenHaGwName       string `json:"autogen_hagw_name,omitempty"`
 	BackupLinkList        []BackupLinkInterface
 	BackupLinkConfig      string `json:"backup_link_config,omitempty"`
 	InterfaceMapping      string `json:"interface_mapping,omitempty"`

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -12,18 +12,18 @@ type TransitHaGateway struct {
 	PrimaryGwName         string `json:"primary_gw_name"`
 	GwName                string `json:"ha_gw_name"`
 	GwSize                string `json:"gw_size"`
-	Subnet                string `json:"gw_subnet,omitempty"`
-	VpcRegion             string `json:"region,omitempty"`
-	Zone                  string `json:"zone,omitempty"`
-	AvailabilityDomain    string `json:"availability_domain,omitempty"`
-	FaultDomain           string `json:"fault_domain,omitempty"`
-	BgpLanVpcId           string `json:"bgp_lan_vpc,omitempty"`
-	BgpLanSubnet          string `json:"bgp_lan_specify_subnet,omitempty"`
+	Subnet                string `json:"gw_subnet"`
+	VpcRegion             string `json:"region"`
+	Zone                  string `json:"zone"`
+	AvailabilityDomain    string `json:"availability_domain"`
+	FaultDomain           string `json:"fault_domain"`
+	BgpLanVpcId           string `json:"bgp_lan_vpc"`
+	BgpLanSubnet          string `json:"bgp_lan_specify_subnet"`
 	Eip                   string `json:"eip,omitempty"`
 	InsaneMode            string `json:"insane_mode"`
-	TagList               string `json:"tag_string,omitempty"`
-	TagJson               string `json:"tag_json,omitempty"`
-	AutoGenHaGwName       string `json:"autogen_hagw_name,omitempty"`
+	TagList               string `json:"tag_string"`
+	TagJson               string `json:"tag_json"`
+	AutoGenHaGwName       string `json:"autogen_hagw_name"`
 	BackupLinkList        []BackupLinkInterface
 	BackupLinkConfig      string `json:"backup_link_config,omitempty"`
 	InterfaceMapping      string `json:"interface_mapping,omitempty"`

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -134,11 +134,11 @@ type TransitGwFireNetInterfacesResp struct {
 }
 
 type EdgeTransitInterface struct {
-	IfName         string   `json:"ifname"`
+	Name           string   `json:"ifname"`
 	Type           string   `json:"type"`
 	PublicIp       string   `json:"public_ip,omitempty"`
 	Dhcp           bool     `json:"dhcp,omitempty"`
-	IpAddr         string   `json:"ipaddr,omitempty"`
+	IpAddress      string   `json:"ipaddr,omitempty"`
 	GatewayIp      string   `json:"gateway_ip,omitempty"`
 	SecondaryCIDRs []string `json:"secondary_private_cidr_list,omitempty"`
 }

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -48,24 +48,35 @@ type TransitVpc struct {
 	OobManagementSubnet          string `form:"oob_mgmt_subnet,omitempty"`
 	HAOobManagementSubnet        string
 	EnableSummarizeCidrToTgw     bool
-	AvailabilityDomain           string   `form:"availability_domain,omitempty"`
-	FaultDomain                  string   `form:"fault_domain,omitempty"`
-	EnableSpotInstance           bool     `form:"spot_instance,omitempty"`
-	SpotPrice                    string   `form:"spot_price,omitempty"`
-	DeleteSpot                   bool     `form:"delete_spot,omitempty"`
-	ApprovedLearnedCidrs         []string `form:"approved_learned_cidrs"`
-	BgpLanVpcID                  string   `form:"bgp_lan_vpc"`
-	BgpLanSpecifySubnet          string   `form:"bgp_lan_subnet"`
-	Async                        bool     `form:"async,omitempty"`
-	BgpLanInterfacesCount        int      `form:"bgp_lan_intf_count,omitempty"`
-	LbVpcId                      string   `form:"lb_vpc_id,omitempty"`
-	Transit                      bool     `form:"transit,omitempty"`
-	DeviceID                     string   `form:"device_id,omitempty"`
-	SiteID                       string   `form:"site_id,omitempty"`
-	Interfaces                   string   `json:"interfaces,omitempty"`
-	InterfaceMapping             string   `json:"interface_mapping,omitempty"`
-	InterfaceList                []EdgeTransitInterface
-	EIPMap                       string `json:"eip_map,omitempty"`
+	AvailabilityDomain           string                 `form:"availability_domain,omitempty"`
+	FaultDomain                  string                 `form:"fault_domain,omitempty"`
+	EnableSpotInstance           bool                   `form:"spot_instance,omitempty"`
+	SpotPrice                    string                 `form:"spot_price,omitempty"`
+	DeleteSpot                   bool                   `form:"delete_spot,omitempty"`
+	ApprovedLearnedCidrs         []string               `form:"approved_learned_cidrs"`
+	BgpLanVpcID                  string                 `form:"bgp_lan_vpc"`
+	BgpLanSpecifySubnet          string                 `form:"bgp_lan_subnet"`
+	Async                        bool                   `form:"async,omitempty"`
+	BgpLanInterfacesCount        int                    `form:"bgp_lan_intf_count,omitempty"`
+	LbVpcId                      string                 `form:"lb_vpc_id,omitempty"`
+	Transit                      bool                   `form:"transit,omitempty"`
+	DeviceID                     string                 `form:"device_id,omitempty"`
+	SiteID                       string                 `form:"site_id,omitempty"`
+	Interfaces                   string                 `json:"interfaces,omitempty"`
+	InterfaceMapping             string                 `json:"interface_mapping,omitempty"`
+	InterfaceList                []EdgeTransitInterface `json:"interface_list,omitempty"`
+	EIPMap                       string                 `json:"eip_map,omitempty"`
+	EIPMapList                   []EIPMap               `json:"eip_map_list,omitempty"`
+}
+
+type EIPMap struct {
+	InterfaceName string       `json:"interface_name"`
+	EIP           []EIPMapping `json:"eip"`
+}
+
+type EIPMapping struct {
+	PrivateIP string `json:"private_ip"`
+	PublicIP  string `json:"public_ip"`
 }
 
 type TransitGatewayAdvancedConfig struct {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -65,18 +65,6 @@ type TransitVpc struct {
 	Interfaces                   string                 `json:"interfaces,omitempty"`
 	InterfaceMapping             string                 `json:"interface_mapping,omitempty"`
 	InterfaceList                []EdgeTransitInterface `json:"interface_list,omitempty"`
-	EIPMap                       string                 `json:"eip_map,omitempty"`
-	EIPMapList                   []EIPMap               `json:"eip_map_list,omitempty"`
-}
-
-type EIPMap struct {
-	InterfaceName string       `json:"interface_name"`
-	EIP           []EIPMapping `json:"eip"`
-}
-
-type EIPMapping struct {
-	PrivateIP string `json:"private_ip"`
-	PublicIP  string `json:"public_ip"`
 }
 
 type TransitGatewayAdvancedConfig struct {


### PR DESCRIPTION
This PR is a follow up of https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2014
- Adding EAT resource document changes
- Updating the interface ordering in transit resource
- Updating the interface names
- Removing device_id from transit resource state