### PR TITLE
AVX-39042: deprecate keep_alive_via_lan_interface_enabled option

### DIFF
--- a/aviatrix/data_source_aviatrix_firenet.go
+++ b/aviatrix/data_source_aviatrix_firenet.go
@@ -32,11 +32,6 @@ func dataSourceAviatrixFireNet() *schema.Resource {
 				Computed:    true,
 				Description: "Hashing algorithm to load balance traffic across the firewall.",
 			},
-			"keep_alive_via_lan_interface_enabled": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "Enable Keep Alive via Firewall LAN Interface.",
-			},
 			"tgw_segmentation_for_egress_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
@@ -72,7 +67,6 @@ func dataSourceAviatrixFireNetRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("vpc_id", fireNetDetail.VpcID)
 	d.Set("hashing_algorithm", fireNetDetail.HashingAlgorithm)
-	d.Set("keep_alive_via_lan_interface_enabled", fireNetDetail.LanPing == "yes")
 	d.Set("tgw_segmentation_for_egress_enabled", fireNetDetail.TgwSegmentationForEgress == "yes")
 	d.Set("egress_static_cidrs", fireNetDetail.EgressStaticCidrs)
 

--- a/aviatrix/resource_aviatrix_firenet.go
+++ b/aviatrix/resource_aviatrix_firenet.go
@@ -3,7 +3,6 @@ package aviatrix
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -57,12 +56,9 @@ func resourceAviatrixFireNet() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"5-Tuple", "2-Tuple"}, false),
 			},
 			"keep_alive_via_lan_interface_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				Deprecated: "Option to enable/disable keep_alive_via_lan_interface will be removed in Aviatrix provider v3.2.0. As of provider v3.1.2, disabling keep_alive_via_lan_interface will NOT be allowed." +
-					"\n\nIf you have set 'keep_alive_via_lan_interface_enabled = true' for AWS or OCI related cloud FireNet, no action is needed at this time. After you upgrade to Aviatrix provider v3.2.0, you can safely remove the 'keep_alive_via_lan_interface_enabled' attribute from your configuration." +
-					"\n\nIf you have set 'keep_alive_via_lan_interface_enabled = false' for non-GWLB AWS or OCI related cloud FireNet, you must enable it before you can upgrade to Aviatrix provider v3.2.0.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Deprecated:  "Option to enable/disable keep_alive_via_lan_interface is removed in Aviatrix provider v3.2.0.",
 				Description: "Enable Keep Alive via Firewall LAN Interface. Supported for AWS and OCI related clouds only.",
 			},
 			"tgw_segmentation_for_egress_enabled": {
@@ -99,25 +95,6 @@ func resourceAviatrixFireNetCreate(d *schema.ResourceData, meta interface{}) err
 
 	fireNet := &goaviatrix.FireNet{
 		VpcID: d.Get("vpc_id").(string),
-	}
-
-	fireNetDetail, err := client.GetFireNet(fireNet)
-	if err != nil {
-		return fmt.Errorf("couldn't find vpc %s: %v", fireNet.VpcID, err)
-	}
-	cloudType, _ := strconv.Atoi(fireNetDetail.CloudType)
-
-	if d.Get("keep_alive_via_lan_interface_enabled").(bool) {
-		if goaviatrix.IsCloudType(cloudType, goaviatrix.GCPRelatedCloudTypes) || goaviatrix.IsCloudType(cloudType, goaviatrix.AzureArmRelatedCloudTypes) {
-			return fmt.Errorf("enabling keep alive via lan interface on FireNet does not support Azure & GCP related clouds")
-		}
-		if fireNetDetail.LanPing != "yes" {
-			return fmt.Errorf("keep alive via lan interface only supports non-GWLB AWS/OCI cloud FireNet, please set keep_alive_via_lan_interface_enabled to false")
-		}
-	} else {
-		if fireNetDetail.LanPing == "yes" {
-			return fmt.Errorf("keep alive via lan interface has to be enabled for non-GWLB AWS/OCI cloud FireNet, please set keep_alive_via_lan_interface_enabled to true")
-		}
 	}
 
 	d.SetId(fireNet.VpcID)
@@ -232,7 +209,6 @@ func resourceAviatrixFireNetRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("vpc_id", fireNetDetail.VpcID)
 	d.Set("hashing_algorithm", fireNetDetail.HashingAlgorithm)
-	d.Set("keep_alive_via_lan_interface_enabled", fireNetDetail.LanPing == "yes")
 	d.Set("tgw_segmentation_for_egress_enabled", fireNetDetail.TgwSegmentationForEgress == "yes")
 	d.Set("egress_static_cidrs", fireNetDetail.EgressStaticCidrs)
 	d.Set("east_west_inspection_excluded_cidrs", fireNetDetail.ExcludedCidrs)
@@ -350,23 +326,6 @@ func resourceAviatrixFireNetUpdate(d *schema.ResourceData, meta interface{}) err
 		err := client.EditFirenetExcludedCidr(fn)
 		if err != nil {
 			return fmt.Errorf("could not edit east-west inspection excluded cidrs during update: %v", err)
-		}
-	}
-
-	if d.HasChange("keep_alive_via_lan_interface_enabled") {
-		fn := &goaviatrix.FireNet{
-			VpcID: d.Get("vpc_id").(string),
-		}
-		if d.Get("keep_alive_via_lan_interface_enabled").(bool) {
-			err := client.EnableFireNetLanKeepAlive(fn)
-			if err != nil {
-				return fmt.Errorf("could not enable keep alive via lan interface while updating firenet: %v", err)
-			}
-		} else {
-			err := client.DisableFireNetLanKeepAlive(fn)
-			if err != nil {
-				return fmt.Errorf("could not disable keep alive via lan interface while updating firenet: %v", err)
-			}
 		}
 	}
 

--- a/docs/data-sources/aviatrix_firenet.md
+++ b/docs/data-sources/aviatrix_firenet.md
@@ -37,7 +37,6 @@ In addition to all arguments above, the following attributes are exported:
 * `egress_static_cidrs` - List of egress static CIDRs.  
 * `tgw_segmentation_for_egress_enabled` - Enable TGW segmentation for egress.  
 * `hashing_algorithm` - (Optional) Hashing algorithm to load balance traffic across the firewall.
-* `keep_alive_via_lan_interface_enabled` - (Optional) Enable Keep Alive via Firewall LAN Interface.
 
 The following arguments are deprecated:
 
@@ -50,3 +49,4 @@ The following arguments are deprecated:
   * `management_interface` - Management interface ID.
   * `egress_interface`- Egress interface ID.
   * `attached`- Switch to attach/detach firewall instance to/from fireNet.
+  * `keep_alive_via_lan_interface_enabled` - (Optional) Enable Keep Alive via Firewall LAN Interface.

--- a/docs/guides/feature-changelist-v3.md
+++ b/docs/guides/feature-changelist-v3.md
@@ -73,14 +73,14 @@ The following logging resources are removed:
 | sumologic_forwarder | **Yes**; please remove these resources from TF configuration |
 
 
-## R3.1.4 (UserConnect-7.1.3006)**
+## R3.1.4 (UserConnect-7.1.3006)
 ### Attribute Deprecations
 | Diff | Resource | Attribute | Action Required? |
 |:----:|:--------:|:---------:|:----------------:|
 |(deprecated) | firenet | keep_alive_via_lan_interface_enabled | **Yes**; as of 3.1.2, disabling keepalive will not be allowed. If this attribute is set to true for AWS or OCI FireNets, no action is required. If this attribute is set to false for non-GWLB AWS or OCI FireNets, please set value to true |
 
 
-## R3.1.5 (UserConnect-7.1.4105)**
+## R3.1.5 (UserConnect-7.1.4105)
 ### Attribute Deprecations
 | Diff | Resource | Attribute | Action Required? |
 |:----:|:--------:|:---------:|:----------------:|
@@ -92,8 +92,4 @@ The following logging resources are removed:
 | Diff | Resource | Attribute | Action Required? |
 |:----:|:--------:|:---------:|:----------------:|
 |(deprecated) | edge_equinix, edge_equinix_ha, edge_csp, edge_csp_ha, edge_neo, edge_neo_ha, edge_platform, edge_platform_ha, edge_zededa, edge_zededa_ha | bandwidth | **Yes**; This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release |
-
-
-
-
-
+|(deprecated) | firenet | keep_alive_via_lan_interface_enabled | **Yes**; This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release |

--- a/docs/resources/aviatrix_firenet.md
+++ b/docs/resources/aviatrix_firenet.md
@@ -20,7 +20,6 @@ resource "aviatrix_firenet" "test_firenet" {
   vpc_id                               = "vpc-032005cc371"
   inspection_enabled                   = true
   egress_enabled                       = false
-  keep_alive_via_lan_interface_enabled = false
 
   depends_on                           = [
     aviatrix_firewall_instance_association.association_1
@@ -34,7 +33,6 @@ resource "aviatrix_firenet" "gcp_firenet" {
   vpc_id                               = format("%s~-~%s", aviatrix_transit_gateway.test_transit_gateway.vpc_id, aviatrix_account.gcp.gcloud_project_id)
   inspection_enabled                   = true
   egress_enabled                       = true
-  keep_alive_via_lan_interface_enabled = false
 
   depends_on                           = [
     aviatrix_firewall_instance_association.association2
@@ -62,10 +60,6 @@ The following arguments are supported:
 * `tgw_segmentation_for_egress_enabled` - (Optional) Enable TGW segmentation for egress. Valid values: true or false. Default value: false. Available as of provider version R2.19+.
 * `hashing_algorithm` - (Optional) Hashing algorithm to load balance traffic across the firewall. Valid values: "2-Tuple", "5-Tuple". Default value: "5-Tuple".
 
-* `keep_alive_via_lan_interface_enabled` - (Optional) Enable Keep Alive via Firewall LAN Interface. Supported for AWS and OCI related clouds only. Valid values: true or false. Default value: false. Available as of provider version R2.18.1+.
-
-~> **NOTE:** `keep_alive_via_lan_interface_enabled` - Option to enable/disable keep_alive_via_lan_interface will be removed in Aviatrix provider v3.2.0. As of provider v3.1.2, disabling keep_alive_via_lan_interface will NOT be allowed.
-
 The following arguments are deprecated:
 
 * `fail_close_enabled` - Enable Fail Close. Removed as of provider version R2.23+.
@@ -79,6 +73,7 @@ The following arguments are deprecated:
   * `management_interface` - (Optional) Management interface ID. **Required if it is a firewall instance.**
   * `egress_interface`- (Optional) Egress interface ID. **Required if it is a firewall instance.**
   * `attached`- (Optional) Switch to attach/detach firewall instance to/from FireNet. Valid values: true, false. Default value: false.
+* `keep_alive_via_lan_interface_enabled` - Option to enable/disable keep_alive_via_lan_interface is removed in Aviatrix provider v3.2.0.
 
 ## Import
 

--- a/goaviatrix/firenet.go
+++ b/goaviatrix/firenet.go
@@ -28,7 +28,6 @@ type FireNetDetail struct {
 	NativeGwlb               bool                   `json:"native_gwlb"`
 	Inspection               string                 `json:"inspection,omitempty"`
 	HashingAlgorithm         string                 `json:"firewall_hashing,omitempty"`
-	LanPing                  string                 `json:"lan_ping"`
 	TgwSegmentationForEgress string                 `json:"tgw_segmentation"`
 	EgressStaticCidrs        []string               `json:"egress_static_cidr"`
 	ExcludedCidrs            []string               `json:"exclude_cidr"`
@@ -263,50 +262,6 @@ func (c *Client) EditFireNetHashingAlgorithm(fireNet *FireNet) error {
 	}
 
 	return c.PostAPI("edit_firenet", data, checkFunc)
-}
-
-func (c *Client) EnableFireNetLanKeepAlive(net *FireNet) error {
-	data := map[string]string{
-		"action":   "edit_firenet",
-		"CID":      c.CID,
-		"vpc_id":   net.VpcID,
-		"lan_ping": "true",
-	}
-
-	customCheck := func(action, method, reason string, ret bool) error {
-		if !ret {
-			// [AVXERR-FIRENET-0029] No change in firenet attribute
-			if strings.Contains(reason, "AVXERR-FIRENET-0029") {
-				return nil
-			}
-			return fmt.Errorf("rest API %s Post failed: %s", action, reason)
-		}
-		return nil
-	}
-
-	return c.PostAPI("edit_firenet(lan_ping=true)", data, customCheck)
-}
-
-func (c *Client) DisableFireNetLanKeepAlive(net *FireNet) error {
-	data := map[string]string{
-		"action":   "edit_firenet",
-		"CID":      c.CID,
-		"vpc_id":   net.VpcID,
-		"lan_ping": "false",
-	}
-
-	customCheck := func(action, method, reason string, ret bool) error {
-		if !ret {
-			// [AVXERR-FIRENET-0029] No change in firenet attribute
-			if strings.Contains(reason, "AVXERR-FIRENET-0029") {
-				return nil
-			}
-			return fmt.Errorf("rest API %s Post failed: %s", action, reason)
-		}
-		return nil
-	}
-
-	return c.PostAPI("edit_firenet(lan_ping=false)", data, customCheck)
 }
 
 func (c *Client) EnableTgwSegmentationForEgress(net *FireNet) error {


### PR DESCRIPTION
Disable keep_alive_via_lan_interface_enabled option in Firenet resource.