### PR TITLE
AVX-51456: DNAT should also include "eth0" when updating s2c [Backport UserConnect-7.1]

### DIFF
--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -221,10 +221,14 @@ func DiffSuppressFuncNatInterface(k, old, new string, d *schema.ResourceData) bo
 	connectionKey := strings.Replace(k, "interface", "connection", 1)
 	connection := d.Get(connectionKey).(string)
 
-	// Check if the number of snat policies has not changed so that interface can be set when a policy is added.
-	// Without this check, the value for interface will be suppressed and interface = "" will
-	// be passed to the API even if interface = "eth0" in the configuration.
-	if !d.HasChange("snat_policy.#") && !(connection == "" || connection == "None") {
+	// If this is a "connection" based NAT, check if the number of SNAT or DNAT
+	// policies have changed. If they have, we set the interface to the default
+	// value of "eth0" and ensure that is sent in the request, otherwise it will
+	// be rejected.
+	// TODO(AVX-54006): The interface should not be required in this particular
+	// case.  This should be fixed on the controller side in the future so that
+	// this check is no longer necessary.
+	if !d.HasChange("snat_policy.#") && !d.HasChange("dnat_policy.#") && !(connection == "" || connection == "None") {
 		return old == "" && new == "eth0"
 	}
 	return false


### PR DESCRIPTION
This is a work-around for now, ideally we shouldn't need to send
any interface information whening using s2c connection in the SNAT/DNAT config.

Longer team goal with be to remove this workaround by adjusting the controller.