### PR TITLE
Golangci-lint Upgrade

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -61,8 +61,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.21
+        id: go
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.55
           only-new-issues: true


### PR DESCRIPTION
Upgrades the golangci-lint version to fix bug where the linter began to lint unknown files.