### PR TITLE
Backport AVX-56134 Adding dns_server_ip and secondary_dns_server_ip to selfmanaged HA GW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,10 @@
 1. Fixed issue in **resource_aviatrix_firewall_instance_association** and **resource_aviatrix_gateway** for Azure where we no longer require special handling of ``fqdn_lan_interface``  and ``lan_interface``.
 2. Fixed issue in **aviatrix_edge_platform_device_onboarding** where importing was failing.
 ### Features:
+1. Added new attribute ``dns_server_ip`` and ``secondary_dns_server_ip`` in **aviatrix_edge_gateway_selfmanaged_ha** resource.
+
 #### Provider:
 1. Added support for the Terraform provider to properly set the user-agent when making requests.
-
-
-### Multi-Cloud Transit:
-1. Added new attribute ``bgp_bfd_polling_time`` to support the bgp bfd configuration in the following resources.
-    - **aviatrix_edge_csp**
-    - **aviatrix_edge_equinix**
-    - **aviatrix_edge_gateway_selfmanaged**
-    - **avaitrix_edge_platform**
-    - **aviatrix_edge_zededa**
-    - **aviatrix_spoke_gateway**
-    - **aviatrix_edge_spoke_gateway**
-    - **aviatrix_transit_gateway**
-2. Added new attribute ``bgp_bfd`` and ``enable_bfd`` to support bgp_bfd configuration in the following resources
-    - **aviatrix_transit_external_device_conn**
-    - **aviatrix_edge_spoke_external_device_conn**
-3. Add new attribute ``dns_server_ip`` and ``secondary_dns_server_ip`` in **aviatrix_edge_gateway_selfmanaged_ha** resource.
 
 
 ### Deprecations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,33 @@
 - Supported Controller version: **UserConnect-TBD**
 - Supported Terraform version: **v1.x**
 
-### Deprecations
-1. Deprecated ``http_access`` in **aviatrix_controller_config**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
-2. Deprecated ``bandwidth`` in WAN/LAN/MGMT interfaces in the following resources. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
-  - **aviatrix_edge_csp**
-  - **aviatrix_edge_csp_ha**
-  - **aviatrix_edge_equinix**
-  - **aviatrix_edge_equinix_ha**
-  - **aviatrix_edge_neo**
-  - **aviatrix_edge_neo_ha**
-  - **aviatrix_edge_platform**
-  - **aviatrix_edge_platform_ha**
-  - **aviatrix_edge_zededa**
-  - **aviatrix_edge_zededa_ha**
+### Bug Fixes:
 
+1. Fixed issue in **resource_aviatrix_firewall_instance_association** and **resource_aviatrix_gateway** for Azure where we no longer require special handling of ``fqdn_lan_interface``  and ``lan_interface``.
+2. Fixed issue in **aviatrix_edge_platform_device_onboarding** where importing was failing.
+### Features:
+#### Provider:
+1. Added support for the Terraform provider to properly set the user-agent when making requests.
+
+
+### Multi-Cloud Transit:
+1. Added new attribute ``bgp_bfd_polling_time`` to support the bgp bfd configuration in the following resources.
+    - **aviatrix_edge_csp**
+    - **aviatrix_edge_equinix**
+    - **aviatrix_edge_gateway_selfmanaged**
+    - **avaitrix_edge_platform**
+    - **aviatrix_edge_zededa**
+    - **aviatrix_spoke_gateway**
+    - **aviatrix_edge_spoke_gateway**
+    - **aviatrix_transit_gateway**
+2. Added new attribute ``bgp_bfd`` and ``enable_bfd`` to support bgp_bfd configuration in the following resources
+    - **aviatrix_transit_external_device_conn**
+    - **aviatrix_edge_spoke_external_device_conn**
+
+
+### Deprecations:
+
+1. Deprecated ``http_access`` in **aviatrix_controller_config**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
 
 ## 3.1.4 (January 11, 2024)
 ### Notes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 2. Added new attribute ``bgp_bfd`` and ``enable_bfd`` to support bgp_bfd configuration in the following resources
     - **aviatrix_transit_external_device_conn**
     - **aviatrix_edge_spoke_external_device_conn**
+3. Add new attribute ``dns_server_ip`` and ``secondary_dns_server_ip`` in **aviatrix_edge_gateway_selfmanaged_ha** resource.
 
 
 ### Deprecations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@
 ### Deprecations:
 
 1. Deprecated ``http_access`` in **aviatrix_controller_config**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
+2. Deprecated ``bandwidth`` in WAN/LAN/MGMT interfaces in the following resources. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.
+  - **aviatrix_edge_csp**
+  - **aviatrix_edge_csp_ha**
+  - **aviatrix_edge_equinix**
+  - **aviatrix_edge_equinix_ha**
+  - **aviatrix_edge_neo**
+  - **aviatrix_edge_neo_ha**
+  - **aviatrix_edge_platform**
+  - **aviatrix_edge_platform_ha**
+  - **aviatrix_edge_zededa**
+  - **aviatrix_edge_zededa_ha**
 
 ## 3.1.4 (January 11, 2024)
 ### Notes:

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -340,9 +340,13 @@ func marshalEdgeGatewaySelfmanagedInput(d *schema.ResourceData) *goaviatrix.Edge
 			PublicIp:  if1["wan_public_ip"].(string),
 			IpAddr:    if1["ip_address"].(string),
 			GatewayIp: if1["gateway_ip"].(string),
-			VrrpState: if1["enable_vrrp"].(bool),
-			VirtualIp: if1["vrrp_virtual_ip"].(string),
 			Tag:       if1["tag"].(string),
+		}
+
+		// vrrp and vrrp_virtual_ip are only applicable for LAN interfaces
+		if if1["type"].(string) == "LAN" {
+			if2.VrrpState = if1["enable_vrrp"].(bool)
+			if2.VirtualIp = if1["vrrp_virtual_ip"].(string)
 		}
 
 		edgeSpoke.InterfaceList = append(edgeSpoke.InterfaceList, if2)
@@ -618,11 +622,12 @@ func resourceAviatrixEdgeGatewaySelfmanagedRead(ctx context.Context, d *schema.R
 		if1["wan_public_ip"] = if0.PublicIp
 		if1["ip_address"] = if0.IpAddr
 		if1["gateway_ip"] = if0.GatewayIp
-		if1["vrrp_virtual_ip"] = if0.VirtualIp
 		if1["tag"] = if0.Tag
 
+		// set vrrp and vrrp_virtual_ip only for LAN interfaces
 		if if0.Type == "LAN" {
 			if1["enable_vrrp"] = if0.VrrpState
+			if1["vrrp_virtual_ip"] = if0.VirtualIp
 		}
 
 		if if0.Type == "LAN" && if0.SubInterfaces != nil {

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_ha.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_ha.go
@@ -53,6 +53,20 @@ func resourceAviatrixEdgeGatewaySelfmanagedHa() *schema.Resource {
 				},
 				Description: "The location where the ZTP file will be stored.",
 			},
+			"dns_server_ip": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "DNS server IP.",
+				ValidateFunc: validation.IsIPAddress,
+			},
+			"secondary_dns_server_ip": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "Secondary DNS server IP.",
+				ValidateFunc: validation.IsIPAddress,
+			},
 			"interfaces": {
 				Type:        schema.TypeSet,
 				Required:    true,
@@ -110,6 +124,8 @@ func marshalEdgeGatewaySelfmanagedHaInput(d *schema.ResourceData) *goaviatrix.Ed
 		SiteId:                   d.Get("site_id").(string),
 		ZtpFileType:              d.Get("ztp_file_type").(string),
 		ZtpFileDownloadPath:      d.Get("ztp_file_download_path").(string),
+		DnsServerIp:              d.Get("dns_server_ip").(string),
+		SecondaryDnsServerIp:     d.Get("secondary_dns_server_ip").(string),
 		ManagementEgressIpPrefix: strings.Join(getStringSet(d, "management_egress_ip_prefix_list"), ","),
 	}
 
@@ -168,6 +184,8 @@ func resourceAviatrixEdgeGatewaySelfmanagedHaRead(ctx context.Context, d *schema
 
 	d.Set("primary_gw_name", edgeGatewaySelfmanagedHaResp.PrimaryGwName)
 	d.Set("site_id", edgeGatewaySelfmanagedHaResp.SiteId)
+	d.Set("dns_server_ip", edgeGatewaySelfmanagedHaResp.DnsServerIp)
+	d.Set("secondary_dns_server_ip", edgeGatewaySelfmanagedHaResp.SecondaryDnsServerIp)
 
 	if edgeGatewaySelfmanagedHaResp.ZtpFileType == "iso" || edgeGatewaySelfmanagedHaResp.ZtpFileType == "cloud-init" {
 		d.Set("ztp_file_type", edgeGatewaySelfmanagedHaResp.ZtpFileType)

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_ha_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_ha_test.go
@@ -86,7 +86,7 @@ resource "aviatrix_edge_gateway_selfmanaged_ha" "test" {
 	ztp_file_type           = "iso"
 	ztp_file_download_path  = "%[3]s"
 	dns_server_ip           = "8.8.8.8"
-    secondary_dns_server_ip = "8.8.6.6"
+	secondary_dns_server_ip = "8.8.6.6"
 
 	interfaces {
 		name       = "eth0"

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_ha_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_ha_test.go
@@ -36,6 +36,8 @@ func TestAccAviatrixEdgeGatewaySelfmanagedHa_basic(t *testing.T) {
 					testAccCheckEdgeGatewaySelfmanagedHaExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "primary_gw_name", gwName),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.220.11.20/24"),
+					resource.TestCheckResourceAttr(resourceName, "dns_server_ip", "8.8.8.8"),
+					resource.TestCheckResourceAttr(resourceName, "secondary_dns_server_ip", "8.8.6.6"),
 				),
 			},
 			{
@@ -79,10 +81,12 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 	}
 }
 resource "aviatrix_edge_gateway_selfmanaged_ha" "test" {
-	primary_gw_name        = aviatrix_edge_gateway_selfmanaged.test.gw_name
-	site_id                = aviatrix_edge_gateway_selfmanaged.test.site_id
-	ztp_file_type          = "iso"
-	ztp_file_download_path = "%[3]s"
+	primary_gw_name         = aviatrix_edge_gateway_selfmanaged.test.gw_name
+	site_id                 = aviatrix_edge_gateway_selfmanaged.test.site_id
+	ztp_file_type           = "iso"
+	ztp_file_download_path  = "%[3]s"
+	dns_server_ip           = "8.8.8.8"
+    secondary_dns_server_ip = "8.8.6.6"
 
 	interfaces {
 		name       = "eth0"

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged_ha.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged_ha.md
@@ -21,6 +21,16 @@ resource "aviatrix_edge_gateway_selfmanaged_ha" "test" {
   site_id                = "site-123"
   ztp_file_type          = "iso"
   ztp_file_download_path = "/ztp/download/path"
+  dns_server_ip = "8.8.8.8"
+  secondary_dns_server_ip = "8.8.6.6"
+
+  interfaces {
+    name          = "eth0"
+    type          = "WAN"
+    ip_address    = "10.230.6.32/24"
+    gateway_ip    = "10.230.6.100"
+    wan_public_ip = "64.71.25.221"
+  }
 
   interfaces {
     name       = "eth1"
@@ -56,6 +66,8 @@ The following arguments are supported:
 
 ### Optional
 * `management_egress_ip_prefix_list` - (Optional) Set of management egress gateway IP and subnet prefix. Example: ["67.207.104.16/29", "64.71.12.144/29"].
+* `dns_server_ip` - (Optional) DNS server IP. Required and valid when `management_interface_config` is "Static".
+* `secondary_dns_server_ip` - (Optional) Secondary DNS server IP. Required and valid when `management_interface_config` is "Static".
 
 ## Import
 

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged_ha.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged_ha.md
@@ -17,11 +17,11 @@ The **aviatrix_edge_gateway_selfmanaged_ha** resource creates the Aviatrix Edge 
 ```hcl
 # Create an Edge Gateway Selfmanaged HA
 resource "aviatrix_edge_gateway_selfmanaged_ha" "test" {
-  primary_gw_name        = "primary-edge-vm-selfmanaged"
-  site_id                = "site-123"
-  ztp_file_type          = "iso"
-  ztp_file_download_path = "/ztp/download/path"
-  dns_server_ip = "8.8.8.8"
+  primary_gw_name         = "primary-edge-vm-selfmanaged"
+  site_id                 = "site-123"
+  ztp_file_type           = "iso"
+  ztp_file_download_path  = "/ztp/download/path"
+  dns_server_ip           = "8.8.8.8"
   secondary_dns_server_ip = "8.8.6.6"
 
   interfaces {

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -59,25 +59,25 @@ type EdgeSpoke struct {
 type EdgeSpokeInterface struct {
 	IfName        string           `json:"ifname"`
 	Type          string           `json:"type"`
-	Dhcp          bool             `json:"dhcp"`
-	PublicIp      string           `json:"public_ip"`
-	IpAddr        string           `json:"ipaddr"`
-	GatewayIp     string           `json:"gateway_ip"`
-	SubInterfaces []*EdgeSpokeVlan `json:"subinterfaces"`
-	VrrpState     bool             `json:"vrrp_state"`
-	VirtualIp     string           `json:"virtual_ip"`
-	Tag           string           `json:"tag"`
+	Dhcp          bool             `json:"dhcp,omitempty"`
+	PublicIp      string           `json:"public_ip,omitempty"`
+	IpAddr        string           `json:"ipaddr,omitempty"`
+	GatewayIp     string           `json:"gateway_ip,omitempty"`
+	SubInterfaces []*EdgeSpokeVlan `json:"subinterfaces,omitempty"`
+	VrrpState     bool             `json:"vrrp_state,omitempty"`
+	VirtualIp     string           `json:"virtual_ip,omitempty"`
+	Tag           string           `json:"tag,omitempty"`
 }
 
 type EdgeSpokeVlan struct {
 	ParentInterface string `json:"parent_interface"`
-	VlanId          string `json:"vlan_id"`
-	IpAddr          string `json:"ipaddr"`
-	GatewayIp       string `json:"gateway_ip"`
-	PeerIpAddr      string `json:"peer_ipaddr"`
-	PeerGatewayIp   string `json:"peer_gateway_ip"`
-	VirtualIp       string `json:"virtual_ip"`
-	Tag             string `json:"tag"`
+	VlanId          string `json:"vlan_id,omitempty"`
+	IpAddr          string `json:"ipaddr,omitempty"`
+	GatewayIp       string `json:"gateway_ip,omitempty"`
+	PeerIpAddr      string `json:"peer_ipaddr,omitempty"`
+	PeerGatewayIp   string `json:"peer_gateway_ip,omitempty"`
+	VirtualIp       string `json:"virtual_ip,omitempty"`
+	Tag             string `json:"tag,omitempty"`
 }
 
 type EdgeSpokeResp struct {

--- a/goaviatrix/edge_vm_selfmanaged_ha.go
+++ b/goaviatrix/edge_vm_selfmanaged_ha.go
@@ -16,6 +16,8 @@ type EdgeVmSelfmanagedHa struct {
 	SiteId                   string
 	ZtpFileType              string
 	ZtpFileDownloadPath      string
+	DnsServerIp              string `json:"dns_server_ip,omitempty"`
+	SecondaryDnsServerIp     string `json:"dns_server_ip_secondary,omitempty"`
 	InterfaceList            []*EdgeSpokeInterface
 	Interfaces               string `json:"interfaces"`
 	NoProgressBar            bool   `json:"no_progress_bar,omitempty"`
@@ -30,6 +32,8 @@ type EdgeVmSelfmanagedHaResp struct {
 	ZtpFileType              string                `json:"ztp_file_type"`
 	InterfaceList            []*EdgeSpokeInterface `json:"interfaces"`
 	ManagementEgressIpPrefix string                `json:"mgmt_egress_ip"`
+	DnsServerIp              string                `json:"dns_server_ip,omitempty"`
+	SecondaryDnsServerIp     string                `json:"dns_server_ip_secondary,omitempty"`
 }
 
 type EdgeVmSelfmanagedHaListResp struct {


### PR DESCRIPTION
Master PR - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2065
- Updating the resource_aviatrix_edge_gateway_selfmanaged_ha to have the following dns configuration
dns_server_ip
secondary_dns_server_ip
- Making the edge gateway interface attribute optional as they were failing the interface validation check
- Updating the documentation for the changes
```
resource "aviatrix_edge_gateway_selfmanaged_ha" "test" {
  primary_gw_name         = "Edge-183"
  site_id                 = "SC"
  ztp_file_type           = "iso"
  ztp_file_download_path  = "ztp"
  dns_server_ip           = "8.8.8.8"
  secondary_dns_server_ip = "8.8.6.6"

  interfaces {
    name          = "eth0"
    type          = "WAN"
    ip_address    = "10.230.6.32/24"
    gateway_ip    = "10.230.6.100"
    wan_public_ip = "64.71.25.221"
  }

  interfaces {
    name       = "eth1"
    type       = "LAN"
    ip_address = "10.230.7.32/24"
  }

  interfaces {
    name        = "eth2"
    type        = "MANAGEMENT"
    enable_dhcp = true
  } 
}
```