### PR TITLE
AVX-59353 Updating the state for default bgp_bfd config

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -454,12 +454,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 		d.Set("bgp_remote_as_num", strconv.Itoa(conn.BgpRemoteAsNum))
 	}
 	d.Set("enable_bfd", conn.EnableBfd)
-	// set the bgp_bfd config details only if the user has enabled BFD and provided the config details. For default values, the config is not set
-	bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
-	if !ok {
-		return diag.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
-	}
-	if conn.EnableBfd && len(bgpBfdConfig) != 0 {
+	if conn.EnableBfd {
 		var bgpBfdConfig []map[string]interface{}
 		bfd := conn.BgpBfdConfig
 		bfdMap := make(map[string]interface{})

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -992,12 +992,7 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 		}
 
 		d.Set("enable_bfd", conn.EnableBfd)
-		// set the bgp_bfd config details only if the user has enabled BFD and provided the config details. For default values, the config is not set
-		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
-		if !ok {
-			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
-		}
-		if conn.EnableBfd && len(bgpBfdConfig) != 0 {
+		if conn.EnableBfd {
 			var bgpBfdConfig []map[string]interface{}
 			bfd := conn.BgpBfdConfig
 			bfdMap := make(map[string]interface{})

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -1094,12 +1094,7 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 		}
 
 		d.Set("enable_bfd", conn.EnableBfd)
-		// set the bgp_bfd config details only if the user has enabled BFD and provided the config details. For default values, the config is not set
-		bgpBfdConfig, ok := d.Get("bgp_bfd").([]interface{})
-		if !ok {
-			return fmt.Errorf("expected bgp_bfd to be a list of maps, but got %T", d.Get("bgp_bfd"))
-		}
-		if conn.EnableBfd && len(bgpBfdConfig) != 0 {
+		if conn.EnableBfd {
 			var bgpBfdConfig []map[string]interface{}
 			bfd := conn.BgpBfdConfig
 			bfdMap := make(map[string]interface{})


### PR DESCRIPTION
Setting the state for bgp_bfd config if default values are used. If enable_bfd is set to true then bgp_bfd state will always be set for external connection.

Updates are made to the following resources
* aviatrix_edge_spoke_external_conn
* aviatrix_spoke_external_conn
* aviatrix_transit_external_conn

**Link** - https://aviatrix.atlassian.net/browse/AVX-59353