### PR TITLE
Backport AVX-57867 Adding BGP BFD polling time for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
     - **avaitrix_edge_platform**
     - **aviatrix_edge_zededa**
     - **aviatrix_spoke_gateway**
+    - **aviatrix_edge_spoke_gateway**
     - **aviatrix_transit_gateway**
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@
 1. Added support for the Terraform provider to properly set the user-agent when making requests.
 
 
+### Multi-Cloud Transit:
+1. Added new attribute ``bgp_bfd_polling_time`` to support the bgp bfd configuration in the following resources.
+    - **aviatrix_edge_equinix**
+    - **aviatrix_edge_gateway_selfmanaged**
+    - **avaitrix_edge_platform**
+    - **aviatrix_edge_zededa**
+    - **aviatrix_spoke_gateway**
+    - **aviatrix_transit_gateway**
+
+
 ### Deprecations:
 
 1. Deprecated ``http_access`` in **aviatrix_controller_config**. This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ### Multi-Cloud Transit:
 1. Added new attribute ``bgp_bfd_polling_time`` to support the bgp bfd configuration in the following resources.
+    - **aviatrix_edge_csp**
     - **aviatrix_edge_equinix**
     - **aviatrix_edge_gateway_selfmanaged**
     - **avaitrix_edge_platform**

--- a/aviatrix/resource_aviatrix_edge_csp.go
+++ b/aviatrix/resource_aviatrix_edge_csp.go
@@ -909,7 +909,7 @@ func resourceAviatrixEdgeCSPUpdate(ctx context.Context, d *schema.ResourceData, 
 	if d.HasChange("bgp_bfd_polling_time") {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp polling time during Edge CSP update: %v", err)
+			return diag.Errorf("could not set bgp bfd polling time during Edge CSP update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_csp.go
+++ b/aviatrix/resource_aviatrix_edge_csp.go
@@ -156,6 +156,13 @@ func resourceAviatrixEdgeCSP() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
+			"bgp_bfd_polling_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpBfdPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -393,6 +400,7 @@ func marshalEdgeCSPInput(d *schema.ResourceData) *goaviatrix.EdgeCSP {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -553,9 +561,16 @@ func resourceAviatrixEdgeCSPCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if edgeCSP.BgpPollingTime >= 10 && edgeCSP.BgpPollingTime != defaultBgpPollingTime {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeCSP.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time after Edge CSP creation: %v", err)
+		}
+	}
+
+	if edgeCSP.BgpBfdPollingTime >= 1 && edgeCSP.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time after Edge CSP creation: %v", err)
 		}
 	}
 
@@ -695,6 +710,7 @@ func resourceAviatrixEdgeCSPRead(ctx context.Context, d *schema.ResourceData, me
 
 	d.Set("enable_preserve_as_path", edgeCSPResp.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeCSPResp.BgpPollingTime)
+	d.Set("bgp_bfd_polling_time", edgeCSPResp.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeCSPResp.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeCSPResp.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeCSPResp.EnableJumboFrame)
@@ -884,7 +900,14 @@ func resourceAviatrixEdgeCSPUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeCSP.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp polling time during Edge CSP update: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge CSP update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_csp_test.go
+++ b/aviatrix/resource_aviatrix_edge_csp_test.go
@@ -39,6 +39,8 @@ func TestAccAviatrixEdgeCSP_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
 				),
 			},
 			{
@@ -59,12 +61,14 @@ resource "aviatrix_account" "test_account" {
 	edge_csp_password = "%s"
 }
 resource "aviatrix_edge_csp" "test" {
-	account_name      = aviatrix_account.test_account.account_name
-	gw_name           = "%s"
-	site_id           = "%s"
- 	project_uuid      = "%s"
- 	compute_node_uuid = "%s"
- 	template_uuid     = "%s"
+	account_name         = aviatrix_account.test_account.account_name
+	gw_name              = "%s"
+	site_id              = "%s"
+ 	project_uuid         = "%s"
+ 	compute_node_uuid    = "%s"
+ 	template_uuid        = "%s"
+	bgp_polling_time     = 50
+	bgp_bfd_polling_time = 5
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_equinix.go
+++ b/aviatrix/resource_aviatrix_edge_equinix.go
@@ -855,7 +855,7 @@ func resourceAviatrixEdgeEquinixUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeEquinix.BgpBfdPollingTime)
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeEquinix.BgpBfdPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge Equinix update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_equinix.go
+++ b/aviatrix/resource_aviatrix_edge_equinix.go
@@ -148,6 +148,13 @@ func resourceAviatrixEdgeEquinix() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
+			"bgp_bfd_polling_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpBfdPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -354,6 +361,7 @@ func marshalEdgeEquinixInput(d *schema.ResourceData) *goaviatrix.EdgeEquinix {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -653,6 +661,7 @@ func resourceAviatrixEdgeEquinixRead(ctx context.Context, d *schema.ResourceData
 
 	d.Set("enable_preserve_as_path", edgeEquinixResp.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeEquinixResp.BgpPollingTime)
+	d.Set("bgp_bfd_polling_time", edgeEquinixResp.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeEquinixResp.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeEquinixResp.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeEquinixResp.EnableJumboFrame)
@@ -842,6 +851,13 @@ func resourceAviatrixEdgeEquinixUpdate(ctx context.Context, d *schema.ResourceDa
 		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeEquinix.BgpPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge Equinix update: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeEquinix.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time during Edge Equinix update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_equinix.go
+++ b/aviatrix/resource_aviatrix_edge_equinix.go
@@ -522,9 +522,16 @@ func resourceAviatrixEdgeEquinixCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if edgeEquinix.BgpPollingTime >= 10 && edgeEquinix.BgpPollingTime != defaultBgpPollingTime {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeEquinix.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeEquinix.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time after Edge Equinix creation: %v", err)
+		}
+	}
+
+	if edgeEquinix.BgpBfdPollingTime >= 1 && edgeEquinix.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeEquinix.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time after Edge Equinix creation: %v", err)
 		}
 	}
 
@@ -848,14 +855,14 @@ func resourceAviatrixEdgeEquinixUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeEquinix.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeEquinix.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge Equinix update: %v", err)
 		}
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeEquinix.BgpBfdPollingTime))
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeEquinix.BgpBfdPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge Equinix update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_equinix_test.go
+++ b/aviatrix/resource_aviatrix_edge_equinix_test.go
@@ -41,6 +41,8 @@ func TestAccAviatrixEdgeEquinix_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
 				),
 			},
 			{
@@ -65,6 +67,8 @@ resource "aviatrix_edge_equinix" "test" {
 	gw_name                = "%s"
 	site_id                = "%s"
 	ztp_file_download_path = "%s"
+	bgp_polling_time       = 50
+	bgp_bfd_polling_time   = 5
 	
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -148,6 +148,13 @@ func resourceAviatrixEdgeGatewaySelfmanaged() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
+			"bgp_bfd_polling_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpBfdPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -321,6 +328,7 @@ func marshalEdgeGatewaySelfmanagedInput(d *schema.ResourceData) *goaviatrix.Edge
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -598,6 +606,7 @@ func resourceAviatrixEdgeGatewaySelfmanagedRead(ctx context.Context, d *schema.R
 
 	d.Set("enable_preserve_as_path", edgeSpoke.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeSpoke.BgpPollingTime)
+	d.Set("bgp_bfd_polling_time", edgeSpoke.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeSpoke.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeSpoke.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeSpoke.EnableJumboFrame)
@@ -779,6 +788,13 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge Gateway Selfmanaged update: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time during Edge Gateway Selfmanaged update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -483,7 +483,7 @@ func resourceAviatrixEdgeGatewaySelfmanagedCreate(ctx context.Context, d *schema
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
+	if edgeSpoke.BgpBfdPollingTime >= 1 && edgeSpoke.BgpBfdPollingTime != defaultBgpBfdPollingTime {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time after Edge Gateway Selfmanaged creation: %v", err)

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -477,9 +477,16 @@ func resourceAviatrixEdgeGatewaySelfmanagedCreate(ctx context.Context, d *schema
 	}
 
 	if edgeSpoke.BgpPollingTime >= 10 && edgeSpoke.BgpPollingTime != defaultBgpPollingTime {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time after Edge Gateway Selfmanaged creation: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time after Edge Gateway Selfmanaged creation: %v", err)
 		}
 	}
 
@@ -785,14 +792,14 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge Gateway Selfmanaged update: %v", err)
 		}
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpBfdPollingTime))
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge Gateway Selfmanaged update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -792,7 +792,7 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpBfdPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge Gateway Selfmanaged update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
@@ -39,6 +39,8 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
 				),
 			},
 			{
@@ -58,6 +60,8 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 	site_id                = "%s"
 	ztp_file_type          = "iso"
 	ztp_file_download_path = "%s"
+	bgp_polling_time       = 50
+	bgp_bfd_polling_time   = 5
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_neo.go
+++ b/aviatrix/resource_aviatrix_edge_neo.go
@@ -546,9 +546,16 @@ func resourceAviatrixEdgeNEOCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if edgeNEO.BgpPollingTime >= 10 && edgeNEO.BgpPollingTime != defaultBgpPollingTime {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeNEO.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time after Edge NEO creation: %v", err)
+		}
+	}
+
+	if edgeNEO.BgpBfdPollingTime >= 1 && edgeNEO.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time after Edge NEO creation: %v", err)
 		}
 	}
 
@@ -876,7 +883,7 @@ func resourceAviatrixEdgeNEOUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeNEO.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge NEO update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_neo_test.go
+++ b/aviatrix/resource_aviatrix_edge_neo_test.go
@@ -40,6 +40,8 @@ func TestAccAviatrixEdgeNEO_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
 				),
 			},
 			{
@@ -69,6 +71,8 @@ resource "aviatrix_edge_neo" "test" {
 	site_id                    = "%s"
 	device_id                  = aviatrix_edge_neo_device_onboarding.test.device_id
 	gw_size                    = "small"
+	bgp_polling_time           = 50
+	bgp_bfd_polling_time       = 5
 	management_interface_names = ["eth2"]
 	lan_interface_names        = ["eth1"]
 	wan_interface_names        = ["eth0"]

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -890,7 +890,7 @@ func resourceAviatrixEdgePlatformUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpBfdPollingTime)
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeNEO.BgpBfdPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge Platform update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -150,6 +150,13 @@ func resourceAviatrixEdgePlatform() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
+			"bgp_bfd_polling_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -384,6 +391,7 @@ func marshalEdgePlatformInput(d *schema.ResourceData) *goaviatrix.EdgeNEO {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -685,6 +693,7 @@ func resourceAviatrixEdgePlatformRead(ctx context.Context, d *schema.ResourceDat
 
 	d.Set("enable_preserve_as_path", edgeNEOResp.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeNEOResp.BgpPollingTime)
+	d.Set("bgp_bfd_polling_time", edgeNEOResp.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeNEOResp.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeNEOResp.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeNEOResp.EnableJumboFrame)
@@ -877,6 +886,13 @@ func resourceAviatrixEdgePlatformUpdate(ctx context.Context, d *schema.ResourceD
 		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeNEO.BgpPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge Platform update: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time during Edge Platform update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -552,9 +552,16 @@ func resourceAviatrixEdgePlatformCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if edgeNEO.BgpPollingTime >= 10 && edgeNEO.BgpPollingTime != defaultBgpPollingTime {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeNEO.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time after Edge Platform creation: %v", err)
+		}
+	}
+
+	if edgeNEO.BgpBfdPollingTime >= 1 && edgeNEO.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time after Edge Platform creation: %v", err)
 		}
 	}
 
@@ -883,14 +890,14 @@ func resourceAviatrixEdgePlatformUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeNEO.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge Platform update: %v", err)
 		}
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeNEO.BgpBfdPollingTime))
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpBfdPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge Platform update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_platform_test.go
+++ b/aviatrix/resource_aviatrix_edge_platform_test.go
@@ -40,6 +40,8 @@ func TestAccAviatrixEdgePlatform_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
 				),
 			},
 			{
@@ -69,6 +71,8 @@ resource "aviatrix_edge_platform" "test" {
 	site_id                    = "%s"
 	device_id                  = aviatrix_edge_platform_device_onboarding.test.device_id
 	gw_size                    = "small"
+	bgp_polling_time           = 50
+	bgp_bfd_polling_time       = 5
 	management_interface_names = ["eth2"]
 	lan_interface_names        = ["eth1"]
 	wan_interface_names        = ["eth0"]

--- a/aviatrix/resource_aviatrix_edge_spoke.go
+++ b/aviatrix/resource_aviatrix_edge_spoke.go
@@ -390,9 +390,16 @@ func resourceAviatrixEdgeSpokeCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if edgeSpoke.BgpPollingTime >= 10 && edgeSpoke.BgpPollingTime != defaultBgpPollingTime {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time after Edge as a Spoke creation: %v", err)
+		}
+	}
+
+	if edgeSpoke.BgpBfdPollingTime >= 1 && edgeSpoke.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time after Edge as a Spoke creation: %v", err)
 		}
 	}
 
@@ -669,14 +676,14 @@ func resourceAviatrixEdgeSpokeUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge as a Spoke update: %v", err)
 		}
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpBfdPollingTime))
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge as a Spoke update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_spoke.go
+++ b/aviatrix/resource_aviatrix_edge_spoke.go
@@ -149,6 +149,13 @@ func resourceAviatrixEdgeSpoke() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
+			"bgp_bfd_polling_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpBfdPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -260,6 +267,7 @@ func marshalEdgeSpokeInput(d *schema.ResourceData) *goaviatrix.EdgeSpoke {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -511,6 +519,7 @@ func resourceAviatrixEdgeSpokeRead(ctx context.Context, d *schema.ResourceData, 
 
 	d.Set("enable_preserve_as_path", edgeSpoke.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeSpoke.BgpPollingTime)
+	d.Set("bgp_bfd_polling_time", edgeSpoke.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeSpoke.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeSpoke.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeSpoke.EnableJumboFrame)
@@ -663,6 +672,13 @@ func resourceAviatrixEdgeSpokeUpdate(ctx context.Context, d *schema.ResourceData
 		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge as a Spoke update: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpBfdPollingTime))
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time during Edge as a Spoke update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_spoke_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_test.go
@@ -39,6 +39,8 @@ func TestAccAviatrixEdgeSpoke_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
 				),
 			},
 			{
@@ -58,6 +60,8 @@ resource "aviatrix_edge_spoke" "test" {
 	site_id                = "%s"
 	ztp_file_type          = "iso"
 	ztp_file_download_path = "%s"
+	bgp_polling_time       = 50
+	bgp_bfd_polling_time   = 5
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_vm_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_vm_selfmanaged.go
@@ -381,7 +381,7 @@ func resourceAviatrixEdgeVmSelfmanagedCreate(ctx context.Context, d *schema.Reso
 	}
 
 	if edgeSpoke.BgpPollingTime >= 10 && edgeSpoke.BgpPollingTime != defaultBgpPollingTime {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time after Edge VM Selfmanaged creation: %v", err)
 		}
@@ -659,7 +659,7 @@ func resourceAviatrixEdgeVmSelfmanagedUpdate(ctx context.Context, d *schema.Reso
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeSpoke.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge VM Selfmanaged update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_zededa.go
+++ b/aviatrix/resource_aviatrix_edge_zededa.go
@@ -559,9 +559,16 @@ func resourceAviatrixEdgeZededaCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if edgeCSP.BgpPollingTime >= 10 && edgeCSP.BgpPollingTime != defaultBgpPollingTime {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeCSP.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time after Edge Zededa creation: %v", err)
+		}
+	}
+
+	if edgeCSP.BgpBfdPollingTime >= 1 && edgeCSP.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time after Edge Zededa creation: %v", err)
 		}
 	}
 
@@ -891,14 +898,14 @@ func resourceAviatrixEdgeZededaUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeCSP.BgpPollingTime))
+		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge Zededa update: %v", err)
 		}
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeCSP.BgpBfdPollingTime))
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge Zededa update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_zededa.go
+++ b/aviatrix/resource_aviatrix_edge_zededa.go
@@ -156,6 +156,13 @@ func resourceAviatrixEdgeZededa() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
+			"bgp_bfd_polling_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpBfdPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -391,6 +398,7 @@ func marshalEdgeZededaInput(d *schema.ResourceData) *goaviatrix.EdgeCSP {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -693,6 +701,7 @@ func resourceAviatrixEdgeZededaRead(ctx context.Context, d *schema.ResourceData,
 
 	d.Set("enable_preserve_as_path", edgeCSPResp.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeCSPResp.BgpPollingTime)
+	d.Set("bgp_bfd_polling_time", edgeCSPResp.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeCSPResp.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeCSPResp.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeCSPResp.EnableJumboFrame)
@@ -885,6 +894,13 @@ func resourceAviatrixEdgeZededaUpdate(ctx context.Context, d *schema.ResourceDat
 		err := client.SetBgpPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeCSP.BgpPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp polling time during Edge Zededa update: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
+		if err != nil {
+			return diag.Errorf("could not set bgp bfd polling time during Edge Zededa update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_zededa.go
+++ b/aviatrix/resource_aviatrix_edge_zededa.go
@@ -898,7 +898,7 @@ func resourceAviatrixEdgeZededaUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if d.HasChange("bgp_bfd_polling_time") {
-		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
+		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, strconv.Itoa(edgeCSP.BgpBfdPollingTime))
 		if err != nil {
 			return diag.Errorf("could not set bgp bfd polling time during Edge Zededa update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_edge_zededa_test.go
+++ b/aviatrix/resource_aviatrix_edge_zededa_test.go
@@ -39,6 +39,8 @@ func TestAccAviatrixEdgeZededa_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
 				),
 			},
 			{
@@ -59,12 +61,14 @@ resource "aviatrix_account" "test_account" {
 	edge_zededa_password = "%s"
 }
 resource "aviatrix_edge_zededa" "test" {
-	account_name      = aviatrix_account.test_account.account_name
-	gw_name           = "%s"
-	site_id           = "%s"
- 	project_uuid      = "%s"
- 	compute_node_uuid = "%s"
- 	template_uuid     = "%s"
+	account_name         = aviatrix_account.test_account.account_name
+	gw_name              = "%s"
+	site_id              = "%s"
+ 	project_uuid         = "%s"
+ 	compute_node_uuid    = "%s"
+ 	template_uuid        = "%s"
+	bgp_polling_time     = 50
+	bgp_bfd_polling_time = 5
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -391,6 +391,12 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
+			"bgp_bfd_polling_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     defaultBgpBfdPollingTime,
+				Description: "BGP BFD route polling time. Unit is in seconds. Valid values are between 1 and 10.",
+			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -1320,6 +1326,13 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
+	if val, ok := d.GetOk("bgp_bfd_polling_time"); ok {
+		err := client.SetBgpBfdPollingTimeSpoke(gateway, strconv.Itoa(val.(int)))
+		if err != nil {
+			return fmt.Errorf("could not set bgp bfd polling time: %v", err)
+		}
+	}
+
 	if holdTime := d.Get("bgp_hold_time").(int); holdTime != defaultBgpHoldTime {
 		err := client.ChangeBgpHoldTime(gateway.GwName, holdTime)
 		if err != nil {
@@ -1481,10 +1494,12 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	if gw.EnableBgp {
 		d.Set("learned_cidrs_approval_mode", gw.LearnedCidrsApprovalMode)
 		d.Set("bgp_polling_time", gw.BgpPollingTime)
+		d.Set("bgp_bdf_polling_time", gw.BgpBfdPollingTime)
 		d.Set("bgp_hold_time", gw.BgpHoldTime)
 	} else {
 		d.Set("learned_cidrs_approval_mode", "gateway")
 		d.Set("bgp_polling_time", 50)
+		d.Set("bgp_bdf_polling_time", defaultBgpBfdPollingTime)
 		d.Set("bgp_hold_time", 180)
 	}
 	d.Set("tunnel_detection_time", gw.TunnelDetectionTime)
@@ -2643,6 +2658,17 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 		err := client.SetBgpPollingTimeSpoke(gateway, strconv.Itoa(bgpPollingTime.(int)))
 		if err != nil {
 			return fmt.Errorf("could not update bgp polling time during Spoke Gateway update: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		bgpBfdPollingTime := d.Get("bgp_bfd_polling_time")
+		gateway := &goaviatrix.SpokeVpc{
+			GwName: d.Get("gw_name").(string),
+		}
+		err := client.SetBgpBfdPollingTimeSpoke(gateway, strconv.Itoa(bgpBfdPollingTime.(int)))
+		if err != nil {
+			return fmt.Errorf("could not update bgp bfd polling time during Spoke Gateway update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -391,10 +391,11 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_bfd_polling_time": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     defaultBgpBfdPollingTime,
-				Description: "BGP BFD route polling time. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpBfdPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP BFD route polling time. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1320,16 +1320,22 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if val, ok := d.GetOk("bgp_polling_time"); ok {
-		err := client.SetBgpPollingTimeSpoke(gateway, val.(int))
-		if err != nil {
-			return fmt.Errorf("could not set bgp polling time: %v", err)
+		bgp_polling_time := val.(int)
+		if bgp_polling_time >= 10 && bgp_polling_time != defaultBgpPollingTime {
+			err := client.SetBgpPollingTimeSpoke(gateway, bgp_polling_time)
+			if err != nil {
+				return fmt.Errorf("could not set bgp polling time: %v", err)
+			}
 		}
 	}
 
 	if val, ok := d.GetOk("bgp_bfd_polling_time"); ok {
-		err := client.SetBgpBfdPollingTimeSpoke(gateway, val.(int))
-		if err != nil {
-			return fmt.Errorf("could not set bgp bfd polling time: %v", err)
+		bgp_bfd_polling_time := val.(int)
+		if bgp_bfd_polling_time >= 1 && bgp_bfd_polling_time != defaultBgpBfdPollingTime {
+			err := client.SetBgpBfdPollingTimeSpoke(gateway, val.(int))
+			if err != nil {
+				return fmt.Errorf("could not set bgp bfd polling time: %v", err)
+			}
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1320,14 +1319,14 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if val, ok := d.GetOk("bgp_polling_time"); ok {
-		err := client.SetBgpPollingTimeSpoke(gateway, strconv.Itoa(val.(int)))
+		err := client.SetBgpPollingTimeSpoke(gateway, val.(int))
 		if err != nil {
 			return fmt.Errorf("could not set bgp polling time: %v", err)
 		}
 	}
 
 	if val, ok := d.GetOk("bgp_bfd_polling_time"); ok {
-		err := client.SetBgpBfdPollingTimeSpoke(gateway, strconv.Itoa(val.(int)))
+		err := client.SetBgpBfdPollingTimeSpoke(gateway, val.(int))
 		if err != nil {
 			return fmt.Errorf("could not set bgp bfd polling time: %v", err)
 		}
@@ -2655,7 +2654,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 		gateway := &goaviatrix.SpokeVpc{
 			GwName: d.Get("gw_name").(string),
 		}
-		err := client.SetBgpPollingTimeSpoke(gateway, strconv.Itoa(bgpPollingTime.(int)))
+		err := client.SetBgpPollingTimeSpoke(gateway, bgpPollingTime.(int))
 		if err != nil {
 			return fmt.Errorf("could not update bgp polling time during Spoke Gateway update: %v", err)
 		}
@@ -2666,7 +2665,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 		gateway := &goaviatrix.SpokeVpc{
 			GwName: d.Get("gw_name").(string),
 		}
-		err := client.SetBgpBfdPollingTimeSpoke(gateway, strconv.Itoa(bgpBfdPollingTime.(int)))
+		err := client.SetBgpBfdPollingTimeSpoke(gateway, bgpBfdPollingTime.(int))
 		if err != nil {
 			return fmt.Errorf("could not update bgp bfd polling time during Spoke Gateway update: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_spoke_gateway_test.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway_test.go
@@ -97,6 +97,8 @@ func TestAccAviatrixSpokeGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "subnet", os.Getenv("AWS_SUBNET4")),
 						resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AWS_REGION")),
 						resource.TestCheckResourceAttr(resourceName, "single_ip_snat", "false"),
+						resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
+						resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
 					),
 				},
 				{
@@ -231,14 +233,16 @@ resource "aviatrix_account" "test_acc_aws" {
 	aws_secret_key     = "%s"
 }
 resource "aviatrix_spoke_gateway" "test_spoke_gateway" {
-	cloud_type     = 1
-	account_name   = aviatrix_account.test_acc_aws.account_name
-	gw_name        = "tfg-aws-%[1]s"
-	vpc_id         = "%[5]s"
-	vpc_reg        = "%[6]s"
-	gw_size        = "%[7]s"
-	subnet         = "%[8]s"
-	single_ip_snat = false
+	cloud_type           = 1
+	account_name         = aviatrix_account.test_acc_aws.account_name
+	gw_name              = "tfg-aws-%[1]s"
+	vpc_id               = "%[5]s"
+	vpc_reg              = "%[6]s"
+	gw_size              = "%[7]s"
+	subnet               = "%[8]s"
+	single_ip_snat       = false
+	bgp_polling_time     = 50
+	bgp_bfd_polling_time = 5
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		os.Getenv("AWS_VPC_ID4"), os.Getenv("AWS_REGION"), awsGwSize, os.Getenv("AWS_SUBNET4"))

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -18,6 +18,7 @@ import (
 const (
 	defaultLearnedCidrApprovalMode = "gateway"
 	defaultBgpPollingTime          = 50
+	defaultBgpBfdPollingTime       = 5
 	defaultBgpHoldTime             = 180
 )
 

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -53,6 +53,8 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceNameAws, "vpc_id", os.Getenv("AWS_VPC_ID")),
 						resource.TestCheckResourceAttr(resourceNameAws, "subnet", os.Getenv("AWS_SUBNET")),
 						resource.TestCheckResourceAttr(resourceNameAws, "vpc_reg", os.Getenv("AWS_REGION")),
+						resource.TestCheckResourceAttr(resourceNameAws, "bgp_polling_time", "50"),
+						resource.TestCheckResourceAttr(resourceNameAws, "bgp_bfd_polling_time", "5"),
 					),
 				},
 				{
@@ -194,13 +196,15 @@ resource "aviatrix_account" "test_acc_aws" {
 	aws_secret_key     = "%s"
 }
 resource "aviatrix_transit_gateway" "test_transit_gateway_aws" {
-	cloud_type   = 1
-	account_name = aviatrix_account.test_acc_aws.account_name
-	gw_name      = "tfg-aws-%[1]s"
-	vpc_id       = "%[5]s"
-	vpc_reg      = "%[6]s"
-	gw_size      = "t2.micro"
-	subnet       = "%[7]s"
+	cloud_type           = 1
+	account_name         = aviatrix_account.test_acc_aws.account_name
+	gw_name              = "tfg-aws-%[1]s"
+	vpc_id               = "%[5]s"
+	vpc_reg              = "%[6]s"
+	gw_size              = "t2.micro"
+	subnet               = "%[7]s"
+	bgp_polling_time     = 50
+	bgp_bfd_polling_time = 5
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		os.Getenv("AWS_VPC_ID"), os.Getenv("AWS_REGION"), os.Getenv("AWS_SUBNET"))

--- a/docs/data-sources/aviatrix_spoke_gateways.md
+++ b/docs/data-sources/aviatrix_spoke_gateways.md
@@ -70,6 +70,7 @@ The following attributes are exported:
     * `local_as_number` - Changes the Aviatrix Spoke Gateway ASN number before you setup Aviatrix Spoke Gateway connection configurations.
     * `prepend_as_path` - List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
     * `bgp_polling_time` - BGP route polling time. Unit is in seconds.
+    * `bgp_bfd_polling_time` - BGP BFD route polling time. Unit is in seconds. Valid values are between 1 and 10. Default value: 5.
     * `bgp_hold_time` - BGP Hold Time.
     * `enable_spot_instance` - Enable spot instance. NOT supported for production deployment.
     * `spot_price` - Price for spot instance. NOT supported for production deployment.

--- a/docs/data-sources/aviatrix_spoke_gateways.md
+++ b/docs/data-sources/aviatrix_spoke_gateways.md
@@ -70,7 +70,6 @@ The following attributes are exported:
     * `local_as_number` - Changes the Aviatrix Spoke Gateway ASN number before you setup Aviatrix Spoke Gateway connection configurations.
     * `prepend_as_path` - List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
     * `bgp_polling_time` - BGP route polling time. Unit is in seconds.
-    * `bgp_bfd_polling_time` - BGP BFD route polling time. Unit is in seconds. Valid values are between 1 and 10. Default value: 5.
     * `bgp_hold_time` - BGP Hold Time.
     * `enable_spot_instance` - Enable spot instance. NOT supported for production deployment.
     * `spot_price` - Price for spot instance. NOT supported for production deployment.

--- a/docs/data-sources/aviatrix_transit_gateway.md
+++ b/docs/data-sources/aviatrix_transit_gateway.md
@@ -90,6 +90,7 @@ In addition to all arguments above, the following attributes are exported:
 * `learned_cidrs_approval_mode` - Learned CIDRs approval mode.
 * `approved_learned_cidrs` - Approved learned CIDRs.
 * `bgp_polling_time` - BGP route polling time.
+* `bgp_bfd_polling_time` - BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `prepend_as_path` - List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
 * `bgp_ecmp` - Status of Equal Cost Multi Path (ECMP) routing for the next hop.
 * `enable_segmentation` - Status of segmentation.

--- a/docs/data-sources/aviatrix_transit_gateway.md
+++ b/docs/data-sources/aviatrix_transit_gateway.md
@@ -90,7 +90,6 @@ In addition to all arguments above, the following attributes are exported:
 * `learned_cidrs_approval_mode` - Learned CIDRs approval mode.
 * `approved_learned_cidrs` - Approved learned CIDRs.
 * `bgp_polling_time` - BGP route polling time.
-* `bgp_bfd_polling_time` - BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `prepend_as_path` - List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
 * `bgp_ecmp` - Status of Equal Cost Multi Path (ECMP) routing for the next hop.
 * `enable_segmentation` - Status of segmentation.

--- a/docs/data-sources/aviatrix_transit_gateways.md
+++ b/docs/data-sources/aviatrix_transit_gateways.md
@@ -32,6 +32,7 @@ In addition to all arguments above, the following attributes are exported:
   * `bgp_lan_interfaces` - Interfaces to run BGP protocol on top of the ethernet interface, to connect to the onprem/remote peer. Only available for GCP Transit.
   * `bgp_lan_ip_list` - List of available BGP LAN interface IPs for transit external device connection creation. Only supports GCP. Available as of provider version R2.21.0+.
   * `bgp_polling_time` - BGP route polling time. Unit is in seconds.
+  * `bgp_bfd_polling_time` - BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
   * `cloud_instance_id` - Instance ID of the transit gateway.
   * `cloud_type` - Type of cloud service provider.
   * `connected_transit"` -  Status of Connected Transit of transit gateway.

--- a/docs/data-sources/aviatrix_transit_gateways.md
+++ b/docs/data-sources/aviatrix_transit_gateways.md
@@ -32,7 +32,6 @@ In addition to all arguments above, the following attributes are exported:
   * `bgp_lan_interfaces` - Interfaces to run BGP protocol on top of the ethernet interface, to connect to the onprem/remote peer. Only available for GCP Transit.
   * `bgp_lan_ip_list` - List of available BGP LAN interface IPs for transit external device connection creation. Only supports GCP. Available as of provider version R2.21.0+.
   * `bgp_polling_time` - BGP route polling time. Unit is in seconds.
-  * `bgp_bfd_polling_time` - BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
   * `cloud_instance_id` - Instance ID of the transit gateway.
   * `cloud_type` - Type of cloud service provider.
   * `connected_transit"` -  Status of Connected Transit of transit gateway.

--- a/docs/resources/aviatrix_edge_csp.md
+++ b/docs/resources/aviatrix_edge_csp.md
@@ -92,6 +92,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: 50.
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_equinix.md
+++ b/docs/resources/aviatrix_edge_equinix.md
@@ -81,6 +81,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time in seconds. Valid values are between 10 and 50. Default value: 50.
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -83,6 +83,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: 50.
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_neo.md
+++ b/docs/resources/aviatrix_edge_neo.md
@@ -94,6 +94,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time in seconds. Valid values are between 10 and 50. Default value: 50.
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_platform.md
+++ b/docs/resources/aviatrix_edge_platform.md
@@ -92,6 +92,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time in seconds. Valid values are between 10 and 50. Default value: 50.
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_spoke.md
+++ b/docs/resources/aviatrix_edge_spoke.md
@@ -84,6 +84,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: 50.
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_zededa.md
+++ b/docs/resources/aviatrix_edge_zededa.md
@@ -90,6 +90,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: 50.
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -305,6 +305,7 @@ The following arguments are supported:
 * `bgp_ecmp` - (Optional) Enable Equal Cost Multi Path (ECMP) routing for the next hop. Default value: false.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: "50".
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Intended CIDR list to be advertised to external BGP router. Empty list is not valid. Example: ["10.2.0.0/16", "10.4.0.0/16"].
 * `enable_active_standby` - (Optional) Enables [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby). Available only with HA enabled. Valid values: true, false. Default value: false.
 * `enable_active_standby_preemptive` - (Optional) Enables Preemptive Mode for Active-Standby. Available only with BGP enabled, HA enabled and Active-Standby enabled. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -344,6 +344,7 @@ The following arguments are supported:
 * `enable_active_standby` - (Optional) Enables [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby). Available only with HA enabled. Valid values: true, false. Default value: false. Available in provider version R2.17.1+.
 * `enable_active_standby_preemptive` - (Optional) Enables Preemptive Mode for Active-Standby. Available only with BGP enabled, HA enabled and Active-Standby enabled. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: "50".
+* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `prepend_as_path` - (Optional) List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
 * `local_as_number` - (Optional) Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations.

--- a/goaviatrix/edge_csp.go
+++ b/goaviatrix/edge_csp.go
@@ -34,6 +34,7 @@ type EdgeCSP struct {
 	SpokeBgpManualAdvertisedCidrs      []string `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
 	EnablePreserveAsPath               bool     `json:"preserve_as_path,omitempty"`
 	BgpPollingTime                     int      `json:"bgp_polling_time,omitempty"`
+	BgpBfdPollingTime                  int      `json:"bgp_bfd_polling_time,omitempty"`
 	BgpHoldTime                        int      `json:"bgp_hold_time,omitempty"`
 	EnableEdgeTransitiveRouting        bool     `json:"edge_transitive_routing,omitempty"`
 	EnableJumboFrame                   bool     `json:"jumbo_frame,omitempty"`
@@ -109,6 +110,7 @@ type EdgeCSPResp struct {
 	SpokeBgpManualAdvertisedCidrs      []string     `json:"bgp_manual_spoke_advertise_cidrs"`
 	EnablePreserveAsPath               bool         `json:"preserve_as_path"`
 	BgpPollingTime                     int          `json:"bgp_polling_time"`
+	BgpBfdPollingTime                  int          `json:"bgp_bfd_polling_time"`
 	BgpHoldTime                        int          `json:"bgp_hold_time"`
 	EnableEdgeTransitiveRouting        bool         `json:"edge_transitive_routing"`
 	EnableJumboFrame                   bool         `json:"jumbo_frame"`

--- a/goaviatrix/edge_equinix.go
+++ b/goaviatrix/edge_equinix.go
@@ -33,6 +33,7 @@ type EdgeEquinix struct {
 	SpokeBgpManualAdvertisedCidrs      []string `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
 	EnablePreserveAsPath               bool     `json:"preserve_as_path,omitempty"`
 	BgpPollingTime                     int      `json:"bgp_polling_time,omitempty"`
+	BgpBfdPollingTime                  int      `json:"bgp_bfd_polling_time,omitempty"`
 	BgpHoldTime                        int      `json:"bgp_hold_time,omitempty"`
 	EnableEdgeTransitiveRouting        bool     `json:"edge_transitive_routing,omitempty"`
 	EnableJumboFrame                   bool     `json:"jumbo_frame,omitempty"`
@@ -102,6 +103,7 @@ type EdgeEquinixResp struct {
 	SpokeBgpManualAdvertisedCidrs      []string     `json:"bgp_manual_spoke_advertise_cidrs"`
 	EnablePreserveAsPath               bool         `json:"preserve_as_path"`
 	BgpPollingTime                     int          `json:"bgp_polling_time"`
+	BgpBfdPollingTime                  int          `json:"bgp_bfd_polling_time"`
 	BgpHoldTime                        int          `json:"bgp_hold_time"`
 	EnableEdgeTransitiveRouting        bool         `json:"edge_transitive_routing"`
 	EnableJumboFrame                   bool         `json:"jumbo_frame"`

--- a/goaviatrix/edge_neo.go
+++ b/goaviatrix/edge_neo.go
@@ -32,6 +32,7 @@ type EdgeNEO struct {
 	SpokeBgpManualAdvertisedCidrs      []string `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
 	EnablePreserveAsPath               bool     `json:"preserve_as_path,omitempty"`
 	BgpPollingTime                     int      `json:"bgp_polling_time,omitempty"`
+	BgpBfdPollingTime                  int      `json:"bgp_bfd_polling_time,omitempty"`
 	BgpHoldTime                        int      `json:"bgp_hold_time,omitempty"`
 	EnableEdgeTransitiveRouting        bool     `json:"edge_transitive_routing,omitempty"`
 	EnableJumboFrame                   bool     `json:"jumbo_frame,omitempty"`
@@ -102,6 +103,7 @@ type EdgeNEOResp struct {
 	SpokeBgpManualAdvertisedCidrs      []string            `json:"bgp_manual_spoke_advertise_cidrs"`
 	EnablePreserveAsPath               bool                `json:"preserve_as_path"`
 	BgpPollingTime                     int                 `json:"bgp_polling_time"`
+	BgpBfdPollingTime                  int                 `json:"bgp_bfd_polling_time"`
 	BgpHoldTime                        int                 `json:"bgp_hold_time"`
 	EnableEdgeTransitiveRouting        bool                `json:"edge_transitive_routing"`
 	EnableJumboFrame                   bool                `json:"jumbo_frame"`

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -41,6 +41,7 @@ type EdgeSpoke struct {
 	SpokeBgpManualAdvertisedCidrs      []string `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
 	EnablePreserveAsPath               bool     `json:"preserve_as_path,omitempty"`
 	BgpPollingTime                     int      `json:"bgp_polling_time,omitempty"`
+	BgpBfdPollingTime                  int      `json:"bgp_bfd_polling_time,omitempty"`
 	BgpHoldTime                        int      `json:"bgp_hold_time,omitempty"`
 	EnableEdgeTransitiveRouting        bool     `json:"edge_transitive_routing,omitempty"`
 	EnableJumboFrame                   bool     `json:"jumbo_frame,omitempty"`
@@ -99,6 +100,7 @@ type EdgeSpokeResp struct {
 	SpokeBgpManualAdvertisedCidrs      []string              `json:"bgp_manual_spoke_advertise_cidrs"`
 	EnablePreserveAsPath               bool                  `json:"preserve_as_path"`
 	BgpPollingTime                     int                   `json:"bgp_polling_time"`
+	BgpBfdPollingTime                  int                   `json:"bgp_bfd_polling_time"`
 	BgpHoldTime                        int                   `json:"bgp_hold_time"`
 	EnableEdgeTransitiveRouting        bool                  `json:"edge_transitive_routing"`
 	EnableJumboFrame                   bool                  `json:"jumbo_frame"`

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -174,7 +174,7 @@ type Gateway struct {
 	TunnelDetectionTime             int                                 `json:"detection_time"`
 	BgpHoldTime                     int                                 `json:"bgp_hold_time"`
 	BgpPollingTime                  int                                 `json:"bgp_polling_time"`
-	BgpBfdPollingTime               int                                 `json:"bgp_bfd_polling_time,omitempty"`
+	BgpBfdPollingTime               int                                 `json:"bgp_bfd_polling_time"`
 	PrependASPath                   string                              `json:"prepend_as_path"`
 	LocalASNumber                   string                              `json:"local_as_number"`
 	BgpEcmp                         bool                                `json:"bgp_ecmp"`

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -174,6 +174,7 @@ type Gateway struct {
 	TunnelDetectionTime             int                                 `json:"detection_time"`
 	BgpHoldTime                     int                                 `json:"bgp_hold_time"`
 	BgpPollingTime                  int                                 `json:"bgp_polling_time"`
+	BgpBfdPollingTime               int                                 `json:"bgp_bfd_polling_time,omitempty"`
 	PrependASPath                   string                              `json:"prepend_as_path"`
 	LocalASNumber                   string                              `json:"local_as_number"`
 	BgpEcmp                         bool                                `json:"bgp_ecmp"`

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -56,6 +56,7 @@ type SpokeVpc struct {
 
 type SpokeGatewayAdvancedConfig struct {
 	BgpPollingTime                    string
+	BgpBfdPollingTime                 string
 	PrependASPath                     []string
 	LocalASNumber                     string
 	BgpEcmpEnabled                    bool
@@ -362,13 +363,13 @@ func (c *Client) SetBgpPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime s
 	}, BasicCheck)
 }
 
-func (c *Client) SetBgpBfdPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime int) error {
+func (c *Client) SetBgpBfdPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime string) error {
 	action := "change_bgp_bfd_polling_time"
 	return c.PostAPI(action, struct {
 		CID         string `form:"CID"`
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
-		PollingTime int    `form:"bgp_bfd_polling_time"`
+		PollingTime string `form:"bgp_bfd_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -2,7 +2,6 @@ package goaviatrix
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -55,8 +54,8 @@ type SpokeVpc struct {
 }
 
 type SpokeGatewayAdvancedConfig struct {
-	BgpPollingTime                    string
-	BgpBfdPollingTime                 string
+	BgpPollingTime                    int
+	BgpBfdPollingTime                 int
 	PrependASPath                     []string
 	LocalASNumber                     string
 	BgpEcmpEnabled                    bool
@@ -236,7 +235,8 @@ func (c *Client) GetSpokeGatewayAdvancedConfig(spokeGateway *SpokeVpc) (*SpokeGa
 	}
 
 	return &SpokeGatewayAdvancedConfig{
-		BgpPollingTime:                    strconv.Itoa(data.Results.BgpPollingTime),
+		BgpPollingTime:                    data.Results.BgpPollingTime,
+		BgpBfdPollingTime:                 data.Results.BgpBfdPollingTime,
 		PrependASPath:                     filteredStrings,
 		LocalASNumber:                     data.Results.LocalASNumber,
 		BgpEcmpEnabled:                    data.Results.BgpEcmpEnabled == "yes",
@@ -348,13 +348,13 @@ func (c *Client) SetPrependASPathSpoke(spokeGateway *SpokeVpc, prependASPath []s
 	}, BasicCheck)
 }
 
-func (c *Client) SetBgpPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime string) error {
+func (c *Client) SetBgpPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime int) error {
 	action := "change_bgp_polling_time"
 	return c.PostAPI(action, struct {
 		CID         string `form:"CID"`
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
-		PollingTime string `form:"bgp_polling_time"`
+		PollingTime int    `form:"bgp_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,
@@ -363,13 +363,13 @@ func (c *Client) SetBgpPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime s
 	}, BasicCheck)
 }
 
-func (c *Client) SetBgpBfdPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime string) error {
+func (c *Client) SetBgpBfdPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime int) error {
 	action := "change_bgp_bfd_polling_time"
 	return c.PostAPI(action, struct {
 		CID         string `form:"CID"`
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
-		PollingTime string `form:"bgp_bfd_polling_time"`
+		PollingTime int    `form:"bgp_bfd_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -79,6 +79,7 @@ type SpokeGatewayAdvancedConfigResp struct {
 
 type SpokeGatewayAdvancedConfigRespResult struct {
 	BgpPollingTime                    int                       `json:"bgp_polling_time"`
+	BgpBfdPollingTime                 int                       `json:"bgp_bfd_polling_time,omitempty"`
 	PrependASPath                     string                    `json:"bgp_prepend_as_path"`
 	LocalASNumber                     string                    `json:"local_asn_num"`
 	BgpEcmpEnabled                    string                    `json:"bgp_ecmp"`
@@ -353,6 +354,21 @@ func (c *Client) SetBgpPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime s
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
 		PollingTime string `form:"bgp_polling_time"`
+	}{
+		CID:         c.CID,
+		Action:      action,
+		GatewayName: spokeGateway.GwName,
+		PollingTime: newPollingTime,
+	}, BasicCheck)
+}
+
+func (c *Client) SetBgpBfdPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime int) error {
+	action := "change_bgp_bfd_polling_time"
+	return c.PostAPI(action, struct {
+		CID         string `form:"CID"`
+		Action      string `form:"action"`
+		GatewayName string `form:"gateway_name"`
+		PollingTime int    `form:"bgp_bfd_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -64,6 +64,7 @@ type TransitVpc struct {
 
 type TransitGatewayAdvancedConfig struct {
 	BgpPollingTime                    string
+	BgpBfdPollingTime                 string
 	PrependASPath                     []string
 	LocalASNumber                     string
 	BgpEcmpEnabled                    bool
@@ -86,6 +87,7 @@ type StandbyConnection struct {
 
 type TransitGatewayAdvancedConfigRespResult struct {
 	BgpPollingTime                    int                       `json:"bgp_polling_time"`
+	BgpBfdPollingTime                 int                       `json:"bgp_bfd_polling_time"`
 	PrependASPath                     string                    `json:"bgp_prepend_as_path"`
 	LocalASNumber                     string                    `json:"local_asn_num"`
 	BgpEcmpEnabled                    string                    `json:"bgp_ecmp"`
@@ -356,6 +358,21 @@ func (c *Client) SetBgpPollingTime(transitGateway *TransitVpc, newPollingTime st
 	}, BasicCheck)
 }
 
+func (c *Client) SetBgpBfdPollingTime(transitGateway *TransitVpc, newPollingTime int) error {
+	action := "change_bgp_bfd_polling_time"
+	return c.PostAPI(action, struct {
+		CID         string `form:"CID"`
+		Action      string `form:"action"`
+		GatewayName string `form:"gateway_name"`
+		PollingTime int    `form:"bgp_bfd_polling_time"`
+	}{
+		CID:         c.CID,
+		Action:      action,
+		GatewayName: transitGateway.GwName,
+		PollingTime: newPollingTime,
+	}, BasicCheck)
+}
+
 func (c *Client) SetPrependASPath(transitGateway *TransitVpc, prependASPath []string) error {
 	action, subaction := "edit_aviatrix_transit_advanced_config", "prepend_as_path"
 	return c.PostAPI(action+"/"+subaction, struct {
@@ -450,6 +467,7 @@ func (c *Client) GetTransitGatewayAdvancedConfig(transitGateway *TransitVpc) (*T
 
 	return &TransitGatewayAdvancedConfig{
 		BgpPollingTime:                    strconv.Itoa(data.Results.BgpPollingTime),
+		BgpBfdPollingTime:                 strconv.Itoa(data.Results.BgpBfdPollingTime),
 		PrependASPath:                     filteredStrings,
 		LocalASNumber:                     data.Results.LocalASNumber,
 		BgpEcmpEnabled:                    data.Results.BgpEcmpEnabled == "yes",

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -63,8 +63,8 @@ type TransitVpc struct {
 }
 
 type TransitGatewayAdvancedConfig struct {
-	BgpPollingTime                    string
-	BgpBfdPollingTime                 string
+	BgpPollingTime                    int
+	BgpBfdPollingTime                 int
 	PrependASPath                     []string
 	LocalASNumber                     string
 	BgpEcmpEnabled                    bool
@@ -466,8 +466,8 @@ func (c *Client) GetTransitGatewayAdvancedConfig(transitGateway *TransitVpc) (*T
 	}
 
 	return &TransitGatewayAdvancedConfig{
-		BgpPollingTime:                    strconv.Itoa(data.Results.BgpPollingTime),
-		BgpBfdPollingTime:                 strconv.Itoa(data.Results.BgpBfdPollingTime),
+		BgpPollingTime:                    data.Results.BgpPollingTime,
+		BgpBfdPollingTime:                 data.Results.BgpBfdPollingTime,
 		PrependASPath:                     filteredStrings,
 		LocalASNumber:                     data.Results.LocalASNumber,
 		BgpEcmpEnabled:                    data.Results.BgpEcmpEnabled == "yes",

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -358,13 +358,13 @@ func (c *Client) SetBgpPollingTime(transitGateway *TransitVpc, newPollingTime st
 	}, BasicCheck)
 }
 
-func (c *Client) SetBgpBfdPollingTime(transitGateway *TransitVpc, newPollingTime int) error {
+func (c *Client) SetBgpBfdPollingTime(transitGateway *TransitVpc, newPollingTime string) error {
 	action := "change_bgp_bfd_polling_time"
 	return c.PostAPI(action, struct {
 		CID         string `form:"CID"`
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
-		PollingTime int    `form:"bgp_bfd_polling_time"`
+		PollingTime string `form:"bgp_bfd_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,


### PR DESCRIPTION
Backport PR for for 7.2.b - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2048

Adding the bgp-bfd polling time to the following resources:

aviatrix_edge_equinix
aviatrix_edge_gateway_selfmanaged
avaitrix_edge_platform
aviatrix_edge_zededa
aviatrix_spoke_gateway
aviatrix_edge_spoke_gateway
aviatrix_transit_gateway