### PR TITLE
AVX-56220: Fix various issues with the account creation logic. [Backport UserConnect-7.2]

### DIFF
--- a/aviatrix/data_source_aviatrix_vpc.go
+++ b/aviatrix/data_source_aviatrix_vpc.go
@@ -240,10 +240,7 @@ func dataSourceAviatrixVpcRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		var subscriptionId string
-		if acc != nil {
-			subscriptionId = acc.ArmSubscriptionId
-		}
+		subscriptionId := acc.ArmSubscriptionId
 
 		var resourceGroup string
 		if vC.ResourceGroup != "" {

--- a/aviatrix/resource_aviatrix_account.go
+++ b/aviatrix/resource_aviatrix_account.go
@@ -435,7 +435,6 @@ func resourceAviatrixAccount() *schema.Resource {
 
 func resourceAviatrixAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*goaviatrix.Client)
-	defer client.InvalidateCache()
 	account := &goaviatrix.Account{
 		AccountName:                           d.Get("account_name").(string),
 		CloudType:                             d.Get("cloud_type").(int),
@@ -810,31 +809,17 @@ func resourceAviatrixAccountCreate(ctx context.Context, d *schema.ResourceData, 
 		err = client.CreateAccount(account)
 	}
 
-	if _, ok := err.(goaviatrix.DuplicateError); ok {
-		return diag.Errorf("failed to create Aviatrix Account: %s", err)
-	}
-
-	d.SetId(account.AccountName)
-	flag := false
-	defer resourceAviatrixAccountReadIfRequired(ctx, d, meta, &flag)
 	if err != nil {
 		return diag.Errorf("failed to create Aviatrix Account: %s", err)
 	}
 
-	return resourceAviatrixAccountReadIfRequired(ctx, d, meta, &flag)
-}
-
-func resourceAviatrixAccountReadIfRequired(ctx context.Context, d *schema.ResourceData, meta interface{}, flag *bool) diag.Diagnostics {
-	if !(*flag) {
-		*flag = true
-		return resourceAviatrixAccountRead(ctx, d, meta)
-	}
-	return nil
+	d.SetId(account.AccountName)
+	client.InvalidateCache()
+	return resourceAviatrixAccountRead(ctx, d, meta)
 }
 
 func resourceAviatrixAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(goaviatrix.ClientInterface)
-
 	var diags diag.Diagnostics
 
 	accountName := d.Get("account_name").(string)
@@ -861,95 +846,94 @@ func resourceAviatrixAccountRead(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("aviatrix Account: %s", err)
 	}
 
-	if acc != nil {
-		d.Set("account_name", acc.AccountName)
-		d.Set("cloud_type", acc.CloudType)
-		if acc.CloudType == goaviatrix.AWS {
-			d.Set("aws_account_number", acc.AwsAccountNumber)
-			if acc.AwsRoleEc2 != "" {
-				//force default setting and save to .tfstate file
-				d.Set("aws_access_key", "")
-				d.Set("aws_secret_key", "")
-				d.Set("aws_iam", true)
-				d.Set("aws_role_app", acc.AwsRoleApp)
-				d.Set("aws_role_ec2", acc.AwsRoleEc2)
-				d.Set("aws_gateway_role_app", acc.AwsGatewayRoleApp)
-				d.Set("aws_gateway_role_ec2", acc.AwsGatewayRoleEc2)
-			} else {
-				d.Set("aws_iam", false)
-			}
-		} else if acc.CloudType == goaviatrix.GCP {
-			d.Set("gcloud_project_id", acc.GcloudProjectName)
-		} else if acc.CloudType == goaviatrix.Azure {
-			d.Set("arm_subscription_id", acc.ArmSubscriptionId)
-		} else if acc.CloudType == goaviatrix.AWSGov {
-			d.Set("awsgov_account_number", acc.AwsgovAccountNumber)
-			if acc.AwsgovRoleEc2 != "" {
-				d.Set("awsgov_access_key", "")
-				d.Set("awsgov_secret_key", "")
-				d.Set("awsgov_iam", true)
-				d.Set("awsgov_role_app", acc.AwsgovRoleApp)
-				d.Set("awsgov_role_ec2", acc.AwsgovRoleEc2)
-				d.Set("aws_gateway_role_app", acc.AwsGatewayRoleApp)
-				d.Set("aws_gateway_role_ec2", acc.AwsGatewayRoleEc2)
-			} else {
-				d.Set("awsgov_iam", false)
-			}
-		} else if acc.CloudType == goaviatrix.AzureGov {
-			d.Set("azuregov_subscription_id", acc.AzuregovSubscriptionId)
-		} else if goaviatrix.IsCloudType(acc.CloudType, goaviatrix.AWSChina) {
-			d.Set("awschina_account_number", acc.AwsChinaAccountNumber)
-			if acc.AwsChinaRoleEc2 != "" {
-				// Force access key and secret key to be empty
-				d.Set("awschina_access_key", "")
-				d.Set("awschina_secret_key", "")
-				d.Set("awschina_iam", true)
-				d.Set("awschina_role_app", acc.AwsChinaRoleApp)
-				d.Set("awschina_role_ec2", acc.AwsChinaRoleEc2)
-				d.Set("aws_gateway_role_app", acc.AwsGatewayRoleApp)
-				d.Set("aws_gateway_role_ec2", acc.AwsGatewayRoleEc2)
-			} else {
-				d.Set("awschina_iam", false)
-			}
-		} else if goaviatrix.IsCloudType(acc.CloudType, goaviatrix.AzureChina) {
-			d.Set("azurechina_subscription_id", acc.AzureChinaSubscriptionId)
-		} else if acc.CloudType == goaviatrix.AliCloud {
-			d.Set("alicloud_account_id", acc.AwsAccountNumber)
-		} else if acc.CloudType == goaviatrix.AWSTS {
-			d.Set("awsts_account_number", acc.AwsTsAccountNumber)
-			d.Set("awsts_cap_url", acc.AwsTsCapUrl)
-			d.Set("awsts_cap_agency", acc.AwsTsCapAgency)
-			d.Set("awsts_cap_mission", acc.AwsTsCapMission)
-			d.Set("awsts_cap_role_name", acc.AwsTsCapRoleName)
+	d.Set("account_name", acc.AccountName)
+	d.Set("cloud_type", acc.CloudType)
+	if acc.CloudType == goaviatrix.AWS {
+		d.Set("aws_account_number", acc.AwsAccountNumber)
+		if acc.AwsRoleEc2 != "" {
+			//force default setting and save to .tfstate file
+			d.Set("aws_access_key", "")
+			d.Set("aws_secret_key", "")
+			d.Set("aws_iam", true)
+			d.Set("aws_role_app", acc.AwsRoleApp)
+			d.Set("aws_role_ec2", acc.AwsRoleEc2)
+			d.Set("aws_gateway_role_app", acc.AwsGatewayRoleApp)
+			d.Set("aws_gateway_role_ec2", acc.AwsGatewayRoleEc2)
+		} else {
+			d.Set("aws_iam", false)
+		}
+	} else if acc.CloudType == goaviatrix.GCP {
+		d.Set("gcloud_project_id", acc.GcloudProjectName)
+	} else if acc.CloudType == goaviatrix.Azure {
+		d.Set("arm_subscription_id", acc.ArmSubscriptionId)
+	} else if acc.CloudType == goaviatrix.AWSGov {
+		d.Set("awsgov_account_number", acc.AwsgovAccountNumber)
+		if acc.AwsgovRoleEc2 != "" {
+			d.Set("awsgov_access_key", "")
+			d.Set("awsgov_secret_key", "")
+			d.Set("awsgov_iam", true)
+			d.Set("awsgov_role_app", acc.AwsgovRoleApp)
+			d.Set("awsgov_role_ec2", acc.AwsgovRoleEc2)
+			d.Set("aws_gateway_role_app", acc.AwsGatewayRoleApp)
+			d.Set("aws_gateway_role_ec2", acc.AwsGatewayRoleEc2)
+		} else {
+			d.Set("awsgov_iam", false)
+		}
+	} else if acc.CloudType == goaviatrix.AzureGov {
+		d.Set("azuregov_subscription_id", acc.AzuregovSubscriptionId)
+	} else if goaviatrix.IsCloudType(acc.CloudType, goaviatrix.AWSChina) {
+		d.Set("awschina_account_number", acc.AwsChinaAccountNumber)
+		if acc.AwsChinaRoleEc2 != "" {
+			// Force access key and secret key to be empty
+			d.Set("awschina_access_key", "")
+			d.Set("awschina_secret_key", "")
+			d.Set("awschina_iam", true)
+			d.Set("awschina_role_app", acc.AwsChinaRoleApp)
+			d.Set("awschina_role_ec2", acc.AwsChinaRoleEc2)
+			d.Set("aws_gateway_role_app", acc.AwsGatewayRoleApp)
+			d.Set("aws_gateway_role_ec2", acc.AwsGatewayRoleEc2)
+		} else {
+			d.Set("awschina_iam", false)
+		}
+	} else if goaviatrix.IsCloudType(acc.CloudType, goaviatrix.AzureChina) {
+		d.Set("azurechina_subscription_id", acc.AzureChinaSubscriptionId)
+	} else if acc.CloudType == goaviatrix.AliCloud {
+		d.Set("alicloud_account_id", acc.AwsAccountNumber)
+	} else if acc.CloudType == goaviatrix.AWSTS {
+		d.Set("awsts_account_number", acc.AwsTsAccountNumber)
+		d.Set("awsts_cap_url", acc.AwsTsCapUrl)
+		d.Set("awsts_cap_agency", acc.AwsTsCapAgency)
+		d.Set("awsts_cap_mission", acc.AwsTsCapMission)
+		d.Set("awsts_cap_role_name", acc.AwsTsCapRoleName)
 
-			d.Set("awsts_cap_cert_path", acc.AwsTsCapCertPath)
-			d.Set("awsts_cap_cert_key_path", acc.AwsTsCapCertKeyPath)
-			d.Set("aws_ca_cert_path", acc.AwsCaCertPath)
-		} else if acc.CloudType == goaviatrix.AWSS {
-			d.Set("awss_account_number", acc.AwsSAccountNumber)
-			d.Set("awss_cap_url", acc.AwsSCapUrl)
-			d.Set("awss_cap_agency", acc.AwsSCapAgency)
-			d.Set("awss_cap_account_name", acc.AwsSCapAccountName)
-			d.Set("awss_cap_role_name", acc.AwsSCapRoleName)
+		d.Set("awsts_cap_cert_path", acc.AwsTsCapCertPath)
+		d.Set("awsts_cap_cert_key_path", acc.AwsTsCapCertKeyPath)
+		d.Set("aws_ca_cert_path", acc.AwsCaCertPath)
+	} else if acc.CloudType == goaviatrix.AWSS {
+		d.Set("awss_account_number", acc.AwsSAccountNumber)
+		d.Set("awss_cap_url", acc.AwsSCapUrl)
+		d.Set("awss_cap_agency", acc.AwsSCapAgency)
+		d.Set("awss_cap_account_name", acc.AwsSCapAccountName)
+		d.Set("awss_cap_role_name", acc.AwsSCapRoleName)
 
-			d.Set("awss_cap_cert_path", acc.AwsSCapCertPath)
-			d.Set("awss_cap_cert_key_path", acc.AwsSCapCertKeyPath)
-			d.Set("aws_ca_cert_path", acc.AwsCaCertPath)
-		} else if acc.CloudType == goaviatrix.EDGECSP {
-			if d.Get("edge_csp_password").(string) != "" {
-				d.Set("edge_csp_username", acc.EdgeCSPUsername)
-			} else if d.Get("edge_zededa_password").(string) != "" {
-				d.Set("edge_zededa_username", acc.EdgeCSPUsername)
-			} else {
-				// let user choose when importing CSP/Zededa account
-				d.Set("edge_csp_username", acc.EdgeCSPUsername)
-				d.Set("edge_zededa_username", acc.EdgeCSPUsername)
-			}
+		d.Set("awss_cap_cert_path", acc.AwsSCapCertPath)
+		d.Set("awss_cap_cert_key_path", acc.AwsSCapCertKeyPath)
+		d.Set("aws_ca_cert_path", acc.AwsCaCertPath)
+	} else if acc.CloudType == goaviatrix.EDGECSP {
+		if d.Get("edge_csp_password").(string) != "" {
+			d.Set("edge_csp_username", acc.EdgeCSPUsername)
+		} else if d.Get("edge_zededa_password").(string) != "" {
+			d.Set("edge_zededa_username", acc.EdgeCSPUsername)
+		} else {
+			// let user choose when importing CSP/Zededa account
+			d.Set("edge_csp_username", acc.EdgeCSPUsername)
+			d.Set("edge_zededa_username", acc.EdgeCSPUsername)
 		}
 
-		d.Set("rbac_groups", acc.GroupNamesRead)
-		d.SetId(acc.AccountName)
 	}
+
+	d.Set("rbac_groups", acc.GroupNamesRead)
+	d.SetId(acc.AccountName)
 
 	// Don't check account audit during import. In terraform version 0.14.11 or earlier, returning diag.Warning during import
 	// will cause it to fail silently. It will not return an error, but the state file will not be updated after.

--- a/aviatrix/resource_aviatrix_account_unit_test.go
+++ b/aviatrix/resource_aviatrix_account_unit_test.go
@@ -84,9 +84,9 @@ func TestResourceAviatrixAccountDelete_WhenDeleteAccountFails(t *testing.T) {
 
 func TestResourceAviatrixAccountRead_AccountWithAudit(t *testing.T) {
 	client := &goaviatrix.ClientInterfaceMock{
-		GetAccountFunc: func(account *goaviatrix.Account) (*goaviatrix.Account, error) {
+		GetAccountFunc: func(account *goaviatrix.Account) (goaviatrix.Account, error) {
 			assert.Equal(t, "unit_test_account", account.AccountName)
-			return &goaviatrix.Account{
+			return goaviatrix.Account{
 				AccountName:      "unit_test_account",
 				CloudType:        goaviatrix.AWS,
 				AwsAccountNumber: "123456789012",

--- a/aviatrix/resource_aviatrix_vpc.go
+++ b/aviatrix/resource_aviatrix_vpc.go
@@ -427,10 +427,7 @@ func resourceAviatrixVpcRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		var subscriptionId string
-		if acc != nil {
-			subscriptionId = acc.ArmSubscriptionId
-		}
+		subscriptionId := acc.ArmSubscriptionId
 
 		var resourceGroup string
 		if vC.ResourceGroup != "" {

--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -225,7 +225,7 @@ func (c *Client) InvalidateCache() {
 }
 
 func (c *Client) ListAccounts() ([]Account, error) {
-	// If cached accounts are recent enough, return them
+	// If we have cached accounts, return them.
 	c.cacheMutex.Lock()
 	defer c.cacheMutex.Unlock()
 	if c.cachedAccounts != nil {
@@ -233,7 +233,6 @@ func (c *Client) ListAccounts() ([]Account, error) {
 	}
 
 	// Otherwise, fetch from the backend
-
 	form := map[string]string{
 		"CID":    c.CID,
 		"action": "list_accounts",
@@ -243,27 +242,31 @@ func (c *Client) ListAccounts() ([]Account, error) {
 	if err != nil {
 		return nil, err
 	}
-	accounts := resp.Results.AccountList
+	c.cachedAccounts = resp.Results.AccountList
 
-	// Cache the result
-	c.cachedAccounts = accounts
-
-	return accounts, nil
+	return c.cachedAccounts, nil
 }
 
-func (c *Client) GetAccount(account *Account) (*Account, error) {
+// GetAccount returns the account from the cache. We return an account object
+// instead of a pointer to ensure that the caller receives a copy of the
+// account data rather than a reference to the cached object. This helps avoid
+// potential issues with unintended modifications to the cached account data by
+// the caller.
+func (c *Client) GetAccount(account *Account) (Account, error) {
 	accList, err := c.ListAccounts()
 	if err != nil {
-		return nil, err
+		return Account{}, err
 	}
+	c.cacheMutex.Lock()
+	defer c.cacheMutex.Unlock()
 	for i := range accList {
 		if accList[i].AccountName == account.AccountName {
 			log.Infof("Found Aviatrix Account %s", account.AccountName)
-			return &accList[i], nil
+			return accList[i], nil
 		}
 	}
 	log.Errorf("Couldn't find Aviatrix account %s", account.AccountName)
-	return nil, ErrNotFound
+	return Account{}, ErrNotFound
 }
 
 func (c *Client) UpdateAccount(account *Account) error {

--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -46,7 +46,7 @@ type APIRequest struct {
 //go:generate moq -rm -out client_mock.go . ClientInterface
 type ClientInterface interface {
 	DeleteAccount(account *Account) error
-	GetAccount(account *Account) (*Account, error)
+	GetAccount(account *Account) (Account, error)
 	AuditAccount(ctx context.Context, account *Account) error
 	InvalidateCache()
 }

--- a/goaviatrix/client_mock.go
+++ b/goaviatrix/client_mock.go
@@ -24,7 +24,7 @@ var _ ClientInterface = &ClientInterfaceMock{}
 //			DeleteAccountFunc: func(account *Account) error {
 //				panic("mock out the DeleteAccount method")
 //			},
-//			GetAccountFunc: func(account *Account) (*Account, error) {
+//			GetAccountFunc: func(account *Account) (Account, error) {
 //				panic("mock out the GetAccount method")
 //			},
 //		}
@@ -41,7 +41,7 @@ type ClientInterfaceMock struct {
 	DeleteAccountFunc func(account *Account) error
 
 	// GetAccountFunc mocks the GetAccount method.
-	GetAccountFunc func(account *Account) (*Account, error)
+	GetAccountFunc func(account *Account) (Account, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -140,7 +140,7 @@ func (mock *ClientInterfaceMock) DeleteAccountCalls() []struct {
 }
 
 // GetAccount calls GetAccountFunc.
-func (mock *ClientInterfaceMock) GetAccount(account *Account) (*Account, error) {
+func (mock *ClientInterfaceMock) GetAccount(account *Account) (Account, error) {
 	if mock.GetAccountFunc == nil {
 		panic("ClientInterfaceMock.GetAccountFunc: method is nil but ClientInterface.GetAccount was just called")
 	}


### PR DESCRIPTION
- Make sure we lock the cache when iterating through the accounts.
- Return a copy of the account not a pointer.
- Don't defer read in the creation of an account before we performa  SetId.
- Perform the invalidate explicitly after success.
- Always perform a read back on success.
- Fix other related files as a result of returning a copy of an account.
- Removes now unused resourceAviatrixAccountReadIfRequired function.