### PR TITLE
AVX-58466: Lift restriction for Palo Alto to use user_data

### DIFF
--- a/aviatrix/resource_aviatrix_firewall_instance.go
+++ b/aviatrix/resource_aviatrix_firewall_instance.go
@@ -399,9 +399,6 @@ func resourceAviatrixFirewallInstanceCreate(d *schema.ResourceData, meta interfa
 			return fmt.Errorf("advanced option 'iam_role' is only supported for AWS provider, please set to empty")
 		}
 	}
-	if firewallInstance.UserData != "" && strings.HasPrefix(firewallInstance.FirewallImage, "Palo Alto Networks") {
-		return fmt.Errorf("advanced option of 'user_data' is only supported for Check Point Series and Fortinet FortiGate Series, not for %s", firewallInstance.FirewallImage)
-	}
 	if firewallInstance.StorageAccessKey != "" || firewallInstance.FileShareFolder != "" || firewallInstance.ShareDirectory != "" {
 		if !strings.HasPrefix(firewallInstance.FirewallImage, "Palo Alto Networks") || !goaviatrix.IsCloudType(cloudType, goaviatrix.AzureArmRelatedCloudTypes) {
 			return fmt.Errorf("advanced options of 'storage_access_key', 'file_share_folder' and 'share_directory' are only supported for Azure and Palo Alto Networks VM-Series")

--- a/docs/resources/aviatrix_firewall_instance.md
+++ b/docs/resources/aviatrix_firewall_instance.md
@@ -432,7 +432,7 @@ Valid `firewall_image` values:
 * `container_folder` - (Optional) Advanced option. Container folder. Applicable to Azure or AzureGov and Fortinet Series deployment only.
 * `sas_url_config` - (Optional) Advanced option. SAS URL Config. Applicable to Azure or AzureGov and Fortinet Series deployment only.
 * `sas_url_license` - (Optional) Advanced option. SAS URL License. Applicable to Azure or AzureGov and Fortinet Series deployment only.
-* `user_data` - (Optional) Advanced option. User Data. Applicable to Check Point Series and Fortinet Series deployment only. Type: String.
+* `user_data` - (Optional) Advanced option. User Data. Type: String.
 
 ### Misc.
 * `tags` - (Optional) Mapping of key value pairs of tags for a firewall instance. Only available for AWS, AWSGov, GCP and Azure firewall instances. For AWS, AWSGov and Azure allowed characters are: letters, spaces, and numbers plus the following special characters: + - = . _ : @. For GCP allowed characters are: lowercase letters, numbers, "-" and "_". Example: {"key1" = "value1", "key2" = "value2"}.


### PR DESCRIPTION
Currently, the provider blocks usage of user_data for bootstrapping PANW instances. This PR lifts that restriction, allowing PANW instanced to be bootstrapped using user_data. The UI and API already allow for this and this PR provides parity for Terraform.