### PR TITLE
AVX-58209 Updating the transit gateway with bgp-bfd polling time

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -309,6 +309,13 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Default:     "50",
 				Description: "BGP route polling time. Unit is in seconds. Valid values are between 10 and 50.",
 			},
+			"bgp_bfd_polling_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpBfdPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP BFD route polling time for BGP Transit Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+			},
 			"prepend_as_path": {
 				Type:         schema.TypeList,
 				Optional:     true,
@@ -1710,9 +1717,16 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		}
 
 		if val, ok := d.GetOk("bgp_polling_time"); ok {
-			err := client.SetBgpPollingTime(gateway, val.(string))
+			err := client.SetBgpPollingTime(gateway, val.(int))
 			if err != nil {
 				return fmt.Errorf("could not set bgp polling time: %v", err)
+			}
+		}
+
+		if val, ok := d.GetOk("bgp_bfd_polling_time"); ok {
+			err := client.SetBgpBfdPollingTime(gateway, val.(int))
+			if err != nil {
+				return fmt.Errorf("could not set bgp bfd polling time: %v", err)
 			}
 		}
 
@@ -2024,7 +2038,8 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		d.Set("enable_hybrid_connection", goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes) && gw.EnableHybridConnection)
 		d.Set("connected_transit", gw.ConnectedTransit == "yes")
 		d.Set("bgp_hold_time", gw.BgpHoldTime)
-		d.Set("bgp_polling_time", strconv.Itoa(gw.BgpPollingTime))
+		d.Set("bgp_polling_time", gw.BgpPollingTime)
+		d.Set("bgp_bfd_polling_time", gw.BgpBfdPollingTime)
 		d.Set("image_version", gw.ImageVersion)
 		d.Set("software_version", gw.SoftwareVersion)
 		d.Set("rx_queue_size", gw.RxQueueSize)
@@ -3358,11 +3373,22 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 	}
 
 	if d.HasChange("bgp_polling_time") {
-		bgpPollingTime := d.Get("bgp_polling_time").(string)
+		bgpPollingTime := d.Get("bgp_polling_time").(int)
 		gateway := &goaviatrix.TransitVpc{
 			GwName: d.Get("gw_name").(string),
 		}
 		err := client.SetBgpPollingTime(gateway, bgpPollingTime)
+		if err != nil {
+			return fmt.Errorf("could not update bgp polling time: %v", err)
+		}
+	}
+
+	if d.HasChange("bgp_bfd_polling_time") {
+		bgpBfdPollingTime := d.Get("bgp_bfd_polling_time").(int)
+		gateway := &goaviatrix.TransitVpc{
+			GwName: d.Get("gw_name").(string),
+		}
+		err := client.SetBgpBfdPollingTime(gateway, bgpBfdPollingTime)
 		if err != nil {
 			return fmt.Errorf("could not update bgp polling time: %v", err)
 		}

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -304,10 +304,11 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Description: "Approved learned CIDRs. Available as of provider version R2.21+.",
 			},
 			"bgp_polling_time": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "50",
-				Description: "BGP route polling time. Unit is in seconds. Valid values are between 10 and 50.",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpPollingTime,
+				ValidateFunc: validation.IntBetween(10, 50),
+				Description:  "BGP route polling time. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_bfd_polling_time": {
 				Type:         schema.TypeInt,

--- a/docs/guides/feature-changelist-v3.md
+++ b/docs/guides/feature-changelist-v3.md
@@ -95,7 +95,7 @@ The following logging resources are removed:
 |(deprecated) | firenet | keep_alive_via_lan_interface_enabled | **Yes**; This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release |
 
 
-## R3.2.1 (UserConnect-7.2)**
+## R3.2.1 (UserConnect-7.2)
 ### Attribute Change
 | Diff | Resource | Attribute | Action Required? |
 |:----:|:--------:|:---------:|:----------------:|

--- a/docs/guides/feature-changelist-v3.md
+++ b/docs/guides/feature-changelist-v3.md
@@ -93,3 +93,10 @@ The following logging resources are removed:
 |:----:|:--------:|:---------:|:----------------:|
 |(deprecated) | edge_equinix, edge_equinix_ha, edge_csp, edge_csp_ha, edge_neo, edge_neo_ha, edge_platform, edge_platform_ha, edge_zededa, edge_zededa_ha | bandwidth | **Yes**; This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release |
 |(deprecated) | firenet | keep_alive_via_lan_interface_enabled | **Yes**; This configuration value no longer has any effect. It will be removed from the Aviatrix provider in the 3.2.0 release |
+
+
+## R3.2.1 (UserConnect-7.2)**
+### Attribute Change
+| Diff | Resource | Attribute | Action Required? |
+|:----:|:--------:|:---------:|:----------------:|
+|(changed) | edge_csp, edge_equinix, edge_gateway_selfmanaged, edge_platform, edge_zededa, spoke_gateway, transit_gateway, edge_spoke_gateway | bgp_polling_time | **Yes**; Accepted values are changed to **int** |

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -357,13 +357,13 @@ func (c *Client) UpdateTransitPendingApprovedCidrs(gateway *TransitVpc) error {
 	return c.PostAPI(form["action"], form, BasicCheck)
 }
 
-func (c *Client) SetBgpPollingTime(transitGateway *TransitVpc, newPollingTime string) error {
+func (c *Client) SetBgpPollingTime(transitGateway *TransitVpc, newPollingTime int) error {
 	action := "change_bgp_polling_time"
 	return c.PostAPI(action, struct {
 		CID         string `form:"CID"`
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
-		PollingTime string `form:"bgp_polling_time"`
+		PollingTime int    `form:"bgp_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,
@@ -372,13 +372,13 @@ func (c *Client) SetBgpPollingTime(transitGateway *TransitVpc, newPollingTime st
 	}, BasicCheck)
 }
 
-func (c *Client) SetBgpBfdPollingTime(transitGateway *TransitVpc, newPollingTime string) error {
+func (c *Client) SetBgpBfdPollingTime(transitGateway *TransitVpc, newPollingTime int) error {
 	action := "change_bgp_bfd_polling_time"
 	return c.PostAPI(action, struct {
 		CID         string `form:"CID"`
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
-		PollingTime string `form:"bgp_bfd_polling_time"`
+		PollingTime int    `form:"bgp_bfd_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,


### PR DESCRIPTION
This bug fixes the missing bgp-bfd polling time in transit gateway. This change got overridden while merging conflicts.
https://aviatrix.atlassian.net/browse/AVX-58209
UT is already a part of my previously merged PR - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2048