### PR TITLE
AVX-56749: Extend data source aviatrix_smart_groups for k8s selectors…

### DIFF
--- a/aviatrix/data_source_aviatrix_smart_groups.go
+++ b/aviatrix/data_source_aviatrix_smart_groups.go
@@ -36,61 +36,81 @@ func dataSourceAviatrixSmartGroups() *schema.Resource {
 										Computed: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
-												"cidr": {
+												goaviatrix.CidrKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "CIDR block or IP Address this expression matches.",
 												},
-												"fqdn": {
+												goaviatrix.FqdnKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "FQDN address this expression matches.",
 												},
-												"site": {
+												goaviatrix.SiteKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "Edge Site-ID this expression matches.",
 												},
-												"type": {
+												goaviatrix.TypeKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "Type of resource this expression matches.",
 												},
-												"res_id": {
+												goaviatrix.ResIdKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "Resource ID this expression matches.",
 												},
-												"account_id": {
+												goaviatrix.AccountIdKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "Account ID this expression matches.",
 												},
-												"account_name": {
+												goaviatrix.AccountNameKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "Account name this expression matches.",
 												},
-												"name": {
+												goaviatrix.NameKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "Name this expression matches.",
 												},
-												"region": {
+												goaviatrix.RegionKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "Region this expression matches.",
 												},
-												"zone": {
+												goaviatrix.ZoneKey: {
 													Type:        schema.TypeString,
 													Computed:    true,
 													Description: "Zone this expression matches.",
 												},
-												"tags": {
+												goaviatrix.TagsPrefix: {
 													Type:        schema.TypeMap,
 													Computed:    true,
 													Elem:        &schema.Schema{Type: schema.TypeString},
 													Description: "Map of tags this expression matches.",
+												},
+												goaviatrix.K8sClusterIdKey: {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Kubernetes Cluster ID this expression matches.",
+												},
+												goaviatrix.K8sPodNameKey: {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Name of the Kubernetes Pod this expression matches.",
+												},
+												goaviatrix.K8sServiceKey: {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Name of the Kubernetes Service this expression matches.",
+												},
+												goaviatrix.K8sNamespaceKey: {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Name of the Kubernetes Namespace this expression matches.",
 												},
 											},
 										},
@@ -125,17 +145,21 @@ func dataSourceAviatrixSmartGroupsRead(ctx context.Context, d *schema.ResourceDa
 
 		for _, filter := range smartGroup.Selector.Expressions {
 			filterMap := map[string]interface{}{
-				"type":         filter.Type,
-				"cidr":         filter.CIDR,
-				"fqdn":         filter.FQDN,
-				"site":         filter.Site,
-				"res_id":       filter.ResId,
-				"account_id":   filter.AccountId,
-				"account_name": filter.AccountName,
-				"name":         filter.Name,
-				"region":       filter.Region,
-				"zone":         filter.Zone,
-				"tags":         filter.Tags,
+				goaviatrix.TypeKey:         filter.Type,
+				goaviatrix.CidrKey:         filter.CIDR,
+				goaviatrix.FqdnKey:         filter.FQDN,
+				goaviatrix.SiteKey:         filter.Site,
+				goaviatrix.ResIdKey:        filter.ResId,
+				goaviatrix.AccountIdKey:    filter.AccountId,
+				goaviatrix.AccountNameKey:  filter.AccountName,
+				goaviatrix.NameKey:         filter.Name,
+				goaviatrix.RegionKey:       filter.Region,
+				goaviatrix.ZoneKey:         filter.Zone,
+				goaviatrix.TagsPrefix:      filter.Tags,
+				goaviatrix.K8sClusterIdKey: filter.K8sClusterId,
+				goaviatrix.K8sNamespaceKey: filter.K8sNamespace,
+				goaviatrix.K8sServiceKey:   filter.K8sService,
+				goaviatrix.K8sPodNameKey:   filter.K8sPodName,
 			}
 
 			expressions = append(expressions, filterMap)

--- a/aviatrix/data_source_aviatrix_smart_groups_test.go
+++ b/aviatrix/data_source_aviatrix_smart_groups_test.go
@@ -2,15 +2,17 @@ package aviatrix
 
 import (
 	"fmt"
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceAviatrixSmartGroups_basic(t *testing.T) {
-	rName := acctest.RandString(5)
 	resourceName := "data.aviatrix_smart_groups.test"
 
 	skipAcc := os.Getenv("SKIP_DATA_SMART_GROUPS")
@@ -25,7 +27,7 @@ func TestAccDataSourceAviatrixSmartGroups_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAviatrixSmartGroupsConfigBasic(rName),
+				Config: testAccDataSourceAviatrixSmartGroupsConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "smart_groups.0.name"),
 					resource.TestCheckResourceAttrSet(resourceName, "smart_groups.0.uuid"),
@@ -35,16 +37,8 @@ func TestAccDataSourceAviatrixSmartGroups_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAviatrixSmartGroupsConfigBasic(rName string) string {
-	return fmt.Sprintf(`
-resource "aviatrix_account" "test" {
-	account_name       = "tfa-%s"
-	cloud_type         = 1
-	aws_account_number = "%s"
-	aws_iam            = false
-	aws_access_key     = "%s"
-	aws_secret_key     = "%s"
-}
+func testAccDataSourceAviatrixSmartGroupsConfigBasic() string {
+	return `
 resource "aviatrix_smart_group" "test" {
 	name = "aaa-smart-group"
 	selector {
@@ -58,5 +52,88 @@ data "aviatrix_smart_groups" "test"{
         aviatrix_smart_group.test
   ]
 }
-`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"))
+`
+}
+
+func TestAccDataSourceAviatrixSmartGroups_k8s(t *testing.T) {
+	resourceName := "data.aviatrix_smart_groups.test"
+
+	skipAcc := os.Getenv("SKIP_DATA_SMART_GROUPS")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Data Source Smart Groups tests as SKIP_DATA_SMART_GROUPS is set")
+	}
+
+	clusterId1 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	namespace1 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	service1 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	clusterId2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	namespace2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	pod2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+
+	expect := func(resourceName string, keySuffix string, value string) func(state *terraform.State) error {
+		return func(state *terraform.State) error {
+			rm := state.RootModule()
+			resource := rm.Resources[resourceName]
+			attrs := resource.Primary.Attributes
+
+			for k, v := range attrs {
+				if value == v {
+					if strings.HasSuffix(k, keySuffix) {
+						return nil
+					}
+					return fmt.Errorf("invalid key %s for value %s", k, value)
+				}
+			}
+			return fmt.Errorf("value %s not found", value)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAviatrixSmartGroupsConfigK8s(clusterId1, namespace1, service1, clusterId2, namespace2, pod2),
+				Check: resource.ComposeTestCheckFunc(
+					expect(resourceName, "."+goaviatrix.K8sClusterIdKey, clusterId1),
+					expect(resourceName, "."+goaviatrix.K8sNamespaceKey, namespace1),
+					expect(resourceName, "."+goaviatrix.K8sServiceKey, service1),
+					expect(resourceName, "."+goaviatrix.K8sClusterIdKey, clusterId2),
+					expect(resourceName, "."+goaviatrix.K8sNamespaceKey, namespace2),
+					expect(resourceName, "."+goaviatrix.K8sPodNameKey, pod2),
+					expect(resourceName, "."+goaviatrix.TypeKey, "k8s"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAviatrixSmartGroupsConfigK8s(clusterId1, namespace1, service1, clusterId2, namespace2, pod2 string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_smart_group" "test" {
+	name = "test-smart-group"
+	selector {
+		match_expressions {
+            type           = "k8s"
+			k8s_cluster_id = "%s"
+		    k8s_namespace  = "%s"
+		    k8s_service    = "%s"
+		}
+
+		match_expressions {
+			type           = "k8s"
+			k8s_cluster_id = "%s"
+			k8s_namespace  = "%s"
+			k8s_pod        = "%s"
+		}
+	}
+}
+data "aviatrix_smart_groups" "test"{
+	depends_on = [
+        aviatrix_smart_group.test
+  ]
+}
+`, clusterId1, namespace1, service1, clusterId2, namespace2, pod2)
 }

--- a/aviatrix/data_source_aviatrix_smart_groups_test.go
+++ b/aviatrix/data_source_aviatrix_smart_groups_test.go
@@ -2,11 +2,11 @@ package aviatrix
 
 import (
 	"fmt"
-	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/docs/data-sources/aviatrix_smart_groups.md
+++ b/docs/data-sources/aviatrix_smart_groups.md
@@ -37,3 +37,7 @@ The following attributes are exported:
             * `region` - Region this expression matches.
             * `zone` - Zone this expression matches.
             * `tags` - Map of tags this expression matches.
+            * `k8s_cluster_id` - Resource ID of the Kubernetes cluster this expression matches. 
+            * `k8s_namespace` - Kubernetes namespace this expression matches.
+            * `k8s_service` - Kubernetes service name this expression matches.
+            * `k8s_pod` - Kubernetes pod name this expression matches.

--- a/goaviatrix/smart_group.go
+++ b/goaviatrix/smart_group.go
@@ -72,8 +72,8 @@ const (
 	ZoneKey         = "zone"
 	K8sClusterIdKey = "k8s_cluster_id"
 	K8sNamespaceKey = "k8s_namespace"
-	K8sServiceKey   = "ka8s_service"
-	K8sPodNameKey   = "ka8s_pod"
+	K8sServiceKey   = "k8s_service"
+	K8sPodNameKey   = "k8s_pod"
 	S2CKey          = "s2c"
 	ExternalKey     = "external"
 


### PR DESCRIPTION
…. Fix k8s selector keys.

Fixes [AVX-56749](https://aviatrix.atlassian.net/browse/AVX-56749)

This PR extends the Terraform data source aviatrix_smart_groups to also support the new K8s selectors like `k8s_namespace` and `k8s_service`.

Additionally, it fixes the typo that sneaked into the name of the k8s selectors. This is a blocker for the k8s feature.

[AVX-56749]: https://aviatrix.atlassian.net/browse/AVX-56749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ