### PR TITLE
AVX-54880: Fix edge device response to match the correct field name. [Backport UserConnect-7.1]

### DIFF
--- a/goaviatrix/edge_neo_device_onbarding.go
+++ b/goaviatrix/edge_neo_device_onbarding.go
@@ -33,7 +33,7 @@ type EdgeNEODeviceResp struct {
 	DeviceId         string                  `json:"deviceId"`
 	SerialNumber     string                  `json:"serial"`
 	HardwareModel    string                  `json:"hardwareId"`
-	Network          []*EdgeNEODeviceNetwork `json:"interfaces"`
+	Network          []*EdgeNEODeviceNetwork `json:"network"`
 	ConnectionStatus string                  `json:"connectionStatus"`
 }
 


### PR DESCRIPTION
This resulted in always incorrectly unmarshaling the `Network` field which made Terraform always think there was a diff.