### PR TITLE
AVX-58410 Renaming bgp_bfd_polling_time with bgp_neighbor_status_polling_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 
 
 ### Multi-Cloud Transit:
-1. Added new attribute ``bgp_bfd_polling_time`` to support the bgp bfd configuration in the following resources.
+1. Added new attribute ``bgp_neighbor_status_polling_time`` to support the bgp bfd configuration in the following resources.
     - **aviatrix_edge_csp**
     - **aviatrix_edge_equinix**
     - **aviatrix_edge_gateway_selfmanaged**

--- a/aviatrix/resource_aviatrix_edge_csp.go
+++ b/aviatrix/resource_aviatrix_edge_csp.go
@@ -156,12 +156,12 @@ func resourceAviatrixEdgeCSP() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
-			"bgp_bfd_polling_time": {
+			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      defaultBgpBfdPollingTime,
+				Default:      defaultBgpNeighborStatusPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
@@ -400,7 +400,7 @@ func marshalEdgeCSPInput(d *schema.ResourceData) *goaviatrix.EdgeCSP {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
-		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_neighbor_status_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -567,10 +567,10 @@ func resourceAviatrixEdgeCSPCreate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	if edgeCSP.BgpBfdPollingTime >= 1 && edgeCSP.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+	if edgeCSP.BgpBfdPollingTime >= 1 && edgeCSP.BgpBfdPollingTime != defaultBgpNeighborStatusPollingTime {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time after Edge CSP creation: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time after Edge CSP creation: %v", err)
 		}
 	}
 
@@ -710,7 +710,7 @@ func resourceAviatrixEdgeCSPRead(ctx context.Context, d *schema.ResourceData, me
 
 	d.Set("enable_preserve_as_path", edgeCSPResp.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeCSPResp.BgpPollingTime)
-	d.Set("bgp_bfd_polling_time", edgeCSPResp.BgpBfdPollingTime)
+	d.Set("bgp_neighbor_status_polling_time", edgeCSPResp.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeCSPResp.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeCSPResp.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeCSPResp.EnableJumboFrame)
@@ -906,10 +906,10 @@ func resourceAviatrixEdgeCSPUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
+	if d.HasChange("bgp_neighbor_status_polling_time") {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time during Edge CSP update: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time during Edge CSP update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_csp_test.go
+++ b/aviatrix/resource_aviatrix_edge_csp_test.go
@@ -40,7 +40,7 @@ func TestAccAviatrixEdgeCSP_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
-					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
 			},
 			{
@@ -61,14 +61,14 @@ resource "aviatrix_account" "test_account" {
 	edge_csp_password = "%s"
 }
 resource "aviatrix_edge_csp" "test" {
-	account_name         = aviatrix_account.test_account.account_name
-	gw_name              = "%s"
-	site_id              = "%s"
- 	project_uuid         = "%s"
- 	compute_node_uuid    = "%s"
- 	template_uuid        = "%s"
-	bgp_polling_time     = 50
-	bgp_bfd_polling_time = 5
+	account_name                     = aviatrix_account.test_account.account_name
+	gw_name                          = "%s"
+	site_id                          = "%s"
+ 	project_uuid                     = "%s"
+ 	compute_node_uuid                = "%s"
+ 	template_uuid                    = "%s"
+	bgp_polling_time                 = 50
+	bgp_neighbor_status_polling_time = 5
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_equinix.go
+++ b/aviatrix/resource_aviatrix_edge_equinix.go
@@ -148,12 +148,12 @@ func resourceAviatrixEdgeEquinix() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
-			"bgp_bfd_polling_time": {
+			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      defaultBgpBfdPollingTime,
+				Default:      defaultBgpNeighborStatusPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
@@ -361,7 +361,7 @@ func marshalEdgeEquinixInput(d *schema.ResourceData) *goaviatrix.EdgeEquinix {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
-		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_neighbor_status_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -529,10 +529,10 @@ func resourceAviatrixEdgeEquinixCreate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	if edgeEquinix.BgpBfdPollingTime >= 1 && edgeEquinix.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+	if edgeEquinix.BgpBfdPollingTime >= 1 && edgeEquinix.BgpBfdPollingTime != defaultBgpNeighborStatusPollingTime {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeEquinix.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time after Edge Equinix creation: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time after Edge Equinix creation: %v", err)
 		}
 	}
 
@@ -669,7 +669,7 @@ func resourceAviatrixEdgeEquinixRead(ctx context.Context, d *schema.ResourceData
 
 	d.Set("enable_preserve_as_path", edgeEquinixResp.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeEquinixResp.BgpPollingTime)
-	d.Set("bgp_bfd_polling_time", edgeEquinixResp.BgpBfdPollingTime)
+	d.Set("bgp_neighbor_status_polling_time", edgeEquinixResp.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeEquinixResp.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeEquinixResp.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeEquinixResp.EnableJumboFrame)
@@ -862,10 +862,10 @@ func resourceAviatrixEdgeEquinixUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
+	if d.HasChange("bgp_neighbor_status_polling_time") {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeEquinix.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time during Edge Equinix update: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time during Edge Equinix update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_equinix_test.go
+++ b/aviatrix/resource_aviatrix_edge_equinix_test.go
@@ -42,7 +42,7 @@ func TestAccAviatrixEdgeEquinix_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
-					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
 			},
 			{
@@ -63,12 +63,12 @@ resource "aviatrix_account" "test" {
 	edge_equinix_username = "%s"
 }
 resource "aviatrix_edge_equinix" "test" {
-	account_name           = aviatrix_account.test_account.account_name
-	gw_name                = "%s"
-	site_id                = "%s"
-	ztp_file_download_path = "%s"
-	bgp_polling_time       = 50
-	bgp_bfd_polling_time   = 5
+	account_name                       = aviatrix_account.test_account.account_name
+	gw_name                            = "%s"
+	site_id                            = "%s"
+	ztp_file_download_path             = "%s"
+	bgp_polling_time                   = 50
+	bgp_neighbor_status_polling_time   = 5
 	
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -148,12 +148,12 @@ func resourceAviatrixEdgeGatewaySelfmanaged() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
-			"bgp_bfd_polling_time": {
+			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      defaultBgpBfdPollingTime,
+				Default:      defaultBgpNeighborStatusPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
@@ -328,7 +328,7 @@ func marshalEdgeGatewaySelfmanagedInput(d *schema.ResourceData) *goaviatrix.Edge
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
-		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_neighbor_status_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -483,10 +483,10 @@ func resourceAviatrixEdgeGatewaySelfmanagedCreate(ctx context.Context, d *schema
 		}
 	}
 
-	if edgeSpoke.BgpBfdPollingTime >= 1 && edgeSpoke.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+	if edgeSpoke.BgpBfdPollingTime >= 1 && edgeSpoke.BgpBfdPollingTime != defaultBgpNeighborStatusPollingTime {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time after Edge Gateway Selfmanaged creation: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time after Edge Gateway Selfmanaged creation: %v", err)
 		}
 	}
 
@@ -613,7 +613,7 @@ func resourceAviatrixEdgeGatewaySelfmanagedRead(ctx context.Context, d *schema.R
 
 	d.Set("enable_preserve_as_path", edgeSpoke.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeSpoke.BgpPollingTime)
-	d.Set("bgp_bfd_polling_time", edgeSpoke.BgpBfdPollingTime)
+	d.Set("bgp_neighbor_status_polling_time", edgeSpoke.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeSpoke.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeSpoke.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeSpoke.EnableJumboFrame)
@@ -798,10 +798,10 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
+	if d.HasChange("bgp_neighbor_status_polling_time") {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time during Edge Gateway Selfmanaged update: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time during Edge Gateway Selfmanaged update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
@@ -40,7 +40,7 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
-					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
 			},
 			{
@@ -56,12 +56,12 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 func testAccEdgeGatewaySelfmanagedBasic(gwName, siteId, path string) string {
 	return fmt.Sprintf(`
 resource "aviatrix_edge_gateway_selfmanaged" "test" {
-	gw_name                = "%s"
-	site_id                = "%s"
-	ztp_file_type          = "iso"
-	ztp_file_download_path = "%s"
-	bgp_polling_time       = 50
-	bgp_bfd_polling_time   = 5
+	gw_name                            = "%s"
+	site_id                            = "%s"
+	ztp_file_type                      = "iso"
+	ztp_file_download_path             = "%s"
+	bgp_polling_time                   = 50
+	bgp_neighbor_status_polling_time   = 5
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_neo.go
+++ b/aviatrix/resource_aviatrix_edge_neo.go
@@ -552,10 +552,10 @@ func resourceAviatrixEdgeNEOCreate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	if edgeNEO.BgpBfdPollingTime >= 1 && edgeNEO.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+	if edgeNEO.BgpBfdPollingTime >= 1 && edgeNEO.BgpBfdPollingTime != defaultBgpNeighborStatusPollingTime {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time after Edge NEO creation: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time after Edge NEO creation: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_neo_test.go
+++ b/aviatrix/resource_aviatrix_edge_neo_test.go
@@ -41,7 +41,7 @@ func TestAccAviatrixEdgeNEO_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
-					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
 			},
 			{
@@ -66,16 +66,16 @@ resource "aviatrix_edge_neo_device_onboarding" "test" {
 	hardware_model = "%s"
 }
 resource "aviatrix_edge_neo" "test" {
-	account_name               = aviatrix_account.test.account_name
-	gw_name                    = "%s"
-	site_id                    = "%s"
-	device_id                  = aviatrix_edge_neo_device_onboarding.test.device_id
-	gw_size                    = "small"
-	bgp_polling_time           = 50
-	bgp_bfd_polling_time       = 5
-	management_interface_names = ["eth2"]
-	lan_interface_names        = ["eth1"]
-	wan_interface_names        = ["eth0"]
+	account_name                     = aviatrix_account.test.account_name
+	gw_name                          = "%s"
+	site_id                          = "%s"
+	device_id                        = aviatrix_edge_neo_device_onboarding.test.device_id
+	gw_size                          = "small"
+	bgp_polling_time                 = 50
+	bgp_neighbor_status_polling_time = 5
+	management_interface_names       = ["eth2"]
+	lan_interface_names              = ["eth1"]
+	wan_interface_names              = ["eth0"]
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -150,12 +150,12 @@ func resourceAviatrixEdgePlatform() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
-			"bgp_bfd_polling_time": {
+			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      defaultBgpPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
@@ -391,7 +391,7 @@ func marshalEdgePlatformInput(d *schema.ResourceData) *goaviatrix.EdgeNEO {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
-		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_neighbor_status_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -558,10 +558,10 @@ func resourceAviatrixEdgePlatformCreate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	if edgeNEO.BgpBfdPollingTime >= 1 && edgeNEO.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+	if edgeNEO.BgpBfdPollingTime >= 1 && edgeNEO.BgpBfdPollingTime != defaultBgpNeighborStatusPollingTime {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time after Edge Platform creation: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time after Edge Platform creation: %v", err)
 		}
 	}
 
@@ -700,7 +700,7 @@ func resourceAviatrixEdgePlatformRead(ctx context.Context, d *schema.ResourceDat
 
 	d.Set("enable_preserve_as_path", edgeNEOResp.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeNEOResp.BgpPollingTime)
-	d.Set("bgp_bfd_polling_time", edgeNEOResp.BgpBfdPollingTime)
+	d.Set("bgp_neighbor_status_polling_time", edgeNEOResp.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeNEOResp.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeNEOResp.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeNEOResp.EnableJumboFrame)
@@ -896,10 +896,10 @@ func resourceAviatrixEdgePlatformUpdate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
+	if d.HasChange("bgp_neighbor_status_polling_time") {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeNEO.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time during Edge Platform update: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time during Edge Platform update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_platform_test.go
+++ b/aviatrix/resource_aviatrix_edge_platform_test.go
@@ -41,7 +41,7 @@ func TestAccAviatrixEdgePlatform_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
-					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
 			},
 			{
@@ -66,16 +66,16 @@ resource "aviatrix_edge_platform_device_onboarding" "test" {
 	hardware_model = "%s"
 }
 resource "aviatrix_edge_platform" "test" {
-	account_name               = aviatrix_account.test.account_name
-	gw_name                    = "%s"
-	site_id                    = "%s"
-	device_id                  = aviatrix_edge_platform_device_onboarding.test.device_id
-	gw_size                    = "small"
-	bgp_polling_time           = 50
-	bgp_bfd_polling_time       = 5
-	management_interface_names = ["eth2"]
-	lan_interface_names        = ["eth1"]
-	wan_interface_names        = ["eth0"]
+	account_name                     = aviatrix_account.test.account_name
+	gw_name                          = "%s"
+	site_id                          = "%s"
+	device_id                        = aviatrix_edge_platform_device_onboarding.test.device_id
+	gw_size                          = "small"
+	bgp_polling_time                 = 50
+	bgp_neighbor_status_polling_time = 5
+	management_interface_names       = ["eth2"]
+	lan_interface_names              = ["eth1"]
+	wan_interface_names              = ["eth0"]
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_spoke.go
+++ b/aviatrix/resource_aviatrix_edge_spoke.go
@@ -149,12 +149,12 @@ func resourceAviatrixEdgeSpoke() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
-			"bgp_bfd_polling_time": {
+			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      defaultBgpBfdPollingTime,
+				Default:      defaultBgpNeighborStatusPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
@@ -267,7 +267,7 @@ func marshalEdgeSpokeInput(d *schema.ResourceData) *goaviatrix.EdgeSpoke {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
-		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_neighbor_status_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -396,10 +396,10 @@ func resourceAviatrixEdgeSpokeCreate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	if edgeSpoke.BgpBfdPollingTime >= 1 && edgeSpoke.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+	if edgeSpoke.BgpBfdPollingTime >= 1 && edgeSpoke.BgpBfdPollingTime != defaultBgpNeighborStatusPollingTime {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time after Edge as a Spoke creation: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time after Edge as a Spoke creation: %v", err)
 		}
 	}
 
@@ -526,7 +526,7 @@ func resourceAviatrixEdgeSpokeRead(ctx context.Context, d *schema.ResourceData, 
 
 	d.Set("enable_preserve_as_path", edgeSpoke.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeSpoke.BgpPollingTime)
-	d.Set("bgp_bfd_polling_time", edgeSpoke.BgpBfdPollingTime)
+	d.Set("bgp_neighbor_status_polling_time", edgeSpoke.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeSpoke.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeSpoke.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeSpoke.EnableJumboFrame)
@@ -682,10 +682,10 @@ func resourceAviatrixEdgeSpokeUpdate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
+	if d.HasChange("bgp_neighbor_status_polling_time") {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeSpoke.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time during Edge as a Spoke update: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time during Edge as a Spoke update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_spoke_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_test.go
@@ -40,7 +40,7 @@ func TestAccAviatrixEdgeSpoke_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
-					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
 			},
 			{
@@ -56,12 +56,12 @@ func TestAccAviatrixEdgeSpoke_basic(t *testing.T) {
 func testAccEdgeSpokeBasic(gwName, siteId, path string) string {
 	return fmt.Sprintf(`
 resource "aviatrix_edge_spoke" "test" {
-	gw_name                = "%s"
-	site_id                = "%s"
-	ztp_file_type          = "iso"
-	ztp_file_download_path = "%s"
-	bgp_polling_time       = 50
-	bgp_bfd_polling_time   = 5
+	gw_name                          = "%s"
+	site_id                          = "%s"
+	ztp_file_type                    = "iso"
+	ztp_file_download_path           = "%s"
+	bgp_polling_time                 = 50
+	bgp_neighbor_status_polling_time = 5
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_edge_zededa.go
+++ b/aviatrix/resource_aviatrix_edge_zededa.go
@@ -156,12 +156,12 @@ func resourceAviatrixEdgeZededa() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
-			"bgp_bfd_polling_time": {
+			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      defaultBgpBfdPollingTime,
+				Default:      defaultBgpNeighborStatusPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP BFD route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
@@ -398,7 +398,7 @@ func marshalEdgeZededaInput(d *schema.ResourceData) *goaviatrix.EdgeCSP {
 		SpokeBgpManualAdvertisedCidrs:      getStringSet(d, "spoke_bgp_manual_advertise_cidrs"),
 		EnablePreserveAsPath:               d.Get("enable_preserve_as_path").(bool),
 		BgpPollingTime:                     d.Get("bgp_polling_time").(int),
-		BgpBfdPollingTime:                  d.Get("bgp_bfd_polling_time").(int),
+		BgpBfdPollingTime:                  d.Get("bgp_neighbor_status_polling_time").(int),
 		BgpHoldTime:                        d.Get("bgp_hold_time").(int),
 		EnableEdgeTransitiveRouting:        d.Get("enable_edge_transitive_routing").(bool),
 		EnableJumboFrame:                   d.Get("enable_jumbo_frame").(bool),
@@ -565,10 +565,10 @@ func resourceAviatrixEdgeZededaCreate(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
-	if edgeCSP.BgpBfdPollingTime >= 1 && edgeCSP.BgpBfdPollingTime != defaultBgpBfdPollingTime {
+	if edgeCSP.BgpBfdPollingTime >= 1 && edgeCSP.BgpBfdPollingTime != defaultBgpNeighborStatusPollingTime {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time after Edge Zededa creation: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time after Edge Zededa creation: %v", err)
 		}
 	}
 
@@ -708,7 +708,7 @@ func resourceAviatrixEdgeZededaRead(ctx context.Context, d *schema.ResourceData,
 
 	d.Set("enable_preserve_as_path", edgeCSPResp.EnablePreserveAsPath)
 	d.Set("bgp_polling_time", edgeCSPResp.BgpPollingTime)
-	d.Set("bgp_bfd_polling_time", edgeCSPResp.BgpBfdPollingTime)
+	d.Set("bgp_neighbor_status_polling_time", edgeCSPResp.BgpBfdPollingTime)
 	d.Set("bgp_hold_time", edgeCSPResp.BgpHoldTime)
 	d.Set("enable_edge_transitive_routing", edgeCSPResp.EnableEdgeTransitiveRouting)
 	d.Set("enable_jumbo_frame", edgeCSPResp.EnableJumboFrame)
@@ -904,10 +904,10 @@ func resourceAviatrixEdgeZededaUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
+	if d.HasChange("bgp_neighbor_status_polling_time") {
 		err := client.SetBgpBfdPollingTimeSpoke(gatewayForSpokeFunctions, edgeCSP.BgpBfdPollingTime)
 		if err != nil {
-			return diag.Errorf("could not set bgp bfd polling time during Edge Zededa update: %v", err)
+			return diag.Errorf("could not set bgp neighbor status polling time during Edge Zededa update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_zededa_test.go
+++ b/aviatrix/resource_aviatrix_edge_zededa_test.go
@@ -40,7 +40,7 @@ func TestAccAviatrixEdgeZededa_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
-					resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
 			},
 			{
@@ -61,14 +61,14 @@ resource "aviatrix_account" "test_account" {
 	edge_zededa_password = "%s"
 }
 resource "aviatrix_edge_zededa" "test" {
-	account_name         = aviatrix_account.test_account.account_name
-	gw_name              = "%s"
-	site_id              = "%s"
- 	project_uuid         = "%s"
- 	compute_node_uuid    = "%s"
- 	template_uuid        = "%s"
-	bgp_polling_time     = 50
-	bgp_bfd_polling_time = 5
+	account_name                     = aviatrix_account.test_account.account_name
+	gw_name                          = "%s"
+	site_id                          = "%s"
+ 	project_uuid                     = "%s"
+ 	compute_node_uuid                = "%s"
+ 	template_uuid                    = "%s"
+	bgp_polling_time                 = 50
+	bgp_neighbor_status_polling_time = 5
 
 	interfaces {
 		name          = "eth0"

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -390,12 +390,12 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
-			"bgp_bfd_polling_time": {
+			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      defaultBgpBfdPollingTime,
+				Default:      defaultBgpNeighborStatusPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP BFD route polling time. Unit is in seconds. Valid values are between 1 and 10.",
+				Description:  "BGP neighbor status polling time. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,
@@ -1329,12 +1329,12 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if val, ok := d.GetOk("bgp_bfd_polling_time"); ok {
-		bgp_bfd_polling_time := val.(int)
-		if bgp_bfd_polling_time >= 1 && bgp_bfd_polling_time != defaultBgpBfdPollingTime {
+	if val, ok := d.GetOk("bgp_neighbor_status_polling_time"); ok {
+		bgp_neighbor_status_polling_time := val.(int)
+		if bgp_neighbor_status_polling_time >= 1 && bgp_neighbor_status_polling_time != defaultBgpNeighborStatusPollingTime {
 			err := client.SetBgpBfdPollingTimeSpoke(gateway, val.(int))
 			if err != nil {
-				return fmt.Errorf("could not set bgp bfd polling time: %v", err)
+				return fmt.Errorf("could not set bgp neighbor status polling time: %v", err)
 			}
 		}
 	}
@@ -1500,12 +1500,12 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	if gw.EnableBgp {
 		d.Set("learned_cidrs_approval_mode", gw.LearnedCidrsApprovalMode)
 		d.Set("bgp_polling_time", gw.BgpPollingTime)
-		d.Set("bgp_bdf_polling_time", gw.BgpBfdPollingTime)
+		d.Set("bgp_neighbor_status_polling_time", gw.BgpBfdPollingTime)
 		d.Set("bgp_hold_time", gw.BgpHoldTime)
 	} else {
 		d.Set("learned_cidrs_approval_mode", "gateway")
 		d.Set("bgp_polling_time", 50)
-		d.Set("bgp_bdf_polling_time", defaultBgpBfdPollingTime)
+		d.Set("bgp_neighbor_status_polling_time", defaultBgpNeighborStatusPollingTime)
 		d.Set("bgp_hold_time", 180)
 	}
 	d.Set("tunnel_detection_time", gw.TunnelDetectionTime)
@@ -2667,14 +2667,14 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
-		bgpBfdPollingTime := d.Get("bgp_bfd_polling_time")
+	if d.HasChange("bgp_neighbor_status_polling_time") {
+		bgpBfdPollingTime := d.Get("bgp_neighbor_status_polling_time")
 		gateway := &goaviatrix.SpokeVpc{
 			GwName: d.Get("gw_name").(string),
 		}
 		err := client.SetBgpBfdPollingTimeSpoke(gateway, bgpBfdPollingTime.(int))
 		if err != nil {
-			return fmt.Errorf("could not update bgp bfd polling time during Spoke Gateway update: %v", err)
+			return fmt.Errorf("could not update bgp neighbor status polling time during Spoke Gateway update: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_gateway_test.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway_test.go
@@ -98,7 +98,7 @@ func TestAccAviatrixSpokeGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AWS_REGION")),
 						resource.TestCheckResourceAttr(resourceName, "single_ip_snat", "false"),
 						resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
-						resource.TestCheckResourceAttr(resourceName, "bgp_bfd_polling_time", "5"),
+						resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 					),
 				},
 				{
@@ -233,16 +233,16 @@ resource "aviatrix_account" "test_acc_aws" {
 	aws_secret_key     = "%s"
 }
 resource "aviatrix_spoke_gateway" "test_spoke_gateway" {
-	cloud_type           = 1
-	account_name         = aviatrix_account.test_acc_aws.account_name
-	gw_name              = "tfg-aws-%[1]s"
-	vpc_id               = "%[5]s"
-	vpc_reg              = "%[6]s"
-	gw_size              = "%[7]s"
-	subnet               = "%[8]s"
-	single_ip_snat       = false
-	bgp_polling_time     = 50
-	bgp_bfd_polling_time = 5
+	cloud_type                       = 1
+	account_name                     = aviatrix_account.test_acc_aws.account_name
+	gw_name                          = "tfg-aws-%[1]s"
+	vpc_id                           = "%[5]s"
+	vpc_reg                          = "%[6]s"
+	gw_size                          = "%[7]s"
+	subnet                           = "%[8]s"
+	single_ip_snat                   = false
+	bgp_polling_time                 = 50
+	bgp_neighbor_status_polling_time = 5
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		os.Getenv("AWS_VPC_ID4"), os.Getenv("AWS_REGION"), awsGwSize, os.Getenv("AWS_SUBNET4"))

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	defaultLearnedCidrApprovalMode = "gateway"
-	defaultBgpPollingTime          = 50
-	defaultBgpBfdPollingTime       = 5
-	defaultBgpHoldTime             = 180
+	defaultLearnedCidrApprovalMode      = "gateway"
+	defaultBgpPollingTime               = 50
+	defaultBgpNeighborStatusPollingTime = 5
+	defaultBgpHoldTime                  = 180
 )
 
 func resourceAviatrixTransitGateway() *schema.Resource {
@@ -310,12 +310,12 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				ValidateFunc: validation.IntBetween(10, 50),
 				Description:  "BGP route polling time. Unit is in seconds. Valid values are between 10 and 50.",
 			},
-			"bgp_bfd_polling_time": {
+			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      defaultBgpBfdPollingTime,
+				Default:      defaultBgpNeighborStatusPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP BFD route polling time for BGP Transit Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Description:  "BGP neighbor status polling time for BGP Transit Gateway. Unit is in seconds. Valid values are between 1 and 10.",
 			},
 			"prepend_as_path": {
 				Type:         schema.TypeList,
@@ -1724,10 +1724,10 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			}
 		}
 
-		if val, ok := d.GetOk("bgp_bfd_polling_time"); ok {
+		if val, ok := d.GetOk("bgp_neighbor_status_polling_time"); ok {
 			err := client.SetBgpBfdPollingTime(gateway, val.(int))
 			if err != nil {
-				return fmt.Errorf("could not set bgp bfd polling time: %v", err)
+				return fmt.Errorf("could not set bgp neighbor status polling time: %v", err)
 			}
 		}
 
@@ -2040,7 +2040,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		d.Set("connected_transit", gw.ConnectedTransit == "yes")
 		d.Set("bgp_hold_time", gw.BgpHoldTime)
 		d.Set("bgp_polling_time", gw.BgpPollingTime)
-		d.Set("bgp_bfd_polling_time", gw.BgpBfdPollingTime)
+		d.Set("bgp_neighbor_status_polling_time", gw.BgpBfdPollingTime)
 		d.Set("image_version", gw.ImageVersion)
 		d.Set("software_version", gw.SoftwareVersion)
 		d.Set("rx_queue_size", gw.RxQueueSize)
@@ -3384,14 +3384,14 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	if d.HasChange("bgp_bfd_polling_time") {
-		bgpBfdPollingTime := d.Get("bgp_bfd_polling_time").(int)
+	if d.HasChange("bgp_neighbor_status_polling_time") {
+		bgpBfdPollingTime := d.Get("bgp_neighbor_status_polling_time").(int)
 		gateway := &goaviatrix.TransitVpc{
 			GwName: d.Get("gw_name").(string),
 		}
 		err := client.SetBgpBfdPollingTime(gateway, bgpBfdPollingTime)
 		if err != nil {
-			return fmt.Errorf("could not update bgp polling time: %v", err)
+			return fmt.Errorf("could not update bgp neighbor status polling time: %v", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -55,7 +55,7 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceNameAws, "subnet", os.Getenv("AWS_SUBNET")),
 						resource.TestCheckResourceAttr(resourceNameAws, "vpc_reg", os.Getenv("AWS_REGION")),
 						resource.TestCheckResourceAttr(resourceNameAws, "bgp_polling_time", "50"),
-						resource.TestCheckResourceAttr(resourceNameAws, "bgp_bfd_polling_time", "5"),
+						resource.TestCheckResourceAttr(resourceNameAws, "bgp_neighbor_status_polling_time", "5"),
 					),
 				},
 				{
@@ -230,15 +230,15 @@ resource "aviatrix_account" "test_acc_aws" {
 	aws_secret_key     = "%s"
 }
 resource "aviatrix_transit_gateway" "test_transit_gateway_aws" {
-	cloud_type           = 1
-	account_name         = aviatrix_account.test_acc_aws.account_name
-	gw_name              = "tfg-aws-%[1]s"
-	vpc_id               = "%[5]s"
-	vpc_reg              = "%[6]s"
-	gw_size              = "t2.micro"
-	subnet               = "%[7]s"
-	bgp_polling_time     = 50
-	bgp_bfd_polling_time = 5
+	cloud_type                       = 1
+	account_name                     = aviatrix_account.test_acc_aws.account_name
+	gw_name                          = "tfg-aws-%[1]s"
+	vpc_id                           = "%[5]s"
+	vpc_reg                          = "%[6]s"
+	gw_size                          = "t2.micro"
+	subnet                           = "%[7]s"
+	bgp_polling_time                 = 50
+	bgp_neighbor_status_polling_time = 5
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		os.Getenv("AWS_VPC_ID"), os.Getenv("AWS_REGION"), os.Getenv("AWS_SUBNET"))

--- a/docs/resources/aviatrix_edge_csp.md
+++ b/docs/resources/aviatrix_edge_csp.md
@@ -92,7 +92,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: 50.
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_equinix.md
+++ b/docs/resources/aviatrix_edge_equinix.md
@@ -81,7 +81,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time in seconds. Valid values are between 10 and 50. Default value: 50.
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -83,7 +83,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: 50.
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_neo.md
+++ b/docs/resources/aviatrix_edge_neo.md
@@ -94,7 +94,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time in seconds. Valid values are between 10 and 50. Default value: 50.
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_platform.md
+++ b/docs/resources/aviatrix_edge_platform.md
@@ -92,7 +92,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time in seconds. Valid values are between 10 and 50. Default value: 50.
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_spoke.md
+++ b/docs/resources/aviatrix_edge_spoke.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: 50.
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_edge_zededa.md
+++ b/docs/resources/aviatrix_edge_zededa.md
@@ -90,7 +90,7 @@ The following arguments are supported:
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Set of intended CIDRs to be advertised to external BGP router. Example: ["10.1.0.0/116", "10.2.0.0/16"].
 * `enable_preserve_as_path` - (Optional) Switch to enable preserve as_path when advertising manual summary CIDRs. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: 50.
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `enable_edge_transitive_routing` - (Optional) Switch to enable Edge transitive routing. Valid values: true, false. Default value: false.
 * `enable_jumbo_frame` - (Optional) Switch to enable jumbo frame. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -305,7 +305,7 @@ The following arguments are supported:
 * `bgp_ecmp` - (Optional) Enable Equal Cost Multi Path (ECMP) routing for the next hop. Default value: false.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: "50".
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `spoke_bgp_manual_advertise_cidrs` - (Optional) Intended CIDR list to be advertised to external BGP router. Empty list is not valid. Example: ["10.2.0.0/16", "10.4.0.0/16"].
 * `enable_active_standby` - (Optional) Enables [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby). Available only with HA enabled. Valid values: true, false. Default value: false.
 * `enable_active_standby_preemptive` - (Optional) Enables Preemptive Mode for Active-Standby. Available only with BGP enabled, HA enabled and Active-Standby enabled. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -446,7 +446,7 @@ The following arguments are supported:
 * `enable_active_standby` - (Optional) Enables [Active-Standby Mode](https://docs.aviatrix.com/HowTos/transit_advanced.html#active-standby). Available only with HA enabled. Valid values: true, false. Default value: false. Available in provider version R2.17.1+.
 * `enable_active_standby_preemptive` - (Optional) Enables Preemptive Mode for Active-Standby. Available only with BGP enabled, HA enabled and Active-Standby enabled. Valid values: true, false. Default value: false.
 * `bgp_polling_time` - (Optional) BGP route polling time. Unit is in seconds. Valid values are between 10 and 50. Default value: "50".
-* `bgp_bfd_polling_time` - (Optional) BGP BFD route polling time in seconds. Valid values are between 1 and 10. Default value: 5.
+* `bgp_neighbor_status_polling_time` - (Optional) BGP neighbor status polling time in seconds. Valid values are between 1 and 10. Default value: 5.
 * `bgp_hold_time` - (Optional) BGP hold time. Unit is in seconds. Valid values are between 12 and 360. Default value: 180.
 * `prepend_as_path` - (Optional) List of AS numbers to populate BGP AP_PATH field when it advertises to VGW or peer devices.
 * `local_as_number` - (Optional) Changes the Aviatrix Transit Gateway ASN number before you setup Aviatrix Transit Gateway connection configurations.

--- a/goaviatrix/edge_csp.go
+++ b/goaviatrix/edge_csp.go
@@ -34,7 +34,7 @@ type EdgeCSP struct {
 	SpokeBgpManualAdvertisedCidrs      []string `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
 	EnablePreserveAsPath               bool     `json:"preserve_as_path,omitempty"`
 	BgpPollingTime                     int      `json:"bgp_polling_time,omitempty"`
-	BgpBfdPollingTime                  int      `json:"bgp_bfd_polling_time,omitempty"`
+	BgpBfdPollingTime                  int      `json:"bgp_neighbor_status_polling_time,omitempty"`
 	BgpHoldTime                        int      `json:"bgp_hold_time,omitempty"`
 	EnableEdgeTransitiveRouting        bool     `json:"edge_transitive_routing,omitempty"`
 	EnableJumboFrame                   bool     `json:"jumbo_frame,omitempty"`
@@ -110,7 +110,7 @@ type EdgeCSPResp struct {
 	SpokeBgpManualAdvertisedCidrs      []string     `json:"bgp_manual_spoke_advertise_cidrs"`
 	EnablePreserveAsPath               bool         `json:"preserve_as_path"`
 	BgpPollingTime                     int          `json:"bgp_polling_time"`
-	BgpBfdPollingTime                  int          `json:"bgp_bfd_polling_time"`
+	BgpBfdPollingTime                  int          `json:"bgp_neighbor_status_polling_time"`
 	BgpHoldTime                        int          `json:"bgp_hold_time"`
 	EnableEdgeTransitiveRouting        bool         `json:"edge_transitive_routing"`
 	EnableJumboFrame                   bool         `json:"jumbo_frame"`

--- a/goaviatrix/edge_equinix.go
+++ b/goaviatrix/edge_equinix.go
@@ -33,7 +33,7 @@ type EdgeEquinix struct {
 	SpokeBgpManualAdvertisedCidrs      []string `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
 	EnablePreserveAsPath               bool     `json:"preserve_as_path,omitempty"`
 	BgpPollingTime                     int      `json:"bgp_polling_time,omitempty"`
-	BgpBfdPollingTime                  int      `json:"bgp_bfd_polling_time,omitempty"`
+	BgpBfdPollingTime                  int      `json:"bgp_neighbor_status_polling_time,omitempty"`
 	BgpHoldTime                        int      `json:"bgp_hold_time,omitempty"`
 	EnableEdgeTransitiveRouting        bool     `json:"edge_transitive_routing,omitempty"`
 	EnableJumboFrame                   bool     `json:"jumbo_frame,omitempty"`
@@ -103,7 +103,7 @@ type EdgeEquinixResp struct {
 	SpokeBgpManualAdvertisedCidrs      []string     `json:"bgp_manual_spoke_advertise_cidrs"`
 	EnablePreserveAsPath               bool         `json:"preserve_as_path"`
 	BgpPollingTime                     int          `json:"bgp_polling_time"`
-	BgpBfdPollingTime                  int          `json:"bgp_bfd_polling_time"`
+	BgpBfdPollingTime                  int          `json:"bgp_neighbor_status_polling_time"`
 	BgpHoldTime                        int          `json:"bgp_hold_time"`
 	EnableEdgeTransitiveRouting        bool         `json:"edge_transitive_routing"`
 	EnableJumboFrame                   bool         `json:"jumbo_frame"`

--- a/goaviatrix/edge_neo.go
+++ b/goaviatrix/edge_neo.go
@@ -32,7 +32,7 @@ type EdgeNEO struct {
 	SpokeBgpManualAdvertisedCidrs      []string `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
 	EnablePreserveAsPath               bool     `json:"preserve_as_path,omitempty"`
 	BgpPollingTime                     int      `json:"bgp_polling_time,omitempty"`
-	BgpBfdPollingTime                  int      `json:"bgp_bfd_polling_time,omitempty"`
+	BgpBfdPollingTime                  int      `json:"bgp_neighbor_status_polling_time,omitempty"`
 	BgpHoldTime                        int      `json:"bgp_hold_time,omitempty"`
 	EnableEdgeTransitiveRouting        bool     `json:"edge_transitive_routing,omitempty"`
 	EnableJumboFrame                   bool     `json:"jumbo_frame,omitempty"`
@@ -103,7 +103,7 @@ type EdgeNEOResp struct {
 	SpokeBgpManualAdvertisedCidrs      []string            `json:"bgp_manual_spoke_advertise_cidrs"`
 	EnablePreserveAsPath               bool                `json:"preserve_as_path"`
 	BgpPollingTime                     int                 `json:"bgp_polling_time"`
-	BgpBfdPollingTime                  int                 `json:"bgp_bfd_polling_time"`
+	BgpBfdPollingTime                  int                 `json:"bgp_neighbor_status_polling_time"`
 	BgpHoldTime                        int                 `json:"bgp_hold_time"`
 	EnableEdgeTransitiveRouting        bool                `json:"edge_transitive_routing"`
 	EnableJumboFrame                   bool                `json:"jumbo_frame"`

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -41,7 +41,7 @@ type EdgeSpoke struct {
 	SpokeBgpManualAdvertisedCidrs      []string `json:"bgp_manual_spoke_advertise_cidrs,omitempty"`
 	EnablePreserveAsPath               bool     `json:"preserve_as_path,omitempty"`
 	BgpPollingTime                     int      `json:"bgp_polling_time,omitempty"`
-	BgpBfdPollingTime                  int      `json:"bgp_bfd_polling_time,omitempty"`
+	BgpBfdPollingTime                  int      `json:"bgp_neighbor_status_polling_time,omitempty"`
 	BgpHoldTime                        int      `json:"bgp_hold_time,omitempty"`
 	EnableEdgeTransitiveRouting        bool     `json:"edge_transitive_routing,omitempty"`
 	EnableJumboFrame                   bool     `json:"jumbo_frame,omitempty"`
@@ -100,7 +100,7 @@ type EdgeSpokeResp struct {
 	SpokeBgpManualAdvertisedCidrs      []string              `json:"bgp_manual_spoke_advertise_cidrs"`
 	EnablePreserveAsPath               bool                  `json:"preserve_as_path"`
 	BgpPollingTime                     int                   `json:"bgp_polling_time"`
-	BgpBfdPollingTime                  int                   `json:"bgp_bfd_polling_time"`
+	BgpBfdPollingTime                  int                   `json:"bgp_neighbor_status_polling_time"`
 	BgpHoldTime                        int                   `json:"bgp_hold_time"`
 	EnableEdgeTransitiveRouting        bool                  `json:"edge_transitive_routing"`
 	EnableJumboFrame                   bool                  `json:"jumbo_frame"`

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -174,7 +174,7 @@ type Gateway struct {
 	TunnelDetectionTime             int                                 `json:"detection_time"`
 	BgpHoldTime                     int                                 `json:"bgp_hold_time"`
 	BgpPollingTime                  int                                 `json:"bgp_polling_time"`
-	BgpBfdPollingTime               int                                 `json:"bgp_bfd_polling_time"`
+	BgpBfdPollingTime               int                                 `json:"bgp_neighbor_status_polling_time"`
 	PrependASPath                   string                              `json:"prepend_as_path"`
 	LocalASNumber                   string                              `json:"local_as_number"`
 	BgpEcmp                         bool                                `json:"bgp_ecmp"`

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -79,7 +79,7 @@ type SpokeGatewayAdvancedConfigResp struct {
 
 type SpokeGatewayAdvancedConfigRespResult struct {
 	BgpPollingTime                    int                       `json:"bgp_polling_time"`
-	BgpBfdPollingTime                 int                       `json:"bgp_bfd_polling_time,omitempty"`
+	BgpBfdPollingTime                 int                       `json:"bgp_neighbor_status_polling_time,omitempty"`
 	PrependASPath                     string                    `json:"bgp_prepend_as_path"`
 	LocalASNumber                     string                    `json:"local_asn_num"`
 	BgpEcmpEnabled                    string                    `json:"bgp_ecmp"`
@@ -364,12 +364,12 @@ func (c *Client) SetBgpPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime i
 }
 
 func (c *Client) SetBgpBfdPollingTimeSpoke(spokeGateway *SpokeVpc, newPollingTime int) error {
-	action := "change_bgp_bfd_polling_time"
+	action := "change_bgp_neighbor_status_polling_time"
 	return c.PostAPI(action, struct {
 		CID         string `form:"CID"`
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
-		PollingTime int    `form:"bgp_bfd_polling_time"`
+		PollingTime int    `form:"bgp_neighbor_status_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -92,7 +92,7 @@ type StandbyConnection struct {
 
 type TransitGatewayAdvancedConfigRespResult struct {
 	BgpPollingTime                    int                       `json:"bgp_polling_time"`
-	BgpBfdPollingTime                 int                       `json:"bgp_bfd_polling_time"`
+	BgpBfdPollingTime                 int                       `json:"bgp_neighbor_status_polling_time"`
 	PrependASPath                     string                    `json:"bgp_prepend_as_path"`
 	LocalASNumber                     string                    `json:"local_asn_num"`
 	BgpEcmpEnabled                    string                    `json:"bgp_ecmp"`
@@ -373,12 +373,12 @@ func (c *Client) SetBgpPollingTime(transitGateway *TransitVpc, newPollingTime in
 }
 
 func (c *Client) SetBgpBfdPollingTime(transitGateway *TransitVpc, newPollingTime int) error {
-	action := "change_bgp_bfd_polling_time"
+	action := "change_bgp_neighbor_status_polling_time"
 	return c.PostAPI(action, struct {
 		CID         string `form:"CID"`
 		Action      string `form:"action"`
 		GatewayName string `form:"gateway_name"`
-		PollingTime int    `form:"bgp_bfd_polling_time"`
+		PollingTime int    `form:"bgp_neighbor_status_polling_time"`
 	}{
 		CID:         c.CID,
 		Action:      action,


### PR DESCRIPTION
Updating the bgp_bfd_polling_time parameter with bgp_neighbor_status_polling_time in the following resources:

    - **aviatrix_edge_csp**
    - **aviatrix_edge_equinix**
    - **aviatrix_edge_gateway_selfmanaged**
    - **avaitrix_edge_platform**
    - **aviatrix_edge_zededa**
    - **aviatrix_spoke_gateway**
    - **aviatrix_edge_spoke_gateway**
    - **aviatrix_transit_gateway**
Link - https://aviatrix.atlassian.net/browse/AVX-58410