### PR TITLE
AVX-58386 Adding BGP BFD config to spoke connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@
 1. Added proxy profile support to **aviatrix_edge_platform_device_onboarding**, enabling the specification of a proxy for onboarding Aviatrix Edge devices.
 2. Updated documentation references by consolidating the legacy terms ``Cloudn`` and ``Multi-Cloud Transit`` under a single ``Edge`` subcategory.
 3. Added support for Kubernetes Smart Groups, updating the **aviatrix_smart_group** resource to allow Smart Groups to be created from artifacts within Kubernetes clusters.
+4. Added new attribute ``bgp_neighbor_status_polling_time`` to support the bgp bfd configuration in the following resources.
+    - **aviatrix_edge_csp**
+    - **aviatrix_edge_equinix**
+    - **aviatrix_edge_gateway_selfmanaged**
+    - **avaitrix_edge_platform**
+    - **aviatrix_edge_zededa**
+    - **aviatrix_spoke_gateway**
+    - **aviatrix_edge_spoke_gateway**
+    - **aviatrix_transit_gateway**
+5. Added new attribute ``bgp_bfd`` and ``enable_bfd`` to support bgp_bfd configuration in the following resources
+    - **aviatrix_transit_external_device_conn**
+    - **aviatrix_edge_spoke_external_device_conn**
+    - **aviatrix_spoke_external_device_conn**
 
 #### Provider:
 1. Added support for the Terraform provider to properly set the user-agent when making requests.
@@ -51,19 +64,7 @@
 
 
 ### Multi-Cloud Transit:
-1. Added new attribute ``bgp_neighbor_status_polling_time`` to support the bgp bfd configuration in the following resources.
-    - **aviatrix_edge_csp**
-    - **aviatrix_edge_equinix**
-    - **aviatrix_edge_gateway_selfmanaged**
-    - **avaitrix_edge_platform**
-    - **aviatrix_edge_zededa**
-    - **aviatrix_spoke_gateway**
-    - **aviatrix_edge_spoke_gateway**
-    - **aviatrix_transit_gateway**
-2. Added new attribute ``bgp_bfd`` and ``enable_bfd`` to support bgp_bfd configuration in the following resources
-    - **aviatrix_transit_external_device_conn**
-    - **aviatrix_edge_spoke_external_device_conn**
-3. Add new attribute ``dns_server_ip`` and ``secondary_dns_server_ip`` in **aviatrix_edge_gateway_selfmanaged_ha** resource.
+1. Add new attribute ``dns_server_ip`` and ``secondary_dns_server_ip`` in **aviatrix_edge_gateway_selfmanaged_ha** resource.
 
 
 ### Deprecations:

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -541,8 +541,8 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 				bfdConfig := v.(map[string]interface{})
 				bgpBfdConfigList = *goaviatrix.CreateBgpBfdConfig(bfdConfig)
 			}
-		} else {
-			// set the bgp bfd config using the default values
+		} else if len(bgpBfdConfig) == 0 {
+			// set the bgp bfd config using the default values if bgd is enabled and no config is provided
 			bgpBfdConfigList = defaultBfdConfig
 		}
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -528,35 +528,30 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 	if !ok {
 		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
-	if enableBfd {
-		// get the new BGP BFD config
-		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
-		if !ok {
-			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
-		}
-		var bgpBfdConfigList goaviatrix.BgpBfdConfig
-		// Update the BGP BFD config if bfd is enabled and config has changed
-		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
-			for _, v := range bgpBfdConfig {
-				bfdConfig := v.(map[string]interface{})
-				bgpBfdConfigList = *goaviatrix.CreateBgpBfdConfig(bfdConfig)
+	// get the BGP BFD config
+	bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
+	if !ok {
+		return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+	}
+	if d.HasChange("enable_bfd") || d.HasChange("bgp_bfd") {
+		// bgp bfd is enabled
+		if enableBfd {
+			bgpBfd := goaviatrix.GetUpdatedBgpBfdConfig(bgpBfdConfig)
+			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
+				GwName:         d.Get("gw_name").(string),
+				ConnectionName: d.Get("connection_name").(string),
+				EnableBfd:      d.Get("enable_bfd").(bool),
+				BgpBfdConfig:   &bgpBfd,
 			}
-		} else if len(bgpBfdConfig) == 0 {
-			// set the bgp bfd config using the default values if bgd is enabled and no config is provided
-			bgpBfdConfigList = defaultBfdConfig
-		}
-		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
-			GwName:         d.Get("gw_name").(string),
-			ConnectionName: d.Get("connection_name").(string),
-			EnableBfd:      d.Get("enable_bfd").(bool),
-			BgpBfdConfig:   &bgpBfdConfigList,
-		}
-		err := client.EditConnectionBgpBfd(externalDeviceConn)
-		if err != nil {
-			return diag.Errorf("could not update BGP BFD config: %v", err)
-		}
-	} else {
-		if d.HasChange("enable_bfd") {
+			err := client.EditConnectionBgpBfd(externalDeviceConn)
+			if err != nil {
+				return diag.Errorf("could not update BGP BFD config: %v", err)
+			}
+		} else {
+			// bgp bfd is disabled
+			if len(bgpBfdConfig) > 0 {
+				return diag.Errorf("bgp_bfd config can't be set when BFD is disabled")
+			}
 			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 				GwName:         d.Get("gw_name").(string),
 				ConnectionName: d.Get("connection_name").(string),

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -346,33 +346,11 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 				if !ok {
 					return diag.Errorf("expected bgp_bfd to be a map, but got %T", bfd0)
 				}
-				transmitInterval := defaultBfdTransmitInterval
-				receiveInterval := defaultBfdReceiveInterval
-				multiplier := defaultBfdMultiplier
-				if value, ok := bfd1["transmit_interval"].(int); ok {
-					transmitInterval = value
-				}
-				if value, ok := bfd1["receive_interval"].(int); ok {
-					receiveInterval = value
-				}
-				if value, ok := bfd1["multiplier"].(int); ok {
-					multiplier = value
-				}
-				bfd2 := &goaviatrix.BgpBfdConfig{
-					TransmitInterval: transmitInterval,
-					ReceiveInterval:  receiveInterval,
-					Multiplier:       multiplier,
-				}
-				externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
+				externalDeviceConn.BgpBfdConfig = goaviatrix.CreateBgpBfdConfig(bfd1)
 			}
 		} else {
 			// set the bgp bfd config using the default values
-			bfd := &goaviatrix.BgpBfdConfig{
-				TransmitInterval: defaultBfdTransmitInterval,
-				ReceiveInterval:  defaultBfdReceiveInterval,
-				Multiplier:       defaultBfdMultiplier,
-			}
-			externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd)
+			externalDeviceConn.BgpBfdConfig = &defaultBfdConfig
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
@@ -464,7 +442,6 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 	d.Set("remote_lan_ip", conn.RemoteLanIP)
 	d.Set("enable_edge_underlay", conn.EnableEdgeUnderlay)
 	d.Set("remote_cloud_type", conn.RemoteCloudType)
-
 	if conn.BgpLocalAsNum != 0 {
 		d.Set("bgp_local_as_num", strconv.Itoa(conn.BgpLocalAsNum))
 	}
@@ -477,24 +454,23 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
 	d.Set("enable_bfd", enable_bfd)
-	if conn.EnableBfd && len(conn.BgpBfdConfig) > 0 {
+	if conn.EnableBfd && conn.BgpBfdConfig != nil {
 		var bgpBfdConfig []map[string]interface{}
-		for _, bfd := range conn.BgpBfdConfig {
-			bfdMap := make(map[string]interface{})
-			bfdMap["transmit_interval"] = defaultBfdTransmitInterval
-			bfdMap["receive_interval"] = defaultBfdReceiveInterval
-			bfdMap["multiplier"] = defaultBfdMultiplier
-			if bfd.TransmitInterval != 0 {
-				bfdMap["transmit_interval"] = bfd.TransmitInterval
-			}
-			if bfd.ReceiveInterval != 0 {
-				bfdMap["receive_interval"] = bfd.ReceiveInterval
-			}
-			if bfd.Multiplier != 0 {
-				bfdMap["multiplier"] = bfd.Multiplier
-			}
-			bgpBfdConfig = append(bgpBfdConfig, bfdMap)
+		bfd := conn.BgpBfdConfig
+		bfdMap := make(map[string]interface{})
+		bfdMap["transmit_interval"] = defaultBfdTransmitInterval
+		bfdMap["receive_interval"] = defaultBfdReceiveInterval
+		bfdMap["multiplier"] = defaultBfdMultiplier
+		if bfd.TransmitInterval != 0 {
+			bfdMap["transmit_interval"] = bfd.TransmitInterval
 		}
+		if bfd.ReceiveInterval != 0 {
+			bfdMap["receive_interval"] = bfd.ReceiveInterval
+		}
+		if bfd.Multiplier != 0 {
+			bfdMap["multiplier"] = bfd.Multiplier
+		}
+		bgpBfdConfig = append(bgpBfdConfig, bfdMap)
 		d.Set("bgp_bfd", bgpBfdConfig)
 	}
 
@@ -558,42 +534,22 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 		if !ok {
 			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
-		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
+		var bgpBfdConfigList goaviatrix.BgpBfdConfig
 		// Update the BGP BFD config if bfd is enabled and config has changed
 		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
 			for _, v := range bgpBfdConfig {
 				bfdConfig := v.(map[string]interface{})
-				transmitInterval, ok := bfdConfig["transmit_interval"].(int)
-				if !ok {
-					transmitInterval = defaultBfdTransmitInterval
-				}
-				receiveInterval, ok := bfdConfig["receive_interval"].(int)
-				if !ok {
-					receiveInterval = defaultBfdReceiveInterval
-				}
-				multiplier, ok := bfdConfig["multiplier"].(int)
-				if !ok {
-					multiplier = defaultBfdMultiplier
-				}
-				bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
-					TransmitInterval: transmitInterval,
-					ReceiveInterval:  receiveInterval,
-					Multiplier:       multiplier,
-				})
+				bgpBfdConfigList = *goaviatrix.CreateBgpBfdConfig(bfdConfig)
 			}
 		} else {
 			// set the bgp bfd config using the default values
-			bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
-				TransmitInterval: defaultBfdTransmitInterval,
-				ReceiveInterval:  defaultBfdReceiveInterval,
-				Multiplier:       defaultBfdMultiplier,
-			})
+			bgpBfdConfigList = defaultBfdConfig
 		}
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			GwName:         d.Get("gw_name").(string),
 			ConnectionName: d.Get("connection_name").(string),
 			EnableBfd:      d.Get("enable_bfd").(bool),
-			BgpBfdConfig:   bgpBfdConfigList,
+			BgpBfdConfig:   &bgpBfdConfigList,
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -728,33 +728,11 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 				if !ok {
 					return fmt.Errorf("expected bgp_bfd to be a map, but got %T", bfd0)
 				}
-				transmitInterval := defaultBfdTransmitInterval
-				receiveInterval := defaultBfdReceiveInterval
-				multiplier := defaultBfdMultiplier
-				if value, ok := bfd1["transmit_interval"].(int); ok {
-					transmitInterval = value
-				}
-				if value, ok := bfd1["receive_interval"].(int); ok {
-					receiveInterval = value
-				}
-				if value, ok := bfd1["multiplier"].(int); ok {
-					multiplier = value
-				}
-				bfd2 := &goaviatrix.BgpBfdConfig{
-					TransmitInterval: transmitInterval,
-					ReceiveInterval:  receiveInterval,
-					Multiplier:       multiplier,
-				}
-				externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
+				externalDeviceConn.BgpBfdConfig = goaviatrix.CreateBgpBfdConfig(bfd1)
 			}
 		} else {
 			// set the bgp bfd config using the default values
-			bfd := &goaviatrix.BgpBfdConfig{
-				TransmitInterval: defaultBfdTransmitInterval,
-				ReceiveInterval:  defaultBfdReceiveInterval,
-				Multiplier:       defaultBfdMultiplier,
-			}
-			externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd)
+			externalDeviceConn.BgpBfdConfig = &defaultBfdConfig
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
@@ -1016,24 +994,23 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 			return fmt.Errorf("BFD is only supported for BGP connection type")
 		}
 		d.Set("enable_bfd", enable_bfd)
-		if conn.EnableBfd && len(conn.BgpBfdConfig) > 0 {
+		if conn.EnableBfd && conn.BgpBfdConfig != nil {
 			var bgpBfdConfig []map[string]interface{}
-			for _, bfd := range conn.BgpBfdConfig {
-				bfdMap := make(map[string]interface{})
-				bfdMap["transmit_interval"] = defaultBfdTransmitInterval
-				bfdMap["receive_interval"] = defaultBfdReceiveInterval
-				bfdMap["multiplier"] = defaultBfdMultiplier
-				if bfd.TransmitInterval != 0 {
-					bfdMap["transmit_interval"] = bfd.TransmitInterval
-				}
-				if bfd.ReceiveInterval != 0 {
-					bfdMap["receive_interval"] = bfd.ReceiveInterval
-				}
-				if bfd.Multiplier != 0 {
-					bfdMap["multiplier"] = bfd.Multiplier
-				}
-				bgpBfdConfig = append(bgpBfdConfig, bfdMap)
+			bfd := conn.BgpBfdConfig
+			bfdMap := make(map[string]interface{})
+			bfdMap["transmit_interval"] = defaultBfdTransmitInterval
+			bfdMap["receive_interval"] = defaultBfdReceiveInterval
+			bfdMap["multiplier"] = defaultBfdMultiplier
+			if bfd.TransmitInterval != 0 {
+				bfdMap["transmit_interval"] = bfd.TransmitInterval
 			}
+			if bfd.ReceiveInterval != 0 {
+				bfdMap["receive_interval"] = bfd.ReceiveInterval
+			}
+			if bfd.Multiplier != 0 {
+				bfdMap["multiplier"] = bfd.Multiplier
+			}
+			bgpBfdConfig = append(bgpBfdConfig, bfdMap)
 			d.Set("bgp_bfd", bgpBfdConfig)
 		}
 
@@ -1248,42 +1225,22 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 		if !ok {
 			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
-		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
+		var bgpBfdConfigList goaviatrix.BgpBfdConfig
 		// Update the BGP BFD config if bfd is enabled and config has changed
 		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
 			for _, v := range bgpBfdConfig {
 				bfdConfig := v.(map[string]interface{})
-				transmitInterval, ok := bfdConfig["transmit_interval"].(int)
-				if !ok {
-					transmitInterval = defaultBfdTransmitInterval
-				}
-				receiveInterval, ok := bfdConfig["receive_interval"].(int)
-				if !ok {
-					receiveInterval = defaultBfdReceiveInterval
-				}
-				multiplier, ok := bfdConfig["multiplier"].(int)
-				if !ok {
-					multiplier = defaultBfdMultiplier
-				}
-				bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
-					TransmitInterval: transmitInterval,
-					ReceiveInterval:  receiveInterval,
-					Multiplier:       multiplier,
-				})
+				bgpBfdConfigList = *goaviatrix.CreateBgpBfdConfig(bfdConfig)
 			}
 		} else {
 			// set the bgp bfd config using the default values
-			bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
-				TransmitInterval: defaultBfdTransmitInterval,
-				ReceiveInterval:  defaultBfdReceiveInterval,
-				Multiplier:       defaultBfdMultiplier,
-			})
+			bgpBfdConfigList = defaultBfdConfig
 		}
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			GwName:         d.Get("gw_name").(string),
 			ConnectionName: d.Get("connection_name").(string),
 			EnableBfd:      d.Get("enable_bfd").(bool),
-			BgpBfdConfig:   bgpBfdConfigList,
+			BgpBfdConfig:   &bgpBfdConfigList,
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -382,6 +382,43 @@ func resourceAviatrixSpokeExternalDeviceConn() *schema.Resource {
 				ForceNew:    true,
 				Description: "Backup Local LAN IP.",
 			},
+			"enable_bfd": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable BGP BFD connection.",
+			},
+			"bgp_bfd": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "BGP BFD configuration details applied to a BGP session.",
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"transmit_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "BFD transmit interval in milliseconds.",
+							ValidateFunc: validation.IntBetween(10, 60000),
+							Default:      defaultBfdTransmitInterval,
+						},
+						"receive_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "BFD receive interval in milliseconds.",
+							ValidateFunc: validation.IntBetween(10, 60000),
+							Default:      defaultBfdReceiveInterval,
+						},
+						"multiplier": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Description:  "BFD detection multiplier.",
+							ValidateFunc: validation.IntBetween(2, 255),
+							Default:      defaultBfdMultiplier,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -670,6 +707,58 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 		return fmt.Errorf("failed to create Aviatrix external device connection: %s", err)
 	}
 
+	enableBFD, ok := d.Get("enable_bfd").(bool)
+	if !ok {
+		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
+	}
+	externalDeviceConn.EnableBfd = enableBFD
+	// set the bgp bfd config details only if the user has enabled BFD
+	if enableBFD {
+		bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
+		if !ok {
+			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+		}
+		// set bgp bfd using the config details provided by the user
+		if len(bgp_bfd) > 0 {
+			for _, bfd0 := range bgp_bfd {
+				bfd1, ok := bfd0.(map[string]interface{})
+				if !ok {
+					return diag.Errorf("expected bgp_bfd to be a map, but got %T", bfd0)
+				}
+				transmitInterval := defaultBfdTransmitInterval
+				receiveInterval := defaultBfdReceiveInterval
+				multiplier := defaultBfdMultiplier
+				if value, ok := bfd1["transmit_interval"].(int); ok {
+					transmitInterval = value
+				}
+				if value, ok := bfd1["receive_interval"].(int); ok {
+					receiveInterval = value
+				}
+				if value, ok := bfd1["multiplier"].(int); ok {
+					multiplier = value
+				}
+				bfd2 := &goaviatrix.BgpBfdConfig{
+					TransmitInterval: transmitInterval,
+					ReceiveInterval:  receiveInterval,
+					Multiplier:       multiplier,
+				}
+				externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd2)
+			}
+		} else {
+			// set the bgp bfd config using the default values
+			bfd := &goaviatrix.BgpBfdConfig{
+				TransmitInterval: defaultBfdTransmitInterval,
+				ReceiveInterval:  defaultBfdReceiveInterval,
+				Multiplier:       defaultBfdMultiplier,
+			}
+			externalDeviceConn.BgpBfdConfig = append(externalDeviceConn.BgpBfdConfig, bfd)
+		}
+		err := client.EditConnectionBgpBfd(externalDeviceConn)
+		if err != nil {
+			return diag.Errorf("could not update BGP BFD config: %v", err)
+		}
+	}
+
 	if d.Get("enable_event_triggered_ha").(bool) {
 		if err := client.EnableSite2CloudEventTriggeredHA(externalDeviceConn.VpcID, externalDeviceConn.ConnectionName); err != nil {
 			return fmt.Errorf("could not enable event triggered HA for external device conn after create: %v", err)
@@ -916,6 +1005,32 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 			d.Set("approved_cidrs", nil)
 		}
 
+		enable_bfd, ok := d.Get("enable_bfd").(bool)
+		if !ok {
+			return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
+		}
+		d.Set("enable_bfd", enable_bfd)
+		if conn.EnableBfd && len(conn.BgpBfdConfig) > 0 {
+			var bgpBfdConfig []map[string]interface{}
+			for _, bfd := range conn.BgpBfdConfig {
+				bfdMap := make(map[string]interface{})
+				bfdMap["transmit_interval"] = defaultBfdTransmitInterval
+				bfdMap["receive_interval"] = defaultBfdReceiveInterval
+				bfdMap["multiplier"] = defaultBfdMultiplier
+				if bfd.TransmitInterval != 0 {
+					bfdMap["transmit_interval"] = bfd.TransmitInterval
+				}
+				if bfd.ReceiveInterval != 0 {
+					bfdMap["receive_interval"] = bfd.ReceiveInterval
+				}
+				if bfd.Multiplier != 0 {
+					bfdMap["multiplier"] = bfd.Multiplier
+				}
+				bgpBfdConfig = append(bgpBfdConfig, bfdMap)
+			}
+			d.Set("bgp_bfd", bgpBfdConfig)
+		}
+
 		if conn.EnableIkev2 == "enabled" {
 			d.Set("enable_ikev2", true)
 		} else {
@@ -1110,6 +1225,71 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 		err := client.EditSpokeExternalDeviceConnASPathPrepend(externalDeviceConn, prependASPath)
 		if err != nil {
 			return fmt.Errorf("could not update prepend_as_path: %v", err)
+		}
+	}
+
+	enableBfd, ok := d.Get("enable_bfd").(bool)
+	if !ok {
+		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
+	}
+	if enableBfd {
+		// get the new BGP BFD config
+		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
+		if !ok {
+			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+		}
+		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
+		// Update the BGP BFD config if bfd is enabled and config has changed
+		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
+			for _, v := range bgpBfdConfig {
+				bfdConfig := v.(map[string]interface{})
+				transmitInterval, ok := bfdConfig["transmit_interval"].(int)
+				if !ok {
+					transmitInterval = defaultBfdTransmitInterval
+				}
+				receiveInterval, ok := bfdConfig["receive_interval"].(int)
+				if !ok {
+					receiveInterval = defaultBfdReceiveInterval
+				}
+				multiplier, ok := bfdConfig["multiplier"].(int)
+				if !ok {
+					multiplier = defaultBfdMultiplier
+				}
+				bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
+					TransmitInterval: transmitInterval,
+					ReceiveInterval:  receiveInterval,
+					Multiplier:       multiplier,
+				})
+			}
+		} else {
+			// set the bgp bfd config using the default values
+			bgpBfdConfigList = append(bgpBfdConfigList, &goaviatrix.BgpBfdConfig{
+				TransmitInterval: defaultBfdTransmitInterval,
+				ReceiveInterval:  defaultBfdReceiveInterval,
+				Multiplier:       defaultBfdMultiplier,
+			})
+		}
+		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
+			GwName:         d.Get("gw_name").(string),
+			ConnectionName: d.Get("connection_name").(string),
+			EnableBfd:      d.Get("enable_bfd").(bool),
+			BgpBfdConfig:   bgpBfdConfigList,
+		}
+		err := client.EditConnectionBgpBfd(externalDeviceConn)
+		if err != nil {
+			return diag.Errorf("could not update BGP BFD config: %v", err)
+		}
+	} else {
+		if d.HasChange("enable_bfd") {
+			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
+				GwName:         d.Get("gw_name").(string),
+				ConnectionName: d.Get("connection_name").(string),
+				EnableBfd:      d.Get("enable_bfd").(bool),
+			}
+			err := client.EditConnectionBgpBfd(externalDeviceConn)
+			if err != nil {
+				return diag.Errorf("could not disable BGP BFD config: %v", err)
+			}
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -709,21 +709,21 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 
 	enableBFD, ok := d.Get("enable_bfd").(bool)
 	if !ok {
-		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
+		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
 	externalDeviceConn.EnableBfd = enableBFD
 	// set the bgp bfd config details only if the user has enabled BFD
 	if enableBFD {
 		bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
 		if !ok {
-			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
 		// set bgp bfd using the config details provided by the user
 		if len(bgp_bfd) > 0 {
 			for _, bfd0 := range bgp_bfd {
 				bfd1, ok := bfd0.(map[string]interface{})
 				if !ok {
-					return diag.Errorf("expected bgp_bfd to be a map, but got %T", bfd0)
+					return fmt.Errorf("expected bgp_bfd to be a map, but got %T", bfd0)
 				}
 				transmitInterval := defaultBfdTransmitInterval
 				receiveInterval := defaultBfdReceiveInterval
@@ -755,7 +755,7 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
-			return diag.Errorf("could not update BGP BFD config: %v", err)
+			return fmt.Errorf("could not update BGP BFD config: %v", err)
 		}
 	}
 
@@ -1007,7 +1007,7 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 
 		enable_bfd, ok := d.Get("enable_bfd").(bool)
 		if !ok {
-			return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
+			return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 		}
 		d.Set("enable_bfd", enable_bfd)
 		if conn.EnableBfd && len(conn.BgpBfdConfig) > 0 {
@@ -1230,13 +1230,13 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 
 	enableBfd, ok := d.Get("enable_bfd").(bool)
 	if !ok {
-		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
+		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
 	if enableBfd {
 		// get the new BGP BFD config
 		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
 		if !ok {
-			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
 		}
 		var bgpBfdConfigList []*goaviatrix.BgpBfdConfig
 		// Update the BGP BFD config if bfd is enabled and config has changed
@@ -1277,7 +1277,7 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
-			return diag.Errorf("could not update BGP BFD config: %v", err)
+			return fmt.Errorf("could not update BGP BFD config: %v", err)
 		}
 	} else {
 		if d.HasChange("enable_bfd") {
@@ -1288,7 +1288,7 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 			}
 			err := client.EditConnectionBgpBfd(externalDeviceConn)
 			if err != nil {
-				return diag.Errorf("could not disable BGP BFD config: %v", err)
+				return fmt.Errorf("could not disable BGP BFD config: %v", err)
 			}
 		}
 	}

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -1232,8 +1232,8 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 				bfdConfig := v.(map[string]interface{})
 				bgpBfdConfigList = *goaviatrix.CreateBgpBfdConfig(bfdConfig)
 			}
-		} else {
-			// set the bgp bfd config using the default values
+		} else if len(bgpBfdConfig) == 0 {
+			// set the bgp bfd config using the default values if bgd is enabled and no config is provided
 			bgpBfdConfigList = defaultBfdConfig
 		}
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -1216,38 +1216,33 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 	if !ok {
 		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
-	if enableBfd && connType != "bgp" {
-		return fmt.Errorf("BFD is only supported for BGP connection type")
+	if connType != "bgp" && enableBfd {
+		return fmt.Errorf("cannot enable BFD for non-BGP connection")
 	}
-	if enableBfd {
-		// get the new BGP BFD config
-		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
-		if !ok {
-			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
-		}
-		var bgpBfdConfigList goaviatrix.BgpBfdConfig
-		// Update the BGP BFD config if bfd is enabled and config has changed
-		if len(bgpBfdConfig) > 0 && d.HasChange("bgp_bfd") {
-			for _, v := range bgpBfdConfig {
-				bfdConfig := v.(map[string]interface{})
-				bgpBfdConfigList = *goaviatrix.CreateBgpBfdConfig(bfdConfig)
+	// get the BGP BFD config
+	bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
+	if !ok {
+		return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+	}
+	if d.HasChange("enable_bfd") || d.HasChange("bgp_bfd") {
+		// bgp bfd is enabled
+		if enableBfd {
+			bgpBfd := goaviatrix.GetUpdatedBgpBfdConfig(bgpBfdConfig)
+			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
+				GwName:         d.Get("gw_name").(string),
+				ConnectionName: d.Get("connection_name").(string),
+				EnableBfd:      d.Get("enable_bfd").(bool),
+				BgpBfdConfig:   &bgpBfd,
 			}
-		} else if len(bgpBfdConfig) == 0 {
-			// set the bgp bfd config using the default values if bgd is enabled and no config is provided
-			bgpBfdConfigList = defaultBfdConfig
-		}
-		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
-			GwName:         d.Get("gw_name").(string),
-			ConnectionName: d.Get("connection_name").(string),
-			EnableBfd:      d.Get("enable_bfd").(bool),
-			BgpBfdConfig:   &bgpBfdConfigList,
-		}
-		err := client.EditConnectionBgpBfd(externalDeviceConn)
-		if err != nil {
-			return fmt.Errorf("could not update BGP BFD config: %v", err)
-		}
-	} else {
-		if d.HasChange("enable_bfd") {
+			err := client.EditConnectionBgpBfd(externalDeviceConn)
+			if err != nil {
+				return fmt.Errorf("could not update BGP BFD config: %v", err)
+			}
+		} else {
+			// bgp bfd is disabled
+			if len(bgpBfdConfig) > 0 {
+				return fmt.Errorf("bgp_bfd config can't be set when BFD is disabled")
+			}
 			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 				GwName:         d.Get("gw_name").(string),
 				ConnectionName: d.Get("connection_name").(string),

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -711,6 +711,9 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 	if !ok {
 		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
+	if enableBFD && externalDeviceConn.ConnectionType != "bgp" {
+		return fmt.Errorf("BFD is only supported for BGP connection type")
+	}
 	externalDeviceConn.EnableBfd = enableBFD
 	// set the bgp bfd config details only if the user has enabled BFD
 	if enableBFD {
@@ -1009,6 +1012,9 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 		if !ok {
 			return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 		}
+		if enable_bfd && conn.ConnectionType != "bgp" {
+			return fmt.Errorf("BFD is only supported for BGP connection type")
+		}
 		d.Set("enable_bfd", enable_bfd)
 		if conn.EnableBfd && len(conn.BgpBfdConfig) > 0 {
 			var bgpBfdConfig []map[string]interface{}
@@ -1093,6 +1099,7 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 
 	gwName := d.Get("gw_name").(string)
 	connName := d.Get("connection_name").(string)
+	connType := d.Get("connection_type").(string)
 
 	if d.HasChange("enable_learned_cidrs_approval") {
 		enableLearnedCIDRApproval := d.Get("enable_learned_cidrs_approval").(bool)
@@ -1231,6 +1238,9 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 	enableBfd, ok := d.Get("enable_bfd").(bool)
 	if !ok {
 		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
+	}
+	if enableBfd && connType != "bgp" {
+		return fmt.Errorf("BFD is only supported for BGP connection type")
 	}
 	if enableBfd {
 		// get the new BGP BFD config

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
@@ -41,6 +41,10 @@ func TestAccAviatrixSpokeExternalDeviceConn_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bgp_local_as_num", "123"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_remote_as_num", "345"),
 					resource.TestCheckResourceAttr(resourceName, "remote_gateway_ip", "172.12.13.14"),
+					resource.TestCheckResourceAttr(resourceName, "enable_bfd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd.0.transmit_interval", "400"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd.0.receive_interval", "400"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_bfd.0.multiplier", "5"),
 				),
 			},
 			{
@@ -80,6 +84,12 @@ resource "aviatrix_spoke_external_device_conn" "test" {
 	bgp_local_as_num  = "123"
 	bgp_remote_as_num = "345"
 	remote_gateway_ip = "172.12.13.14"
+	enable_bfd = true
+	bgp_bfd {
+		transmit_interval = 400
+		receive_interval = 400
+		multiplier = 5
+	}
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		rName, os.Getenv("AWS_VPC_ID"), os.Getenv("AWS_REGION"), os.Getenv("AWS_SUBNET"), rName)

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -1364,8 +1364,8 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 				bfdConfig := v.(map[string]interface{})
 				bgpBfdConfigList = *goaviatrix.CreateBgpBfdConfig(bfdConfig)
 			}
-		} else {
-			// set the bgp bfd config using the default values
+		} else if len(bgpBfdConfig) == 0 {
+			// set the bgp bfd config using the default values if bgd is enabled and no config is provided
 			bgpBfdConfigList = defaultBfdConfig
 		}
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -744,7 +744,6 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 	}
 
 	if d.Get("connection_type").(string) != "bgp" && enableBFD {
-		enableBFD = false
 		return fmt.Errorf("BFD is only supported for BGP connection")
 	}
 	externalDeviceConn.EnableBfd = enableBFD
@@ -1110,7 +1109,7 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 			return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 		}
 		if conn.ConnectionType != "bgp" && enable_bfd {
-			enable_bfd = false
+			return fmt.Errorf("BFD is only supported for BGP connection")
 		}
 		d.Set("enable_bfd", enable_bfd)
 		if enable_bfd && len(conn.BgpBfdConfig) > 0 {
@@ -1365,7 +1364,7 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
 
-	if conn.ConnectionType != "bgp" && enableBfd {
+	if connType != "bgp" && enableBfd {
 		return fmt.Errorf("cannot enable BFD for non-BGP connection")
 	}
 	if enableBfd {

--- a/docs/resources/aviatrix_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_spoke_external_device_conn.md
@@ -38,6 +38,24 @@ resource "aviatrix_spoke_external_device_conn" "test" {
 }
 ```
 ```hcl
+# Create a BGP BFD enabled Aviatrix Spoke External Device Connection
+resource "aviatrix_spoke_external_device_conn" "test" {
+  vpc_id                   = "vpc-abcd1234"
+  connection_name          = "my_conn"
+  gw_name                  = "spokeGw"
+  connection_type          = "static"
+  remote_subnet            = "12.0.0.0/24"
+  remote_gateway_ip        = "172.12.13.14"
+  backup_remote_gateway_ip = "172.12.13.15"
+  enable_bfd = true
+  bgp_bfd {
+    transmit_interval = 400
+    receive_interval = 400
+    multiplier = 5
+  }
+}
+```
+```hcl
 # Create a bgp/GRE Aviatrix Spoke External Device Connection with jumbo frame enabled and ha enabled
 resource "aviatrix_transit_external_device_conn" "test" {
   vpc_id                    = "vpc-abcd1234"
@@ -128,6 +146,11 @@ The following arguments are supported:
 * `bgp_local_as_num` - (Optional) BGP local ASN (Autonomous System Number). Integer between 1-4294967294. Required for 'bgp' connection.
 * `bgp_remote_as_num` - (Optional) BGP remote ASN (Autonomous System Number). Integer between 1-4294967294. Required for 'bgp' connection.
 * `remote_subnet` - (Optional) Remote CIDRs joined as a string with ','. Required for a 'static' type connection.
+* `enable_bfd` - (Optional) Required for BGP BFD over IPsec. Valid values: true, false. Default: false.
+* `bgp_bfd` - (Optional) BGP BFD configuration applied to a BGP session. If config is no provided then default values are applied for the connection.
+  * `transmit_interval` - (Optional) BFD transmit interval in ms. Valid values between 10 to 60000. Default: 300.
+  * `receive_interval` - (Optional) BFD receive interval in ms. Valid values between 10 to 60000. Default: 300.
+  * `multiplier` - (Optional) BFD detection multiplier. Valid values between 2 to 255. Default: 3.
 
 ### HA
 * `ha_enabled` - (Optional) Set as true if there are two external devices.

--- a/goaviatrix/edge_external_device_conn.go
+++ b/goaviatrix/edge_external_device_conn.go
@@ -46,14 +46,14 @@ type EdgeExternalDeviceConn struct {
 	Phase1LocalIdentifier  string
 	Phase1RemoteIdentifier string
 	PrependAsPath          string
-	BgpMd5Key              string          `json:"bgp_md5_key,omitempty"`
-	BackupBgpMd5Key        string          `json:"backup_bgp_md5_key,omitempty"`
-	AuthType               string          `json:"auth_type,omitempty"`
-	EnableEdgeUnderlay     bool            `json:"edge_underlay,omitempty"`
-	RemoteCloudType        string          `json:"remote_cloud_type,omitempty"`
-	BgpMd5KeyChanged       bool            `json:"bgp_md5_key_changed,omitempty"`
-	BgpBfdConfig           []*BgpBfdConfig `json:"bgp_bfd,omitempty"`
-	EnableBfd              bool            `json:"enable_bfd,omitempty"`
+	BgpMd5Key              string        `json:"bgp_md5_key,omitempty"`
+	BackupBgpMd5Key        string        `json:"backup_bgp_md5_key,omitempty"`
+	AuthType               string        `json:"auth_type,omitempty"`
+	EnableEdgeUnderlay     bool          `json:"edge_underlay,omitempty"`
+	RemoteCloudType        string        `json:"remote_cloud_type,omitempty"`
+	BgpMd5KeyChanged       bool          `json:"bgp_md5_key_changed,omitempty"`
+	BgpBfdConfig           *BgpBfdConfig `json:"bgp_bfd,omitempty"`
+	EnableBfd              bool          `json:"enable_bfd,omitempty"`
 }
 
 func (c *Client) CreateEdgeExternalDeviceConn(edgeExternalDeviceConn *EdgeExternalDeviceConn) (string, error) {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -15,6 +15,12 @@ const (
 	defaultBfdMultiplier       = 3
 )
 
+var defaultBfdConfig = BgpBfdConfig{
+	TransmitInterval: defaultBfdTransmitInterval,
+	ReceiveInterval:  defaultBfdReceiveInterval,
+	Multiplier:       defaultBfdMultiplier,
+}
+
 type ExternalDeviceConn struct {
 	Action                 string `form:"action,omitempty"`
 	CID                    string `form:"CID,omitempty"`
@@ -395,6 +401,21 @@ func CreateBgpBfdConfig(bfd map[string]interface{}) *BgpBfdConfig {
 		Multiplier:       multiplier,
 	}
 	return bfd2
+}
+
+func GetUpdatedBgpBfdConfig(bgpBfdConfig []interface{}) BgpBfdConfig {
+	var bgpBfd BgpBfdConfig
+	if len(bgpBfdConfig) > 0 {
+		// get the user provided bgp bfd config
+		for _, v := range bgpBfdConfig {
+			bfdConfig := v.(map[string]interface{})
+			bgpBfd = *CreateBgpBfdConfig(bfdConfig)
+		}
+	} else if len(bgpBfdConfig) == 0 {
+		// use default bgp bfd config
+		bgpBfd = defaultBfdConfig
+	}
+	return bgpBfd
 }
 
 func (c *Client) EditTransitExternalDeviceConnASPathPrepend(externalDeviceConn *ExternalDeviceConn, prependASPath []string) error {


### PR DESCRIPTION
- Updating the spoke external connection with bgp_bfd config
- Adding the check for enable_bfd only for bgp connections
Link - https://aviatrix.atlassian.net/browse/AVX-58386

```
resource "aviatrix_spoke_external_device_conn" "test_spoke_conn" {
	vpc_id            = "vpc-0c9ec6eeb879174bb"
	connection_name   = "test_spoke_conn"
	gw_name           = "cnsvf-aws-spoke-1"
	connection_type   = "bgp"
	bgp_local_as_num  = "65078"
	bgp_remote_as_num = "65079"
	remote_gateway_ip = "35.167.229.132"
        enable_bfd = true
        bgp_bfd {
          transmit_interval = 400
          receive_interval = 400
          multiplier = 5
        }
}
```