### PR TITLE
AVX-54790 Adding BGP BFD config to external connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
     - **aviatrix_spoke_gateway**
     - **aviatrix_edge_spoke_gateway**
     - **aviatrix_transit_gateway**
+2. Added new attribute ``bgp_bfd`` and ``enable_bfd`` to support bgp_bfd configuration in the following resources
+    - **aviatrix_transit_external_device_conn**
+    - **aviatrix_edge_spoke_external_device_conn**
 
 
 ### Deprecations:

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -540,21 +540,29 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 		// get the new BGP BFD config
 		bgpBfdConfig := d.Get("bgp_bfd").([]interface{})
 		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
-		for _, v := range bgpBfdConfig {
-			bfdConfig := v.(map[string]interface{})
-			if bfdConfig["transmit_interval"].(int) == 0 {
-				bfdConfig["transmit_interval"] = defaultBfdTransmitInterval
+		if len(bgpBfdConfig) > 0 {
+			for _, v := range bgpBfdConfig {
+				bfdConfig := v.(map[string]interface{})
+				if bfdConfig["transmit_interval"].(int) == 0 {
+					bfdConfig["transmit_interval"] = defaultBfdTransmitInterval
+				}
+				if bfdConfig["receive_interval"].(int) == 0 {
+					bfdConfig["receive_interval"] = defaultBfdReceiveInterval
+				}
+				if bfdConfig["multiplier"].(int) == 0 {
+					bfdConfig["multiplier"] = defaultBfdMultiplier
+				}
+				bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
+					TransmitInterval: bfdConfig["transmit_interval"].(int),
+					ReceiveInterval:  bfdConfig["receive_interval"].(int),
+					Multiplier:       bfdConfig["multiplier"].(int),
+				})
 			}
-			if bfdConfig["receive_interval"].(int) == 0 {
-				bfdConfig["receive_interval"] = defaultBfdReceiveInterval
-			}
-			if bfdConfig["multiplier"].(int) == 0 {
-				bfdConfig["multiplier"] = defaultBfdMultiplier
-			}
+		} else {
 			bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
-				TransmitInterval: bfdConfig["transmit_interval"].(int),
-				ReceiveInterval:  bfdConfig["receive_interval"].(int),
-				Multiplier:       bfdConfig["multiplier"].(int),
+				TransmitInterval: defaultBfdTransmitInterval,
+				ReceiveInterval:  defaultBfdReceiveInterval,
+				Multiplier:       defaultBfdMultiplier,
 			})
 		}
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -524,6 +524,54 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 		}
 	}
 
+	// Update the BGP BFD config if bfd is enabled and config has changed
+	enableBfd := d.Get("enable_bfd").(bool)
+	if enableBfd && d.HasChange("bgp_bfd") {
+		// get the new BGP BFD config
+		bgpBfdConfig := d.Get("bgp_bfd").([]interface{})
+		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
+		for _, v := range bgpBfdConfig {
+			bfdConfig := v.(map[string]interface{})
+			if bfdConfig["transmit_interval"].(int) == 0 {
+				bfdConfig["transmit_interval"] = defaultBfdTransmitInterval
+			}
+			if bfdConfig["receive_interval"].(int) == 0 {
+				bfdConfig["receive_interval"] = defaultBfdReceiveInterval
+			}
+			if bfdConfig["multiplier"].(int) == 0 {
+				bfdConfig["multiplier"] = defaultBfdMultiplier
+			}
+			bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
+				TransmitInterval: bfdConfig["transmit_interval"].(int),
+				ReceiveInterval:  bfdConfig["receive_interval"].(int),
+				Multiplier:       bfdConfig["multiplier"].(int),
+			})
+		}
+
+		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
+			GwName:         d.Get("gw_name").(string),
+			ConnectionName: d.Get("connection_name").(string),
+			EnableBfd:      d.Get("enable_bfd").(bool),
+			BgpBfdConfig:   bgpBfdConfigList,
+		}
+		err := client.EditConnectionBgpBfd(externalDeviceConn)
+		if err != nil {
+			return diag.Errorf("could not update BGP BFD config: %v", err)
+		}
+	} else {
+		if d.HasChange("enable_bfd") {
+			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
+				GwName:         d.Get("gw_name").(string),
+				ConnectionName: d.Get("connection_name").(string),
+				EnableBfd:      d.Get("enable_bfd").(bool),
+			}
+			err := client.EditConnectionBgpBfd(externalDeviceConn)
+			if err != nil {
+				return diag.Errorf("could not disable BGP BFD config: %v", err)
+			}
+		}
+	}
+
 	if externalDeviceConn.EnableEdgeUnderlay && d.HasChanges("bgp_md5_key", "backup_bgp_md5_key") {
 		edgeExternalDeviceConn := goaviatrix.EdgeExternalDeviceConn(*externalDeviceConn)
 

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -550,14 +550,14 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 	if !ok {
 		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
-	if enableBfd && d.HasChange("bgp_bfd") {
+	if enableBfd {
 		// get the new BGP BFD config
 		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
 		if !ok {
 			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
 		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
-		if len(bgpBfdConfig) > 0 {
+		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
 			for _, v := range bgpBfdConfig {
 				bfdConfig := v.(map[string]interface{})
 				transmitInterval, ok := bfdConfig["transmit_interval"].(int)

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -332,27 +332,36 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 	externalDeviceConn.EnableBfd = enableBFD
 	if enableBFD {
 		bgp_bfd := d.Get("bgp_bfd").([]interface{})
-		for _, bfd0 := range bgp_bfd {
-			bfd1 := bfd0.(map[string]interface{})
-			transmitInterval := defaultBfdTransmitInterval
-			receiveInterval := defaultBfdReceiveInterval
-			multiplier := defaultBfdMultiplier
-			if value, ok := bfd1["transmit_interval"].(int); ok {
-				transmitInterval = value
-			}
-			if value, ok := bfd1["receive_interval"].(int); ok {
-				receiveInterval = value
-			}
-			if value, ok := bfd1["multiplier"].(int); ok {
-				multiplier = value
-			}
+		if len(bgp_bfd) > 0 {
+			for _, bfd0 := range bgp_bfd {
+				bfd1 := bfd0.(map[string]interface{})
+				transmitInterval := defaultBfdTransmitInterval
+				receiveInterval := defaultBfdReceiveInterval
+				multiplier := defaultBfdMultiplier
+				if value, ok := bfd1["transmit_interval"].(int); ok {
+					transmitInterval = value
+				}
+				if value, ok := bfd1["receive_interval"].(int); ok {
+					receiveInterval = value
+				}
+				if value, ok := bfd1["multiplier"].(int); ok {
+					multiplier = value
+				}
 
-			bfd2 := &goaviatrix.BgpBfdConfig{
-				TransmitInterval: transmitInterval,
-				ReceiveInterval:  receiveInterval,
-				Multiplier:       multiplier,
+				bfd2 := &goaviatrix.BgpBfdConfig{
+					TransmitInterval: transmitInterval,
+					ReceiveInterval:  receiveInterval,
+					Multiplier:       multiplier,
+				}
+				externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
 			}
-			externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
+		} else {
+			bfd := &goaviatrix.BgpBfdConfig{
+				TransmitInterval: defaultBfdTransmitInterval,
+				ReceiveInterval:  defaultBfdReceiveInterval,
+				Multiplier:       defaultBfdMultiplier,
+			}
+			externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd)
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
@@ -548,7 +557,6 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 				Multiplier:       bfdConfig["multiplier"].(int),
 			})
 		}
-
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			GwName:         d.Get("gw_name").(string),
 			ConnectionName: d.Get("connection_name").(string),

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -333,11 +333,13 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
 	externalDeviceConn.EnableBfd = enableBFD
+	// set the bgp bfd config details only if the user has enabled BFD
 	if enableBFD {
 		bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
 		if !ok {
 			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
+		// set bgp bfd using the config details provided by the user
 		if len(bgp_bfd) > 0 {
 			for _, bfd0 := range bgp_bfd {
 				bfd1, ok := bfd0.(map[string]interface{})
@@ -364,6 +366,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 				externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
 			}
 		} else {
+			// set the bgp bfd config using the default values
 			bfd := &goaviatrix.BgpBfdConfig{
 				TransmitInterval: defaultBfdTransmitInterval,
 				ReceiveInterval:  defaultBfdReceiveInterval,
@@ -545,7 +548,6 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 		}
 	}
 
-	// Update the BGP BFD config if bfd is enabled and config has changed
 	enableBfd, ok := d.Get("enable_bfd").(bool)
 	if !ok {
 		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
@@ -557,6 +559,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
 		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
+		// Update the BGP BFD config if bfd is enabled and config has changed
 		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
 			for _, v := range bgpBfdConfig {
 				bfdConfig := v.(map[string]interface{})
@@ -579,6 +582,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 				})
 			}
 		} else {
+			// set the bgp bfd config using the default values
 			bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
 				TransmitInterval: defaultBfdTransmitInterval,
 				ReceiveInterval:  defaultBfdReceiveInterval,

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -48,6 +48,45 @@ func TestAccAviatrixEdgeSpokeExternalDeviceConn_basic(t *testing.T) {
 			},
 		},
 	})
+
+	skipBgpBfd := os.Getenv("SKIP_BGP_BFD_EDGE_SPOKE_EXTERNAL_DEVICE_CONN")
+	if skipBgpBfd != "yes" {
+		resourceNameBfd := "aviatrix_edge_spoke_external_device_conn.test-bfd"
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preEdgeSpokeExternalDeviceConnCheck(t)
+			},
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckEdgeSpokeExternalDeviceConnDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccEdgeSpokeExternalDeviceConnConfigBgpBfd(rName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckEdgeSpokeExternalDeviceConnExists(resourceNameBfd),
+						resource.TestCheckResourceAttr(resourceNameBfd, "site_id", os.Getenv("EDGE_SPOKE_SITE_ID")),
+						resource.TestCheckResourceAttr(resourceNameBfd, "connection_name", "cloudn-bgp-lan"),
+						resource.TestCheckResourceAttr(resourceNameBfd, "gw_name", os.Getenv("EDGE_SPOKE_NAME")),
+						resource.TestCheckResourceAttr(resourceNameBfd, "bgp_local_as_num", "65182"),
+						resource.TestCheckResourceAttr(resourceNameBfd, "bgp_remote_as_num", "65220"),
+						resource.TestCheckResourceAttr(resourceNameBfd, "local_lan_ip", "10.220.86.182"),
+						resource.TestCheckResourceAttr(resourceNameBfd, "remote_lan_ip", "10.220.86.100"),
+						resource.TestCheckResourceAttr(resourceNameBfd, "enable_bfd", "true"),
+						resource.TestCheckResourceAttr(resourceNameBfd, "bgo_bfd.0.transmit_interval", "400"),
+						resource.TestCheckResourceAttr(resourceNameBfd, "bgo_bfd.0.receive_interval", "400"),
+						resource.TestCheckResourceAttr(resourceNameBfd, "bgo_bfd.0.multiplier", "5"),
+					),
+				},
+				{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	} else {
+		t.Skip("Skipping BGP BFD Edge as a Spoke external device connection tests as 'SKIP_BGP_BFD_EDGE_SPOKE_EXTERNAL_DEVICE_CONN' is set")
+	}
 }
 
 func preEdgeSpokeExternalDeviceConnCheck(t *testing.T) {
@@ -72,6 +111,26 @@ resource "aviatrix_edge_spoke_external_device_conn" "test" {
 	remote_lan_ip     = "5.6.7.8"
 }
 	`, os.Getenv("EDGE_SPOKE_SITE_ID"), rName, os.Getenv("EDGE_SPOKE_NAME"))
+}
+
+func testAccEdgeSpokeExternalDeviceConnConfigBgpBfd(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_edge_spoke_external_device_conn" "test-bfd" {
+	site_id           = "%s"
+	connection_name   = "cloudn-bgp-lan"
+	gw_name           = "%s"
+	bgp_local_as_num  = "65182"
+	bgp_remote_as_num = "65220"
+	local_lan_ip      = "10.220.86.182"
+	remote_lan_ip     = "10.220.86.100"
+	enable_bfd        = true
+	bgo_bfd {
+		transmit_interval = 400
+		receive_interval = 400
+		multiplier = 5
+	}
+}
+	`, os.Getenv("EDGE_SPOKE_SITE_ID"), os.Getenv("EDGE_SPOKE_NAME"))
 }
 
 func testAccCheckEdgeSpokeExternalDeviceConnExists(resourceName string) resource.TestCheckFunc {

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -61,7 +61,7 @@ func TestAccAviatrixEdgeSpokeExternalDeviceConn_basic(t *testing.T) {
 			CheckDestroy: testAccCheckEdgeSpokeExternalDeviceConnDestroy,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccEdgeSpokeExternalDeviceConnConfigBgpBfd(rName),
+					Config: testAccEdgeSpokeExternalDeviceConnConfigBgpBfd(),
 					Check: resource.ComposeTestCheckFunc(
 						testAccCheckEdgeSpokeExternalDeviceConnExists(resourceNameBfd),
 						resource.TestCheckResourceAttr(resourceNameBfd, "site_id", os.Getenv("EDGE_SPOKE_SITE_ID")),
@@ -113,7 +113,7 @@ resource "aviatrix_edge_spoke_external_device_conn" "test" {
 	`, os.Getenv("EDGE_SPOKE_SITE_ID"), rName, os.Getenv("EDGE_SPOKE_NAME"))
 }
 
-func testAccEdgeSpokeExternalDeviceConnConfigBgpBfd(rName string) string {
+func testAccEdgeSpokeExternalDeviceConnConfigBgpBfd() string {
 	return fmt.Sprintf(`
 resource "aviatrix_edge_spoke_external_device_conn" "test-bfd" {
 	site_id           = "%s"

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -743,11 +743,13 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
 	externalDeviceConn.EnableBfd = enableBFD
+	// set the bgp bfd config details only if the user has enabled BFD
 	if enableBFD {
 		bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
 		if !ok {
 			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
+		// set bgp bfd using the config details provided by the user
 		if len(bgp_bfd) > 0 {
 			for _, bfd0 := range bgp_bfd {
 				bfd1, ok := bfd0.(map[string]interface{})
@@ -774,6 +776,7 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 				externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
 			}
 		} else {
+			// set the bgp bfd config using the default values
 			bfd := &goaviatrix.BgpBfdConfig{
 				TransmitInterval: defaultBfdTransmitInterval,
 				ReceiveInterval:  defaultBfdReceiveInterval,
@@ -1348,7 +1351,6 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 		}
 	}
 
-	// Update the BGP BFD config if bfd is enabled and config has changed
 	enableBfd, ok := d.Get("enable_bfd").(bool)
 	if !ok {
 		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
@@ -1360,6 +1362,7 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
 		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
+		// Update the BGP BFD config if bfd is enabled and config has changed
 		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
 			for _, v := range bgpBfdConfig {
 				bfdConfig := v.(map[string]interface{})
@@ -1382,6 +1385,7 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 				})
 			}
 		} else {
+			// set the bgp bfd config using the default values
 			bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
 				TransmitInterval: defaultBfdTransmitInterval,
 				ReceiveInterval:  defaultBfdReceiveInterval,

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -535,34 +535,6 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 		return fmt.Errorf("'bgp_local_as_num' and 'bgp_remote_as_num' are needed for connection type of 'bgp' not 'static'")
 	}
 
-	enableBFD := d.Get("enable_bfd").(bool)
-	if enableBFD {
-		externalDeviceConn.EnableBfd = enableBFD
-		bgp_bfd := d.Get("bgp_bfd").([]interface{})
-		for _, bfd0 := range bgp_bfd {
-			bfd1 := bfd0.(map[string]interface{})
-			transmitInterval := defaultBfdTransmitInterval
-			receiveInterval := defaultBfdReceiveInterval
-			multiplier := defaultBfdMultiplier
-			if value, ok := bfd1["transmit_interval"].(int); ok {
-				transmitInterval = value
-			}
-			if value, ok := bfd1["receive_interval"].(int); ok {
-				receiveInterval = value
-			}
-			if value, ok := bfd1["multiplier"].(int); ok {
-				multiplier = value
-			}
-
-			bfd2 := &goaviatrix.BgpBfdConfig{
-				TransmitInterval: transmitInterval,
-				ReceiveInterval:  receiveInterval,
-				Multiplier:       multiplier,
-			}
-			externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
-		}
-	}
-
 	customAlgorithms := d.Get("custom_algorithms").(bool)
 	if customAlgorithms {
 		if externalDeviceConn.Phase1Auth == "" ||
@@ -764,6 +736,38 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 			return fmt.Errorf("failed to create Aviatrix transit external device connection: %s", err)
 		}
 		break
+	}
+
+	enableBFD := d.Get("enable_bfd").(bool)
+	externalDeviceConn.EnableBfd = enableBFD
+	if enableBFD {
+		bgp_bfd := d.Get("bgp_bfd").([]interface{})
+		for _, bfd0 := range bgp_bfd {
+			bfd1 := bfd0.(map[string]interface{})
+			transmitInterval := defaultBfdTransmitInterval
+			receiveInterval := defaultBfdReceiveInterval
+			multiplier := defaultBfdMultiplier
+			if value, ok := bfd1["transmit_interval"].(int); ok {
+				transmitInterval = value
+			}
+			if value, ok := bfd1["receive_interval"].(int); ok {
+				receiveInterval = value
+			}
+			if value, ok := bfd1["multiplier"].(int); ok {
+				multiplier = value
+			}
+
+			bfd2 := &goaviatrix.BgpBfdConfig{
+				TransmitInterval: transmitInterval,
+				ReceiveInterval:  receiveInterval,
+				Multiplier:       multiplier,
+			}
+			externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
+		}
+		err := client.EditConnectionBgpBfd(externalDeviceConn)
+		if err != nil {
+			return fmt.Errorf("could not enable BGP BFD connection: %v", err)
+		}
 	}
 
 	transitAdvancedConfig, err := client.GetTransitGatewayAdvancedConfig(&goaviatrix.TransitVpc{GwName: externalDeviceConn.GwName})
@@ -1076,30 +1080,27 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 			d.Set("phase1_remote_identifier", ph1RemoteId)
 		}
 
-		if conn.EnableBfd {
-			d.Set("enable_bfd", true)
-			if len(conn.BgpBfdConfig) > 0 {
-				var bgpBfdConfig []map[string]interface{}
-				for _, bfd := range conn.BgpBfdConfig {
-					bfdMap := make(map[string]interface{})
-					bfdMap["transmit_interval"] = defaultBfdTransmitInterval
-					bfdMap["receive_interval"] = defaultBfdReceiveInterval
-					bfdMap["multiplier"] = defaultBfdMultiplier
-					if bfd.TransmitInterval != 0 {
-						bfdMap["transmit_interval"] = bfd.TransmitInterval
-					}
-					if bfd.ReceiveInterval != 0 {
-						bfdMap["receive_interval"] = bfd.ReceiveInterval
-					}
-					if bfd.Multiplier != 0 {
-						bfdMap["multiplier"] = bfd.Multiplier
-					}
-					bgpBfdConfig = append(bgpBfdConfig, bfdMap)
+		enable_bfd := d.Get("enable_bfd").(bool)
+		d.Set("enable_bfd", enable_bfd)
+		if enable_bfd && len(conn.BgpBfdConfig) > 0 {
+			var bgpBfdConfig []map[string]interface{}
+			for _, bfd := range conn.BgpBfdConfig {
+				bfdMap := make(map[string]interface{})
+				bfdMap["transmit_interval"] = defaultBfdTransmitInterval
+				bfdMap["receive_interval"] = defaultBfdReceiveInterval
+				bfdMap["multiplier"] = defaultBfdMultiplier
+				if bfd.TransmitInterval != 0 {
+					bfdMap["transmit_interval"] = bfd.TransmitInterval
 				}
-				d.Set("bgp_bfd", bgpBfdConfig)
+				if bfd.ReceiveInterval != 0 {
+					bfdMap["receive_interval"] = bfd.ReceiveInterval
+				}
+				if bfd.Multiplier != 0 {
+					bfdMap["multiplier"] = bfd.Multiplier
+				}
+				bgpBfdConfig = append(bgpBfdConfig, bfdMap)
 			}
-		} else {
-			d.Set("enable_bfd", false)
+			d.Set("bgp_bfd", bgpBfdConfig)
 		}
 
 		if conn.PrependAsPath != "" {

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -1353,14 +1353,14 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 	if !ok {
 		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
-	if enableBfd && d.HasChange("bgp_bfd") {
+	if enableBfd {
 		// get the new BGP BFD config
 		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
 		if !ok {
 			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
 		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
-		if len(bgpBfdConfig) > 0 {
+		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
 			for _, v := range bgpBfdConfig {
 				bfdConfig := v.(map[string]interface{})
 				transmitInterval, ok := bfdConfig["transmit_interval"].(int)

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -747,13 +747,13 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 			transmitInterval := defaultBfdTransmitInterval
 			receiveInterval := defaultBfdReceiveInterval
 			multiplier := defaultBfdMultiplier
-			if value, ok := bfd1["transmit_interval"].(int); ok {
+			if value, ok := bfd1["transmit_interval"].(int); ok && value != 0 {
 				transmitInterval = value
 			}
-			if value, ok := bfd1["receive_interval"].(int); ok {
+			if value, ok := bfd1["receive_interval"].(int); ok && value != 0 {
 				receiveInterval = value
 			}
-			if value, ok := bfd1["multiplier"].(int); ok {
+			if value, ok := bfd1["multiplier"].(int); ok && value != 0 {
 				multiplier = value
 			}
 
@@ -1358,6 +1358,8 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 			EnableBfd:      d.Get("enable_bfd").(bool),
 			BgpBfdConfig:   bgpBfdConfigList,
 		}
+		// TODO: Remove this log after debugging
+		log.Printf("[INFO] BGP BFD configuration: %v", externalDeviceConn.BgpBfdConfig)
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
 			return fmt.Errorf("could not update BGP BFD config: %v", err)

--- a/docs/resources/aviatrix_edge_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_edge_spoke_external_device_conn.md
@@ -26,6 +26,24 @@ resource "aviatrix_edge_spoke_external_device_conn" "test" {
   remote_lan_ip     = "10.0.60.1"
 }
 ```
+```hcl
+# Create a BGP BFD enabled Edge as a Spoke External Device Connection
+resource "aviatrix_edge_spoke_external_device_conn" "test" {
+  site_id           = "site-abcd1234"
+  connection_name   = "conn"
+  gw_name           = "eaas"
+  bgp_local_as_num  = "123"
+  bgp_remote_as_num = "345"
+  local_lan_ip      = "10.230.3.23"
+  remote_lan_ip     = "10.0.60.1"
+  enable_bfd = true
+  bgp_bfd {
+    transmit_interval = 400
+    receive_interval = 400
+    multiplier = 5
+  }
+}
+```
 
 ## Argument Reference
 

--- a/docs/resources/aviatrix_edge_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_edge_spoke_external_device_conn.md
@@ -59,6 +59,11 @@ The following arguments are supported:
 * `backup_bgp_remote_as_num` - (Optional) Backup BGP remote ASN (Autonomous System Number). Integer between 1-4294967294. Required if HA enabled for 'bgp' connection.
 * `prepend_as_path` - (Optional) Connection AS Path Prepend customized by specifying AS PATH for a BGP connection.
 * `manual_bgp_advertised_cidrs` - (Optional) Configure manual BGP advertised CIDRs for this connection.
+* `enable_bfd` - (Optional) Required for BGP BFD over IPsec. Valid values: true, false. Default: false.
+* `bgp_bfd` - (Optional) BGP BFD configuration applied to a BGP session. If config is no provided then default values are applied for the connection.
+  * `transmit_interval` - (Optional) BFD transmit interval in ms. Valid values between 10 to 60000. Default: 300.
+  * `receive_interval` - (Optional) BFD receive interval in ms. Valid values between 10 to 60000. Default: 300.
+  * `multiplier` - (Optional) BFD detection multiplier. Valid values between 2 to 255. Default: 3.
 
 ## Import
 

--- a/docs/resources/aviatrix_transit_external_device_conn.md
+++ b/docs/resources/aviatrix_transit_external_device_conn.md
@@ -103,6 +103,25 @@ resource "aviatrix_transit_external_device_conn" "ex-conn" {
   backup_local_lan_ip      = "172.12.13.17"
 }
 ```
+# Create a BGP BFD over IPSEC tunnel Aviatrix Transit External Device Connection 
+resource "aviatrix_transit_external_device_conn" "ex-conn" {
+  vpc_id                   = aviatrix_transit_gateway.transit-gateway.vpc_id
+  connection_name          = "my_conn"
+  gw_name                  = aviatrix_transit_gateway.transit-gateway.gw_name
+  connection_type          = "bgp"
+  tunnel_protocol          = "IPsec"
+  bgp_local_as_num         = "123"
+  bgp_remote_as_num        = "345"
+  remote_gateway_ip        = "3.19.43.179"
+  pre_shared_key = "psk12"
+  enable_bfd = true
+  bgp_bfd {
+    transmit_interval = 400
+    receive_interval = 400
+    multiplier = 3
+  }
+}
+```
 
 ## Argument Reference
 
@@ -163,6 +182,17 @@ The following arguments are supported:
 
 * `bgp_md5_key` - (Optional) BGP MD5 Authentication Key. Example: 'avx01,avx02'. For BGP LAN ActiveMesh mode disabled, example: 'avx01'.
 * `backup_bgp_md5_key` - (Optional) Backup BGP MD5 Authentication Key. Valid with HA enabled for connection. Example: 'avx03,avx04'. For BGP LAN ActiveMesh mode disabled, example: 'avx03'.
+
+### BGP BFD over IPsec 
+
+~> **NOTE:** BGP BFD over IPsec attributes are only valid with `tunnel_protocol` = 'IPsec'.
+
+* `enable_bfd` - (Optional) Required for BGP BFD over IPsec. Valid values: true, false. Default: false.
+* `bgp_bfd` - (Optional) BGP BFD configuration applied to a BGP session. If config is no provided then default values are applied for the connection.
+  * `transmit_interval` - (Optional) BFD transmit interval in ms. Valid values between 10 to 60000. Default: 300.
+  * `receive_interval` - (Optional) BFD receive interval in ms. Valid values between 10 to 60000. Default: 300.
+  * `multiplier` - (Optional) BFD detection multiplier. Valid values between 2 to 255. Default: 3.
+
 
 ### Misc.
 * `direct_connect` - (Optional) Set true for private network infrastructure.

--- a/goaviatrix/edge_external_device_conn.go
+++ b/goaviatrix/edge_external_device_conn.go
@@ -46,12 +46,14 @@ type EdgeExternalDeviceConn struct {
 	Phase1LocalIdentifier  string
 	Phase1RemoteIdentifier string
 	PrependAsPath          string
-	BgpMd5Key              string `json:"bgp_md5_key,omitempty"`
-	BackupBgpMd5Key        string `json:"backup_bgp_md5_key,omitempty"`
-	AuthType               string `json:"auth_type,omitempty"`
-	EnableEdgeUnderlay     bool   `json:"edge_underlay,omitempty"`
-	RemoteCloudType        string `json:"remote_cloud_type,omitempty"`
-	BgpMd5KeyChanged       bool   `json:"bgp_md5_key_changed,omitempty"`
+	BgpMd5Key              string          `json:"bgp_md5_key,omitempty"`
+	BackupBgpMd5Key        string          `json:"backup_bgp_md5_key,omitempty"`
+	AuthType               string          `json:"auth_type,omitempty"`
+	EnableEdgeUnderlay     bool            `json:"edge_underlay,omitempty"`
+	RemoteCloudType        string          `json:"remote_cloud_type,omitempty"`
+	BgpMd5KeyChanged       bool            `json:"bgp_md5_key_changed,omitempty"`
+	BgpBfdConfig           []*BgpBfdConfig `json:"bgp_bfd,omitempty"`
+	EnableBfd              bool            `json:"enable_bfd,omitempty"`
 }
 
 func (c *Client) CreateEdgeExternalDeviceConn(edgeExternalDeviceConn *EdgeExternalDeviceConn) (string, error) {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -383,6 +383,23 @@ func (c *Client) EditTransitExternalDeviceConnASPathPrepend(externalDeviceConn *
 	}, BasicCheck)
 }
 
+func (c *Client) EditConnectionBgpBfd(externalDeviceConn *ExternalDeviceConn) error {
+	action := "edit_connection_bgp_bfd"
+	data := map[string]interface{}{
+		"CID":                c.CID,
+		"action":             action,
+		"gateway_name":       externalDeviceConn.GwName,
+		"connection_name":    externalDeviceConn.ConnectionName,
+		"connection_bgp_bfd": externalDeviceConn.EnableBfd,
+	}
+	if externalDeviceConn.EnableBfd {
+		data["connection_bgp_bfd_receive_interval"] = externalDeviceConn.BgpBfdConfig[0].ReceiveInterval
+		data["connection_bgp_bfd_transmit_interval"] = externalDeviceConn.BgpBfdConfig[0].TransmitInterval
+		data["connection_bgp_bfd_detect_multiplier"] = externalDeviceConn.BgpBfdConfig[0].Multiplier
+	}
+	return c.PostAPI(action, data, BasicCheck)
+}
+
 func (c *Client) EditBgpMd5Key(editBgpMd5Key *EditBgpMd5Key) error {
 	editBgpMd5Key.CID = c.CID
 	editBgpMd5Key.Action = "update_bgp_connection_md5_signature"

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -54,12 +54,14 @@ type ExternalDeviceConn struct {
 	Phase1LocalIdentifier  string
 	Phase1RemoteIdentifier string
 	PrependAsPath          string
-	BgpMd5Key              string `form:"bgp_md5_key,omitempty"`
-	BackupBgpMd5Key        string `form:"backup_bgp_md5_key,omitempty"`
-	AuthType               string `form:"auth_type,omitempty"`
-	EnableEdgeUnderlay     bool   `form:"edge_underlay,omitempty"`
-	RemoteCloudType        string `form:"remote_cloud_type,omitempty"`
-	BgpMd5KeyChanged       bool   `form:"bgp_md5_key_changed,omitempty"`
+	BgpMd5Key              string          `form:"bgp_md5_key,omitempty"`
+	BackupBgpMd5Key        string          `form:"backup_bgp_md5_key,omitempty"`
+	AuthType               string          `form:"auth_type,omitempty"`
+	EnableEdgeUnderlay     bool            `form:"edge_underlay,omitempty"`
+	RemoteCloudType        string          `form:"remote_cloud_type,omitempty"`
+	BgpMd5KeyChanged       bool            `form:"bgp_md5_key_changed,omitempty"`
+	BgpBfdConfig           []*BgpBfdConfig `json:"bgp_bfd,omitempty"`
+	EnableBfd              bool            `form:"enable_bfd,omitempty"`
 }
 
 type EditExternalDeviceConnDetail struct {
@@ -101,6 +103,12 @@ type EditExternalDeviceConnDetail struct {
 	EnableJumboFrame       bool   `json:"jumbo_frame,omitempty"`
 	WanUnderlay            bool   `json:"wan_underlay,omitempty"`
 	RemoteCloudType        string `json:"remote_cloud_type,omitempty"`
+}
+
+type BgpBfdConfig struct {
+	TransmitInterval int `json:"transmit_interval"`
+	ReceiveInterval  int `json:"receive_interval"`
+	Multiplier       int `json:"multiplier"`
 }
 
 type EditBgpMd5Key struct {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -60,7 +60,7 @@ type ExternalDeviceConn struct {
 	EnableEdgeUnderlay     bool            `form:"edge_underlay,omitempty"`
 	RemoteCloudType        string          `form:"remote_cloud_type,omitempty"`
 	BgpMd5KeyChanged       bool            `form:"bgp_md5_key_changed,omitempty"`
-	BgpBfdConfig           []*BgpBfdConfig `json:"bgp_bfd,omitempty"`
+	BgpBfdConfig           []*BgpBfdConfig `form:"bgp_bfd,omitempty"`
 	EnableBfd              bool            `form:"enable_bfd,omitempty"`
 }
 


### PR DESCRIPTION
Updating the following resource with bgp_bfd config
- aviatrix_edge_spoke_external_device_conn
- avaitrix_transit_external_device_conn

Example of the connection resource with BGP-BFD enabled
```
`resource "aviatrix_transit_external_device_conn" "transit-1-transit-2" {
  vpc_id            = "vpc-048eb7341becf3c1b"
  connection_name   = "transit-1-transit-2"
  gw_name           = "udxjl-aws-transit-1"
  connection_type   = "bgp"
  tunnel_protocol    = "IPsec"
  bgp_local_as_num  = "65075"
  bgp_remote_as_num = "65076"
  remote_gateway_ip = "3.19.43.179"
  local_tunnel_cidr  = "169.254.10.1/30"
  remote_tunnel_cidr = "169.254.10.2/30"
  pre_shared_key = "psk12"
  enable_bfd = true
  bgp_bfd {
    transmit_interval = 500
    receive_interval = 500
    multiplier = 5
  }
}

resource "aviatrix_transit_external_device_conn" "transit-2-transit-1" {
  vpc_id            = "vpc-00951e22f3e587165"
  connection_name   = "transit-2-transit-1"
  gw_name           = "udxjl-aws-transit-2"
  connection_type   = "bgp"
  tunnel_protocol    = "IPsec"
  bgp_local_as_num  = "65076"
  bgp_remote_as_num = "65075"
  remote_gateway_ip = "3.140.172.87"
  local_tunnel_cidr  = "169.254.10.2/30"
  remote_tunnel_cidr = "169.254.10.1/30"
  pre_shared_key = "psk12"
}

resource "aviatrix_edge_spoke_external_device_conn" "edge_bgp_lan" {
  site_id                  = "SC"
  connection_name          = "cloudn-bgp-lan"
  gw_name                  = "Edge-182"
  bgp_local_as_num         = "65182"
  bgp_remote_as_num        = "65220"
  local_lan_ip             = "10.220.86.182"
  remote_lan_ip            = "10.220.86.100"
  enable_bfd               = true
  bgp_bfd {
    transmit_interval = 400
    receive_interval = 400
    multiplier = 5
  }
}`
```