### PR TITLE
AVX-59033 Adding the BFD refresh functionality

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -350,7 +350,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 			}
 		} else {
 			// set the bgp bfd config using the default values
-			externalDeviceConn.BgpBfdConfig = &defaultBfdConfig
+			externalDeviceConn.BgpBfdConfig = defaultBfdConfig
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
@@ -454,7 +454,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
 	d.Set("enable_bfd", enable_bfd)
-	if conn.EnableBfd && conn.BgpBfdConfig != nil {
+	if conn.EnableBfd {
 		var bgpBfdConfig []map[string]interface{}
 		bfd := conn.BgpBfdConfig
 		bfdMap := make(map[string]interface{})
@@ -541,7 +541,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 				GwName:         d.Get("gw_name").(string),
 				ConnectionName: d.Get("connection_name").(string),
 				EnableBfd:      d.Get("enable_bfd").(bool),
-				BgpBfdConfig:   &bgpBfd,
+				BgpBfdConfig:   bgpBfd,
 			}
 			err := client.EditConnectionBgpBfd(externalDeviceConn)
 			if err != nil {

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -449,13 +449,12 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 		d.Set("bgp_remote_as_num", strconv.Itoa(conn.BgpRemoteAsNum))
 	}
 	d.Set("enable_bfd", conn.EnableBfd)
-	if conn.EnableBfd {
+	// set the bgp_bfd config details only if the user has enabled BFD and provided the config details. For default values, the config is not set
+	bgpBfdConfig := d.Get("bgp_bfd").([]interface{})
+	if conn.EnableBfd && len(bgpBfdConfig) != 0 {
 		var bgpBfdConfig []map[string]interface{}
 		bfd := conn.BgpBfdConfig
 		bfdMap := make(map[string]interface{})
-		bfdMap["transmit_interval"] = defaultBfdTransmitInterval
-		bfdMap["receive_interval"] = defaultBfdReceiveInterval
-		bfdMap["multiplier"] = defaultBfdMultiplier
 		if bfd.TransmitInterval != 0 {
 			bfdMap["transmit_interval"] = bfd.TransmitInterval
 		}
@@ -544,6 +543,9 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 			}
 		} else {
 			// bgp bfd is disabled
+			if len(bgpBfdConfig) > 0 {
+				return diag.Errorf("bgp_bfd config can't be set when BFD is disabled")
+			}
 			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 				GwName:         d.Get("gw_name").(string),
 				ConnectionName: d.Get("connection_name").(string),

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -450,7 +450,10 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 	}
 	d.Set("enable_bfd", conn.EnableBfd)
 	// set the bgp_bfd config details only if the user has enabled BFD and provided the config details. For default values, the config is not set
-	bgpBfdConfig := d.Get("bgp_bfd").([]interface{})
+	bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
+	if !ok {
+		return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+	}
 	if conn.EnableBfd && len(bgpBfdConfig) != 0 {
 		var bgpBfdConfig []map[string]interface{}
 		bfd := conn.BgpBfdConfig

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -986,15 +986,8 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 			d.Set("approved_cidrs", nil)
 		}
 
-		enable_bfd, ok := d.Get("enable_bfd").(bool)
-		if !ok {
-			return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
-		}
-		if enable_bfd && conn.ConnectionType != "bgp" {
-			return fmt.Errorf("BFD is only supported for BGP connection type")
-		}
-		d.Set("enable_bfd", enable_bfd)
-		if conn.EnableBfd && conn.BgpBfdConfig != nil {
+		d.Set("enable_bfd", conn.EnableBfd)
+		if conn.EnableBfd {
 			var bgpBfdConfig []map[string]interface{}
 			bfd := conn.BgpBfdConfig
 			bfdMap := make(map[string]interface{})

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -988,7 +988,10 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 
 		d.Set("enable_bfd", conn.EnableBfd)
 		// set the bgp_bfd config details only if the user has enabled BFD and provided the config details. For default values, the config is not set
-		bgpBfdConfig := d.Get("bgp_bfd").([]interface{})
+		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
+		if !ok {
+			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+		}
 		if conn.EnableBfd && len(bgpBfdConfig) != 0 {
 			var bgpBfdConfig []map[string]interface{}
 			bfd := conn.BgpBfdConfig

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -886,7 +886,7 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 	}
 
 	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
-	log.Printf("[TRACE] Reading Aviatrix external device conn: %s : %#v", d.Get("connection_name").(string), conn)
+	log.Printf("[TRACE] Reading Aviatrix external device conn: %s : %#v", d.Get("connection_name").(string), externalDeviceConn)
 
 	if err != nil {
 		if err == goaviatrix.ErrNotFound {
@@ -1209,7 +1209,6 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 	if !ok {
 		return fmt.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
-	log.Printf("[TRACE] enable_bfd: %v", enableBfd)
 	if connType != "bgp" && enableBfd {
 		return fmt.Errorf("cannot enable BFD for non-BGP connection")
 	}

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -987,13 +987,12 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 		}
 
 		d.Set("enable_bfd", conn.EnableBfd)
-		if conn.EnableBfd {
+		// set the bgp_bfd config details only if the user has enabled BFD and provided the config details. For default values, the config is not set
+		bgpBfdConfig := d.Get("bgp_bfd").([]interface{})
+		if conn.EnableBfd && len(bgpBfdConfig) != 0 {
 			var bgpBfdConfig []map[string]interface{}
 			bfd := conn.BgpBfdConfig
 			bfdMap := make(map[string]interface{})
-			bfdMap["transmit_interval"] = defaultBfdTransmitInterval
-			bfdMap["receive_interval"] = defaultBfdReceiveInterval
-			bfdMap["multiplier"] = defaultBfdMultiplier
 			if bfd.TransmitInterval != 0 {
 				bfdMap["transmit_interval"] = bfd.TransmitInterval
 			}
@@ -1233,6 +1232,9 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 			}
 		} else {
 			// bgp bfd is disabled
+			if len(bgpBfdConfig) > 0 {
+				return fmt.Errorf("bgp_bfd config can't be set when BFD is disabled")
+			}
 			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 				GwName:         d.Get("gw_name").(string),
 				ConnectionName: d.Get("connection_name").(string),

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -770,7 +770,7 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 			}
 		} else {
 			// set the bgp bfd config using the default values
-			externalDeviceConn.BgpBfdConfig = &defaultBfdConfig
+			externalDeviceConn.BgpBfdConfig = defaultBfdConfig
 		}
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
@@ -1096,7 +1096,7 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 			return fmt.Errorf("BFD is only supported for BGP connection")
 		}
 		d.Set("enable_bfd", enable_bfd)
-		if enable_bfd && conn.BgpBfdConfig != nil {
+		if enable_bfd {
 			var bgpBfdConfig []map[string]interface{}
 			bfd := conn.BgpBfdConfig
 			bfdMap := make(map[string]interface{})
@@ -1362,8 +1362,8 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 				GwName:         d.Get("gw_name").(string),
 				ConnectionName: d.Get("connection_name").(string),
-				EnableBfd:      d.Get("enable_bfd").(bool),
-				BgpBfdConfig:   &bgpBfd,
+				EnableBfd:      enableBfd,
+				BgpBfdConfig:   bgpBfd,
 			}
 			err := client.EditConnectionBgpBfd(externalDeviceConn)
 			if err != nil {
@@ -1377,7 +1377,7 @@ func resourceAviatrixTransitExternalDeviceConnUpdate(d *schema.ResourceData, met
 			externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 				GwName:         d.Get("gw_name").(string),
 				ConnectionName: d.Get("connection_name").(string),
-				EnableBfd:      d.Get("enable_bfd").(bool),
+				EnableBfd:      enableBfd,
 			}
 			err := client.EditConnectionBgpBfd(externalDeviceConn)
 			if err != nil {

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -1090,7 +1090,10 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 
 		d.Set("enable_bfd", conn.EnableBfd)
 		// set the bgp_bfd config details only if the user has enabled BFD and provided the config details. For default values, the config is not set
-		bgpBfdConfig := d.Get("bgp_bfd").([]interface{})
+		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
+		if !ok {
+			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+		}
 		if conn.EnableBfd && len(bgpBfdConfig) != 0 {
 			var bgpBfdConfig []map[string]interface{}
 			bfd := conn.BgpBfdConfig

--- a/goaviatrix/edge_external_device_conn.go
+++ b/goaviatrix/edge_external_device_conn.go
@@ -46,14 +46,14 @@ type EdgeExternalDeviceConn struct {
 	Phase1LocalIdentifier  string
 	Phase1RemoteIdentifier string
 	PrependAsPath          string
-	BgpMd5Key              string        `json:"bgp_md5_key,omitempty"`
-	BackupBgpMd5Key        string        `json:"backup_bgp_md5_key,omitempty"`
-	AuthType               string        `json:"auth_type,omitempty"`
-	EnableEdgeUnderlay     bool          `json:"edge_underlay,omitempty"`
-	RemoteCloudType        string        `json:"remote_cloud_type,omitempty"`
-	BgpMd5KeyChanged       bool          `json:"bgp_md5_key_changed,omitempty"`
-	BgpBfdConfig           *BgpBfdConfig `json:"bgp_bfd,omitempty"`
-	EnableBfd              bool          `json:"enable_bfd,omitempty"`
+	BgpMd5Key              string       `json:"bgp_md5_key,omitempty"`
+	BackupBgpMd5Key        string       `json:"backup_bgp_md5_key,omitempty"`
+	AuthType               string       `json:"auth_type,omitempty"`
+	EnableEdgeUnderlay     bool         `json:"edge_underlay,omitempty"`
+	RemoteCloudType        string       `json:"remote_cloud_type,omitempty"`
+	BgpMd5KeyChanged       bool         `json:"bgp_md5_key_changed,omitempty"`
+	BgpBfdConfig           BgpBfdConfig `json:"bgp_bfd_params,omitempty"`
+	EnableBfd              bool         `json:"bgp_bfd_enabled,omitempty"`
 }
 
 func (c *Client) CreateEdgeExternalDeviceConn(edgeExternalDeviceConn *EdgeExternalDeviceConn) (string, error) {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -71,8 +71,8 @@ type ExternalDeviceConn struct {
 	EnableEdgeUnderlay     bool          `form:"edge_underlay,omitempty"`
 	RemoteCloudType        string        `form:"remote_cloud_type,omitempty"`
 	BgpMd5KeyChanged       bool          `form:"bgp_md5_key_changed,omitempty"`
-	BgpBfdConfig           *BgpBfdConfig `form:"bgp_bfd,omitempty"`
-	EnableBfd              bool          `form:"enable_bfd,omitempty"`
+	BgpBfdConfig           *BgpBfdConfig `form:"bgp_bfd_params,omitempty"`
+	EnableBfd              bool          `form:"bgp_bfd_enabled,omitempty"`
 }
 
 type EditExternalDeviceConnDetail struct {
@@ -117,8 +117,8 @@ type EditExternalDeviceConnDetail struct {
 }
 
 type BgpBfdConfig struct {
-	TransmitInterval int `json:"transmit_interval"`
-	ReceiveInterval  int `json:"receive_interval"`
+	TransmitInterval int `json:"tx_interval"`
+	ReceiveInterval  int `json:"rx_interval"`
 	Multiplier       int `json:"multiplier"`
 }
 

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -65,14 +65,14 @@ type ExternalDeviceConn struct {
 	Phase1LocalIdentifier  string
 	Phase1RemoteIdentifier string
 	PrependAsPath          string
-	BgpMd5Key              string        `form:"bgp_md5_key,omitempty"`
-	BackupBgpMd5Key        string        `form:"backup_bgp_md5_key,omitempty"`
-	AuthType               string        `form:"auth_type,omitempty"`
-	EnableEdgeUnderlay     bool          `form:"edge_underlay,omitempty"`
-	RemoteCloudType        string        `form:"remote_cloud_type,omitempty"`
-	BgpMd5KeyChanged       bool          `form:"bgp_md5_key_changed,omitempty"`
-	BgpBfdConfig           *BgpBfdConfig `form:"bgp_bfd_params,omitempty"`
-	EnableBfd              bool          `form:"bgp_bfd_enabled,omitempty"`
+	BgpMd5Key              string       `form:"bgp_md5_key,omitempty"`
+	BackupBgpMd5Key        string       `form:"backup_bgp_md5_key,omitempty"`
+	AuthType               string       `form:"auth_type,omitempty"`
+	EnableEdgeUnderlay     bool         `form:"edge_underlay,omitempty"`
+	RemoteCloudType        string       `form:"remote_cloud_type,omitempty"`
+	BgpMd5KeyChanged       bool         `form:"bgp_md5_key_changed,omitempty"`
+	BgpBfdConfig           BgpBfdConfig `form:"bgp_bfd_params,omitempty"`
+	EnableBfd              bool         `form:"bgp_bfd_enabled,omitempty"`
 }
 
 type EditExternalDeviceConnDetail struct {
@@ -101,19 +101,21 @@ type EditExternalDeviceConnDetail struct {
 	BackupRemoteGatewayIP  string
 	PreSharedKey           string
 	BackupPreSharedKey     string
-	IkeVer                 string `json:"ike_ver,omitempty"`
-	PeerVnetId             string `json:"peer_vnet_id,omitempty"`
-	RemoteLanIP            string `json:"remote_lan_ip,omitempty"`
-	LocalLanIP             string `json:"local_lan_ip,omitempty"`
-	BackupRemoteLanIP      string `json:"backup_remote_lan_ip,omitempty"`
-	BackupLocalLanIP       string `json:"backup_local_lan_ip,omitempty"`
-	EventTriggeredHA       string `json:"event_triggered_ha,omitempty"`
-	Phase1LocalIdentifier  string `json:"ph1_identifier,omitempty"`
-	Phase1RemoteIdentifier string `json:"phase1_remote_id,omitempty"`
-	PrependAsPath          string `json:"conn_bgp_prepend_as_path,omitempty"`
-	EnableJumboFrame       bool   `json:"jumbo_frame,omitempty"`
-	WanUnderlay            bool   `json:"wan_underlay,omitempty"`
-	RemoteCloudType        string `json:"remote_cloud_type,omitempty"`
+	IkeVer                 string         `json:"ike_ver,omitempty"`
+	PeerVnetId             string         `json:"peer_vnet_id,omitempty"`
+	RemoteLanIP            string         `json:"remote_lan_ip,omitempty"`
+	LocalLanIP             string         `json:"local_lan_ip,omitempty"`
+	BackupRemoteLanIP      string         `json:"backup_remote_lan_ip,omitempty"`
+	BackupLocalLanIP       string         `json:"backup_local_lan_ip,omitempty"`
+	EventTriggeredHA       string         `json:"event_triggered_ha,omitempty"`
+	Phase1LocalIdentifier  string         `json:"ph1_identifier,omitempty"`
+	Phase1RemoteIdentifier string         `json:"phase1_remote_id,omitempty"`
+	PrependAsPath          string         `json:"conn_bgp_prepend_as_path,omitempty"`
+	EnableJumboFrame       bool           `json:"jumbo_frame,omitempty"`
+	WanUnderlay            bool           `json:"wan_underlay,omitempty"`
+	RemoteCloudType        string         `json:"remote_cloud_type,omitempty"`
+	BgpBfdConfig           map[string]int `json:"bgp_bfd_params,omitempty"`
+	EnableBfd              bool           `json:"bgp_bfd_enabled,omitempty"`
 }
 
 type BgpBfdConfig struct {
@@ -322,7 +324,12 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 		externalDeviceConn.EnableEdgeUnderlay = externalDeviceConnDetail.WanUnderlay
 		externalDeviceConn.RemoteCloudType = externalDeviceConnDetail.RemoteCloudType
 		externalDeviceConn.Phase1LocalIdentifier = externalDeviceConnDetail.Phase1LocalIdentifier
-
+		externalDeviceConn.EnableBfd = externalDeviceConnDetail.EnableBfd
+		if externalDeviceConn.EnableBfd {
+			externalDeviceConn.BgpBfdConfig.TransmitInterval = externalDeviceConnDetail.BgpBfdConfig["tx_interval"]
+			externalDeviceConn.BgpBfdConfig.ReceiveInterval = externalDeviceConnDetail.BgpBfdConfig["rx_interval"]
+			externalDeviceConn.BgpBfdConfig.Multiplier = externalDeviceConnDetail.BgpBfdConfig["multiplier"]
+		}
 		return externalDeviceConn, nil
 	}
 
@@ -377,7 +384,7 @@ func TransitExternalDeviceConnPh1RemoteIdDiffSuppressFunc(k, old, new string, d 
 	return false
 }
 
-func CreateBgpBfdConfig(bfd map[string]interface{}) *BgpBfdConfig {
+func CreateBgpBfdConfig(bfd map[string]interface{}) BgpBfdConfig {
 	// Set default values
 	transmitInterval := defaultBfdTransmitInterval
 	receiveInterval := defaultBfdReceiveInterval
@@ -395,7 +402,7 @@ func CreateBgpBfdConfig(bfd map[string]interface{}) *BgpBfdConfig {
 	}
 
 	// Create and return BgpBfdConfig instance
-	bfd2 := &BgpBfdConfig{
+	bfd2 := BgpBfdConfig{
 		TransmitInterval: transmitInterval,
 		ReceiveInterval:  receiveInterval,
 		Multiplier:       multiplier,
@@ -409,7 +416,7 @@ func GetUpdatedBgpBfdConfig(bgpBfdConfig []interface{}) BgpBfdConfig {
 		// get the user provided bgp bfd config
 		for _, v := range bgpBfdConfig {
 			bfdConfig := v.(map[string]interface{})
-			bgpBfd = *CreateBgpBfdConfig(bfdConfig)
+			bgpBfd = CreateBgpBfdConfig(bfdConfig)
 		}
 	} else if len(bgpBfdConfig) == 0 {
 		// use default bgp bfd config


### PR DESCRIPTION
- The bgp_bfd config was not not getting set in terraform. Updated the read back code to address this issue. Now if the bgp_bfd is disabled using the api then the TF code detects this change and updates the external resource connection.
Link - https://aviatrix.atlassian.net/browse/AVX-59033