### PR TITLE
AVX-59225 Updating the check on bgp_bfd config when bfd is disabled

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -333,12 +333,12 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 		return diag.Errorf("expected enable_bfd to be a boolean, but got %T", d.Get("enable_bfd"))
 	}
 	externalDeviceConn.EnableBfd = enableBFD
+	bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
+	if !ok {
+		return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+	}
 	// set the bgp bfd config details only if the user has enabled BFD
 	if enableBFD {
-		bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
-		if !ok {
-			return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
-		}
 		// set bgp bfd using the config details provided by the user
 		if len(bgp_bfd) > 0 {
 			for _, bfd0 := range bgp_bfd {
@@ -355,6 +355,11 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
 			return diag.Errorf("could not update BGP BFD config: %v", err)
+		}
+	} else {
+		// if BFD is disabled and BGP BFD config is provided then throw an error
+		if len(bgp_bfd) > 0 {
+			return diag.Errorf("bgp_bfd config can't be set when BFD is disabled")
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -715,12 +715,12 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 		return fmt.Errorf("BFD is only supported for BGP connection type")
 	}
 	externalDeviceConn.EnableBfd = enableBFD
+	bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
+	if !ok {
+		return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+	}
 	// set the bgp bfd config details only if the user has enabled BFD
 	if enableBFD {
-		bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
-		if !ok {
-			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
-		}
 		// set bgp bfd using the config details provided by the user
 		if len(bgp_bfd) > 0 {
 			for _, bfd0 := range bgp_bfd {
@@ -737,6 +737,11 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
 			return fmt.Errorf("could not update BGP BFD config: %v", err)
+		}
+	} else {
+		// if BFD is disabled and BGP BFD config is provided then throw an error
+		if len(bgp_bfd) > 0 {
+			return fmt.Errorf("bgp_bfd config can't be set when BFD is disabled")
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -753,12 +753,12 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 		return fmt.Errorf("BFD is only supported for BGP connection")
 	}
 	externalDeviceConn.EnableBfd = enableBFD
+	bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
+	if !ok {
+		return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
+	}
 	// set the bgp bfd config details only if the user has enabled BFD
 	if enableBFD {
-		bgp_bfd, ok := d.Get("bgp_bfd").([]interface{})
-		if !ok {
-			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
-		}
 		// set bgp bfd using the config details provided by the user
 		if len(bgp_bfd) > 0 {
 			for _, bfd0 := range bgp_bfd {
@@ -775,6 +775,11 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 		err := client.EditConnectionBgpBfd(externalDeviceConn)
 		if err != nil {
 			return fmt.Errorf("could not enable BGP BFD connection: %v", err)
+		}
+	} else {
+		// if BFD is disabled and BGP BFD config is provided then throw an error
+		if len(bgp_bfd) > 0 {
+			return fmt.Errorf("bgp_bfd config can't be set when BFD is disabled")
 		}
 	}
 


### PR DESCRIPTION
Updating the create function to throw an error when bfd is disabled and bgp-bfd config is provided for the following resources
* spoke_external_device_conn
* edge_spoke_external_device_conn
* transit_external_device_conn
Link - https://aviatrix.atlassian.net/browse/AVX-59225