### PR TITLE
AVX-56803 Updating the Interface config and mapping

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -772,9 +772,10 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"wan", "mgmt"}, false),
 						},
 						"index": {
-							Type:        schema.TypeInt,
-							Required:    true,
-							Description: "Interface index (e.g., '0', '1').",
+							Type:         schema.TypeInt,
+							Required:     true,
+							Description:  "Interface index (e.g., 0, 1).",
+							ValidateFunc: validation.IntAtLeast(0),
 						},
 					},
 				},

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -961,21 +961,13 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			transitHaGw.BackupLinkConfig = b64.StdEncoding.EncodeToString(backupLinkConfig)
 			log.Printf("[INFO] Enabling HA on Transit Gateway")
 			if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGENEO) {
-				enable_interface_mapping := d.Get("enable_interface_mapping").(bool)
-				if enable_interface_mapping {
-					// Set the interface mapping for ESXI devices
-					interfaceMapping["eth0"] = []string{"wan", "0"}
-					interfaceMapping["eth1"] = []string{"wan", "1"}
-					interfaceMapping["eth2"] = []string{"wan", "2"}
-					interfaceMapping["eth3"] = []string{"mgmt", "0"}
-					interfaceMapping["eth4"] = []string{"wan", "3"}
-				} else {
-					// Set the interface mapping for Dell devices
-					interfaceMapping["eth0"] = []string{"mgmt", "0"}
-					interfaceMapping["eth5"] = []string{"wan", "0"}
-					interfaceMapping["eth2"] = []string{"wan", "1"}
-					interfaceMapping["eth3"] = []string{"wan", "2"}
-					interfaceMapping["eth4"] = []string{"wan", "3"}
+				// set the static interface mapping for AEP
+				interfaceMapping := map[string][]string{
+					"eth0": {"wan", "0"},
+					"eth1": {"wan", "1"},
+					"eth2": {"wan", "2"},
+					"eth3": {"mgmt", "0"},
+					"eth4": {"wan", "3"},
 				}
 				// Convert interfaceMapping to JSON byte slice
 				interfaceMappingJSON, err := json.Marshal(interfaceMapping)

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -24,6 +24,12 @@ const (
 	defaultBgpHoldTime             = 180
 )
 
+var InterfaceTypeMapping = map[string]string{
+	"MANAGEMENT": "mgmt",
+	"WAN":        "wan",
+	"LAN":        "lan",
+}
+
 func resourceAviatrixTransitGateway() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAviatrixTransitGatewayCreate,
@@ -711,16 +717,17 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Description: "A list of WAN/Management interfaces, each represented as a map.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Interface name, e.g., 'eth0', 'eth1'.",
-						},
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  "Interface type. Valid values are 'WAN' or 'MANAGEMENT'.",
 							ValidateFunc: validation.StringInSlice([]string{"WAN", "MANAGEMENT"}, false),
+						},
+						"index": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							Description:  "Interface index. Must be unique for each interface type.",
+							ValidateFunc: validation.IntAtLeast(0),
 						},
 						"gateway_ip": {
 							Type:        schema.TypeString,
@@ -786,6 +793,16 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			Transit:     true,
 		}
 		interfaces := d.Get("interfaces").([]interface{})
+		if (interfaces == nil) || (len(interfaces) == 0) {
+			return fmt.Errorf("interfaces attribute is required for EAT gateway")
+		}
+		// get the count of WAN and MANAGEMENT interfaces
+		wanCount, mgmtCount, err := countInterfaceTypes(interfaces)
+		if err != nil {
+			return fmt.Errorf("failed to get the interface count: %v", err)
+		}
+		// Initialize interface mapping for AEP
+		interfaceMapping := make(map[string][]string)
 		for _, iface := range interfaces {
 			ifaceInfo, ok := iface.(map[string]interface{})
 			if !ok {
@@ -793,20 +810,36 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			}
 			// Initialize the interface fields with default values
 			var ifaceName, ifaceType, ifaceGatewayIP, ifaceIP, ifacePublicIP string
+			var ifaceIndex int
 			var ifaceDHCP bool
 			var secondaryCIDRs []string
-			// Check and set 'interface name'
-			if val, exists := ifaceInfo["name"]; exists && val != nil {
-				ifaceName, ok = val.(string)
-				if !ok {
-					return fmt.Errorf("interface name is not a string")
-				}
-			}
 			// Check and set 'type'
 			if val, exists := ifaceInfo["type"]; exists && val != nil {
 				ifaceType, ok = val.(string)
 				if !ok {
 					return fmt.Errorf("interface type is not a string")
+				}
+			}
+			mappedIfaceType, ok := InterfaceTypeMapping[ifaceType]
+			if !ok {
+				return fmt.Errorf("invalid interface type: %s", ifaceType)
+			}
+			ifaceIndex = ifaceInfo["index"].(int)
+
+			// get the interface name using the interface type, index and count
+			// getInterfaceName(intfType string, intfIndex, wanCount, mgmtCount int) (string, error)
+			ifaceName, err := getInterfaceName(ifaceType, ifaceIndex, wanCount, mgmtCount)
+			if err != nil {
+				return fmt.Errorf("failed to get the interface name: %v", err)
+			}
+			// Append values to interface mapping
+			interfaceMapping[ifaceName] = []string{mappedIfaceType, strconv.Itoa(ifaceIndex)}
+
+			// Check and set 'interface name'
+			if val, exists := ifaceInfo["name"]; exists && val != nil {
+				ifaceName, ok = val.(string)
+				if !ok {
+					return fmt.Errorf("interface name is not a string")
 				}
 			}
 			// Check and set 'gateway_ip'
@@ -871,14 +904,6 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		gateway.Interfaces = b64.StdEncoding.EncodeToString(interfaceList)
 
 		if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGENEO) {
-			// set the static interface mapping for AEP
-			interfaceMapping := map[string][]string{
-				"eth0": {"wan", "0"},
-				"eth1": {"wan", "1"},
-				"eth2": {"wan", "2"},
-				"eth3": {"mgmt", "0"},
-				"eth4": {"wan", "3"},
-			}
 			// Convert interfaceMapping to JSON byte slice
 			interfaceMappingJSON, err := json.Marshal(interfaceMapping)
 			if err != nil {
@@ -923,14 +948,6 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			transitHaGw.BackupLinkConfig = b64.StdEncoding.EncodeToString(backupLinkConfig)
 			log.Printf("[INFO] Enabling HA on Transit Gateway")
 			if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGENEO) {
-				// set the static interface mapping for AEP
-				interfaceMapping := map[string][]string{
-					"eth0": {"wan", "0"},
-					"eth1": {"wan", "1"},
-					"eth2": {"wan", "2"},
-					"eth3": {"mgmt", "0"},
-					"eth4": {"wan", "3"},
-				}
 				// Convert interfaceMapping to JSON byte slice
 				interfaceMappingJSON, err := json.Marshal(interfaceMapping)
 				if err != nil {
@@ -3768,4 +3785,63 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 	}
 
 	return nil
+}
+
+// count the number of WAN and MANAGEMENT interfaces in the interface config
+func countInterfaceTypes(interfaceList []interface{}) (int, int, error) {
+	wanCount := 0
+	mgmtCount := 0
+	// Iterate over each interface in the list
+	for _, item := range interfaceList {
+		interfaceMap, ok := item.(map[string]interface{})
+		if !ok {
+			return 0, 0, fmt.Errorf("invalid interface entry, expected a map")
+		}
+		interfaceType, ok := interfaceMap["type"].(string)
+		if !ok {
+			return 0, 0, fmt.Errorf("interface type must be a string")
+		}
+		// Count WAN and MANAGEMENT interfaces
+		switch interfaceType {
+		case "WAN":
+			wanCount++
+		case "MANAGEMENT":
+			mgmtCount++
+		default:
+			return 0, 0, fmt.Errorf("invalid interface type: %s", interfaceType)
+		}
+	}
+	return wanCount, mgmtCount, nil
+}
+
+// get the interface name (ethX) from interface type, index, and counts
+func getInterfaceName(intfType string, intfIndex, wanCount, mgmtCount int) (string, error) {
+	// Check if the interface type is valid
+	if intfType != "WAN" && intfType != "MANAGEMENT" {
+		log.Printf("Invalid interface type %s", intfType)
+		return "", errors.New("invalid interface type " + intfType)
+	}
+	var num int
+	// Determine the interface name based on the type and index
+	switch intfType {
+	case "WAN":
+		if intfIndex == 0 {
+			num = 0 // First WAN interface is eth0
+		} else {
+			// Transit case: wan, wan, mgmt, remaining wans, remaining mgmts if any
+			if intfIndex == 1 {
+				num = 1 // Second WAN is eth1
+			} else {
+				num = intfIndex + 1
+			}
+		}
+	case "MANAGEMENT":
+		num = wanCount + intfIndex
+	default:
+		return "", errors.New("unexpected interface type")
+	}
+
+	interfaceName := fmt.Sprintf("eth%d", num)
+	log.Printf("Mapping interface %s%d to port %s", intfType, intfIndex, interfaceName)
+	return interfaceName, nil
 }

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -920,7 +920,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			*/
 			interfaceMapping := map[string][]string{}
 			interfaceMappingInput := d.Get("interface_mapping").([]interface{})
-			if interfaceMappingInput != nil {
+			if len(interfaceMappingInput) > 0 {
 				// Set the interface mapping for ESXI devices
 				for _, value := range interfaceMappingInput {
 					mappingMap, ok := value.(map[string]interface{})

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -363,8 +363,8 @@ func compareImageSize(imageSize1, imageSize2, flag string, indexFlag int) bool {
 	return false
 }
 
-// Define the interface order including eth0, eth1, eth2, eth3, eth4
-var interfaceOrder = []string{"eth0", "eth1", "eth2", "eth3", "eth4"}
+// Define the interface order including eth0, eth1, eth2, eth3, eth4...etc
+var interfaceOrder = []string{"eth0", "eth1", "eth2", "eth3", "eth4", "eth5", "eth6", "eth7", "eth8", "eth9"}
 
 // Create a mapping of each type to its index in the interface order
 func createOrderMap(order []string) map[string]int {
@@ -390,4 +390,21 @@ func sortInterfacesByCustomOrder(interfaces []goaviatrix.EdgeTransitInterface) [
 		return iIndex < jIndex
 	})
 	return interfaces
+}
+
+// Sorting function that uses the interface mapping order
+func sortInterfaceMappingByCustomOrder(interfaceMapping []goaviatrix.InterfaceMapping) []goaviatrix.InterfaceMapping {
+	orderMap := createOrderMap(interfaceOrder)
+	sort.SliceStable(interfaceMapping, func(i, j int) bool {
+		iIndex, iExists := orderMap[interfaceMapping[i].Name]
+		jIndex, jExists := orderMap[interfaceMapping[j].Name]
+		if !iExists {
+			iIndex = len(orderMap)
+		}
+		if !jExists {
+			jIndex = len(orderMap)
+		}
+		return iIndex < jIndex
+	})
+	return interfaceMapping
 }

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -401,7 +401,7 @@ The following arguments are supported:
 * `site_id` - (Optional) Site id for the EAT gateway. Required and valid only for edge transit gateways AEP and Equinix.
 * `interfaces` - (Optional) A list of WAN/Management interfaces, each represented as a map. Required and valid only for edge transit gateways AEP and Equinix. Each interface has the following attributes:
   * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
-  * `index` - (Required) Interface 
+  * `index` - (Required) Interface index. Valid values are 0,1,2 etc.
   * `gateway_ip` - (Optional) The gateway IP address associated with this interface.
   * `ip_address` - (Optional) The static IP address assigned to this interface.
   * `public_ip` - (Optional) The public IP address associated with this interface.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -400,13 +400,14 @@ The following arguments are supported:
 * `fault_domain` - (Optional) Fault domain. Required and valid only for OCI. Available as of provider version R2.19.3.
 * `site_id` - (Optional) Site id for the EAT gateway. Required and valid only for edge transit gateways AEP and Equinix.
 * `interfaces` - (Optional) A list of WAN/Management interfaces, each represented as a map. Required and valid only for edge transit gateways AEP and Equinix. Each interface has the following attributes:
-  * `name` - (Required) Interface name e.g. eth0, eth1, eh2 etc.
   * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
+  * `index` - (Required) Interface 
   * `gateway_ip` - (Optional) The gateway IP address associated with this interface.
   * `ip_address` - (Optional) The static IP address assigned to this interface.
   * `public_ip` - (Optional) The public IP address associated with this interface.
   * `dhcp` - (Optional) Whether DHCP is enabled on this interface. Set the value to true or false. Applicable to only 'MANAGEMENT' type interface.
   * `secondary_private_cidr_list` - (Optional) A list of secondary private CIDR blocks associated with this interface.
+* `enable_interface_mapping` - (Optional) Interface mapping is configured to support ESXI devices when set to 'TRUE'.
 
 
 ### HA

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -408,7 +408,7 @@ The following arguments are supported:
   * `dhcp` - (Optional) Whether DHCP is enabled on this interface. Set the value to true or false. Applicable to only 'MANAGEMENT' type interface.
   * `secondary_private_cidr_list` - (Optional) A list of secondary private CIDR blocks associated with this interface.
 * `interface_mapping` - (Optional) A list of interface names mapped to interface types and indices. Required and valid only for edge transit gateways (AEP). Each interface has the following attributes:
-  * `name` - (Required) Interface name e.g. eth0, eth1, eh2 etc.
+  * `name` - (Required) Interface name e.g. eth0, eth1, eth2 etc.
   * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
   * `index` - (Requied) Interface index e.g. 0, 1 etc.
 

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -407,7 +407,10 @@ The following arguments are supported:
   * `public_ip` - (Optional) The public IP address associated with this interface.
   * `dhcp` - (Optional) Whether DHCP is enabled on this interface. Set the value to true or false. Applicable to only 'MANAGEMENT' type interface.
   * `secondary_private_cidr_list` - (Optional) A list of secondary private CIDR blocks associated with this interface.
-* `enable_interface_mapping` - (Optional) Interface mapping is configured to support ESXI devices when set to 'TRUE'.
+* `interface_mapping` - (Optional) A list of interface names mapped to interface types and indices. Required and valid only for edge transit gateways (AEP). Each interface has the following attributes:
+  * `name` - (Required) Interface name e.g. eth0, eth1, eh2 etc.
+  * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
+  * `index` - (Requied) Interface index e.g. 0, 1 etc.
 
 
 ### HA

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -303,33 +303,33 @@ resource "aviatrix_transit_gateway" "test-edge-transit-1" {
     site_id = "site-3"
     interfaces {
         gateway_ip    = "192.168.20.1"
-        name          = "eth0"
         ip_address    = "192.168.20.11/24"
         type          = "WAN"
+        index         = 0
     }
     interfaces {
         gateway_ip                  = "192.168.21.1"
-        name                        = "eth1"
         ip_address                  = "192.168.21.11/24"
         type                        = "WAN"
+        index                       = 1
         secondary_private_cidr_list = ["192.168.21.16/29"]
     }
     interfaces {
         dhcp   = true
-        name = "eth2"
         type   = "MANAGEMENT"
+        index  = 0
     }
     interfaces {
         gateway_ip   = "192.168.22.1"
-        name         = "eth3"
         ip_address   = "192.168.22.11/24"
         type         = "WAN"
+        index        = 2
     }
     interfaces {
         gateway_ip   = "192.168.23.1"
-        name         = "eth4"
         ip_address   = "192.168.23.11/24"
         type         = "WAN"
+        index        = 3
     }
 }
 ```

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -223,6 +223,7 @@ type Gateway struct {
 	DeviceID                        string                              `json:"device_id,omitempty"`
 	SiteID                          string                              `json:"site_id,omitempty"`
 	Interfaces                      []EdgeTransitInterface              `json:"interfaces,omitempty"`
+	InterfaceMapping                []InterfaceMapping                  `json:"interface_mapping,omitempty"`
 }
 
 type HaGateway struct {
@@ -287,6 +288,12 @@ type GatewayDetail struct {
 	CustomizedTransitVpcRoutes   []string      `json:"customized_transit_vpc_cidrs"`
 	BundleVpcInfo                BundleVpcInfo `json:"bundle_vpc_info"`
 	BgpEnabled                   bool          `json:"bgp_enabled"`
+}
+
+type InterfaceMapping struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Index string `json:"index"`
 }
 
 type BundleVpcInfo struct {

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -293,7 +293,7 @@ type GatewayDetail struct {
 type InterfaceMapping struct {
 	Name  string `json:"name"`
 	Type  string `json:"type"`
-	Index string `json:"index"`
+	Index int    `json:"index"`
 }
 
 type BundleVpcInfo struct {


### PR DESCRIPTION
- Adding the interface mapping support for Dell and ESXI devices in EAT
- Updated the interface config to accept index and removed the interface name. The name will be updated using the interface type and index provided by the user.
- By default, we are setting the interface mapping to use the dell configuration but if the user provides an interface mapping then it is set for ESXI devices

_Example to provide interface mapping only for ESXI devices_
`resource "aviatrix_transit_gateway" "test-edge-transit-15" {
    cloud_type = 262144
    account_name = "edge_aep"
    gw_name = "test-edge-transit-15"
    vpc_id = "site-15"
    gw_size = "SMALL"
    device_id = "7cf4a6fd-a772-4d0d-a655-2d3d436985ff"
    site_id = "site-15"
    local_as_number = 65441
    interfaces {
        gateway_ip = "192.168.20.1"
        ip_address    = "192.168.20.11/24"
        type       = "WAN"
        index = 0
    }

    interfaces {
        gateway_ip = "192.168.21.1"
        ip_address    = "192.168.21.11/24"
        type       = "WAN"
        index = 1
        secondary_private_cidr_list = ["192.168.21.16/29"]
    }

    interfaces {
        dhcp   = true
        type   = "MANAGEMENT"
        index = 0
    }

    interfaces {
        gateway_ip                  = "192.168.22.1"
        ip_address                     = "192.168.22.11/24"
        type                        = "WAN"
        index = 2
    }

    interfaces {
        gateway_ip                  = "192.168.23.1"
        ip_address                     = "192.168.23.11/24"
        type                        = "WAN"
        index = 3
    }

    interface_mapping{
      name  = "eth0"
      type  = "wan"
      index = "0"
    }

    interface_mapping{
      name  = "eth1"
      type  = "wan"
      index = "1"
    }

    interface_mapping{
      name  = "eth2"
      type  = "wan"
      index = "2"
    }

    interface_mapping{
      name  = "eth3"
      type  = "mgmt"
      index = "0"
    }

    interface_mapping{
      name  = "eth4"
      type  = "wan"
      index = "3"
    }
}`