### PR TITLE
AVX-57905: Fix k8s selector keys.

### DIFF
--- a/goaviatrix/smart_group.go
+++ b/goaviatrix/smart_group.go
@@ -72,8 +72,8 @@ const (
 	ZoneKey         = "zone"
 	K8sClusterIdKey = "k8s_cluster_id"
 	K8sNamespaceKey = "k8s_namespace"
-	K8sServiceKey   = "ka8s_service"
-	K8sPodNameKey   = "ka8s_pod"
+	K8sServiceKey   = "k8s_service"
+	K8sPodNameKey   = "k8s_pod"
 	S2CKey          = "s2c"
 	ExternalKey     = "external"
 


### PR DESCRIPTION
This PR fixes a typo in the constants for the k8s related properties or the smart group resource.

It would be great if we could create a bug fix release 3.2.1 for this, since this bug pretty much breaks the entire Kubernetes feature.