### PR TITLE
Pin go version for lint workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.21
+          go-version: 1.21
         id: go
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
Pins the go version so that UserConnect-7.2 branch still uses 1.21 for linting.