### PR TITLE
AVX-59196 Updating interface config to omit null values backport

### DIFF
--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -488,13 +488,6 @@ func resourceAviatrixEdgePlatformCreate(ctx context.Context, d *schema.ResourceD
 	flag := false
 	defer resourceAviatrixEdgeNEOReadIfRequired(ctx, d, meta, &flag)
 
-	// print the edgeNeo
-	log.Printf("[INFO] Creating Edge Platform: %v", edgeNEO)
-	// print edgeNeo interfaces
-	for _, interface0 := range edgeNEO.InterfaceList {
-		log.Printf("[INFO] Interface: %v", interface0)
-	}
-
 	if err := client.CreateEdgeNEO(ctx, edgeNEO); err != nil {
 		return diag.Errorf("could not create Edge Platform: %v", err)
 	}

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -153,7 +153,7 @@ func resourceAviatrixEdgePlatform() *schema.Resource {
 			"bgp_neighbor_status_polling_time": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      defaultBgpPollingTime,
+				Default:      defaultBgpNeighborStatusPollingTime,
 				ValidateFunc: validation.IntBetween(1, 10),
 				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
 			},
@@ -487,6 +487,13 @@ func resourceAviatrixEdgePlatformCreate(ctx context.Context, d *schema.ResourceD
 	d.SetId(edgeNEO.GwName)
 	flag := false
 	defer resourceAviatrixEdgeNEOReadIfRequired(ctx, d, meta, &flag)
+
+	// print the edgeNeo
+	log.Printf("[INFO] Creating Edge Platform: %v", edgeNEO)
+	// print edgeNeo interfaces
+	for _, interface0 := range edgeNEO.InterfaceList {
+		log.Printf("[INFO] Interface: %v", interface0)
+	}
 
 	if err := client.CreateEdgeNEO(ctx, edgeNEO); err != nil {
 		return diag.Errorf("could not create Edge Platform: %v", err)

--- a/goaviatrix/edge_neo.go
+++ b/goaviatrix/edge_neo.go
@@ -58,27 +58,27 @@ type EdgeNEO struct {
 type EdgeNEOInterface struct {
 	IfName        string         `json:"ifname"`
 	Type          string         `json:"type"`
-	PublicIp      string         `json:"public_ip"`
-	Tag           string         `json:"tag"`
-	Dhcp          bool           `json:"dhcp"`
-	IpAddr        string         `json:"ipaddr"`
-	GatewayIp     string         `json:"gateway_ip"`
-	DnsPrimary    string         `json:"dns_primary"`
-	DnsSecondary  string         `json:"dns_secondary"`
-	SubInterfaces []*EdgeNEOVlan `json:"subinterfaces"`
-	VrrpState     bool           `json:"vrrp_state"`
-	VirtualIp     string         `json:"virtual_ip"`
+	PublicIp      string         `json:"public_ip,omitempty"`
+	Tag           string         `json:"tag,omitempty"`
+	Dhcp          bool           `json:"dhcp,omitempty"`
+	IpAddr        string         `json:"ipaddr,omitempty"`
+	GatewayIp     string         `json:"gateway_ip,omitempty"`
+	DnsPrimary    string         `json:"dns_primary,omitempty"`
+	DnsSecondary  string         `json:"dns_secondary,omitempty"`
+	SubInterfaces []*EdgeNEOVlan `json:"subinterfaces,omitempty"`
+	VrrpState     bool           `json:"vrrp_state,omitempty"`
+	VirtualIp     string         `json:"virtual_ip,omitempty"`
 }
 
 type EdgeNEOVlan struct {
 	ParentInterface string `json:"parent_interface"`
 	VlanId          string `json:"vlan_id"`
 	IpAddr          string `json:"ipaddr"`
-	GatewayIp       string `json:"gateway_ip"`
-	PeerIpAddr      string `json:"peer_ipaddr"`
-	PeerGatewayIp   string `json:"peer_gateway_ip"`
-	VirtualIp       string `json:"virtual_ip"`
-	Tag             string `json:"tag"`
+	GatewayIp       string `json:"gateway_ip,omitempty"`
+	PeerIpAddr      string `json:"peer_ipaddr,omitempty"`
+	PeerGatewayIp   string `json:"peer_gateway_ip,omitempty"`
+	VirtualIp       string `json:"virtual_ip,omitempty"`
+	Tag             string `json:"tag,omitempty"`
 }
 
 type EdgeNEOResp struct {


### PR DESCRIPTION
Backport for - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2114

Interface validations were failing because of the default values present for interface configs. Omitting null values while setting the interface config resolve this error

```
Error: could not create Edge Platform: rest API create_edge_csp_gateway POST failed: [AVXERR-EDGE-0011] Error in EdgeGateway creation: [AVXERR-EDGE-0005] Parameter error: Invalid field subinterfaces in interface eth0.; vrrp_state and virtual_ip are supported only for LAN interfaces.; IP address should not be present for interface eth2 when DHCP is true.; Invalid field subinterfaces in interface eth1.; Spoke mode requires at least one WAN, and exactly one LAN interface.; Edge gateway has no management interface config.

resource "aviatrix_edge_platform" "edge_platform_4" {
    account_name = "edge_aep"
    gw_name = "aep-edge-5"
    site_id = "site-21"
    device_id = "187c781f-7dd4-4b54-8be5-a0b8b96aa616"
    gw_size = "small"
    management_egress_ip_prefix_list = [
        "145.40.88.208/29"
    ]
    local_as_number = "65448"
    wan_interface_names = [
        "eth0"
    ]
    lan_interface_names = [
        "eth1"
    ]
    management_interface_names = [
        "eth2"
    ]
    interfaces {
        name = "eth2"
        type = "MANAGEMENT"
        ip_address = null
        enable_dhcp = true
    }

    interfaces {
        name = "eth1"
        type = "LAN"
        ip_address = "192.168.12.31/24"
    }

    interfaces {
        name = "eth0"
        type = "WAN"
        ip_address = "192.168.20.11/24"
        wan_public_ip = "145.40.88.210"
        gateway_ip = "192.168.20.1"
    }
}
```