### PR TITLE
AVX-59753 Backport for adding checks for bgp_neighbor_status_polling_time for backward compatibilty

### DIFF
--- a/aviatrix/resource_aviatrix_edge_csp.go
+++ b/aviatrix/resource_aviatrix_edge_csp.go
@@ -157,12 +157,14 @@ func resourceAviatrixEdgeCSP() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Default:          defaultBgpNeighborStatusPollingTime,
-				ValidateFunc:     validation.IntBetween(1, 10),
-				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
-				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpNeighborStatusPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "0"
+				},
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_csp.go
+++ b/aviatrix/resource_aviatrix_edge_csp.go
@@ -157,11 +157,12 @@ func resourceAviatrixEdgeCSP() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      defaultBgpNeighborStatusPollingTime,
-				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          defaultBgpNeighborStatusPollingTime,
+				ValidateFunc:     validation.IntBetween(1, 10),
+				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_equinix.go
+++ b/aviatrix/resource_aviatrix_edge_equinix.go
@@ -149,11 +149,12 @@ func resourceAviatrixEdgeEquinix() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      defaultBgpNeighborStatusPollingTime,
-				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          defaultBgpNeighborStatusPollingTime,
+				ValidateFunc:     validation.IntBetween(1, 10),
+				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_equinix.go
+++ b/aviatrix/resource_aviatrix_edge_equinix.go
@@ -149,12 +149,14 @@ func resourceAviatrixEdgeEquinix() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Default:          defaultBgpNeighborStatusPollingTime,
-				ValidateFunc:     validation.IntBetween(1, 10),
-				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
-				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpNeighborStatusPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "0"
+				},
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -149,12 +149,14 @@ func resourceAviatrixEdgeGatewaySelfmanaged() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Default:          defaultBgpNeighborStatusPollingTime,
-				ValidateFunc:     validation.IntBetween(1, 10),
-				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
-				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpNeighborStatusPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "0"
+				},
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -149,11 +149,12 @@ func resourceAviatrixEdgeGatewaySelfmanaged() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      defaultBgpNeighborStatusPollingTime,
-				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          defaultBgpNeighborStatusPollingTime,
+				ValidateFunc:     validation.IntBetween(1, 10),
+				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -151,12 +151,14 @@ func resourceAviatrixEdgePlatform() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Default:          defaultBgpNeighborStatusPollingTime,
-				ValidateFunc:     validation.IntBetween(1, 10),
-				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
-				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpNeighborStatusPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "0"
+				},
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -151,11 +151,12 @@ func resourceAviatrixEdgePlatform() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      defaultBgpNeighborStatusPollingTime,
-				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          defaultBgpNeighborStatusPollingTime,
+				ValidateFunc:     validation.IntBetween(1, 10),
+				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_spoke.go
+++ b/aviatrix/resource_aviatrix_edge_spoke.go
@@ -150,11 +150,12 @@ func resourceAviatrixEdgeSpoke() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      defaultBgpNeighborStatusPollingTime,
-				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          defaultBgpNeighborStatusPollingTime,
+				ValidateFunc:     validation.IntBetween(1, 10),
+				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_spoke.go
+++ b/aviatrix/resource_aviatrix_edge_spoke.go
@@ -150,12 +150,14 @@ func resourceAviatrixEdgeSpoke() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Default:          defaultBgpNeighborStatusPollingTime,
-				ValidateFunc:     validation.IntBetween(1, 10),
-				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
-				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpNeighborStatusPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "0"
+				},
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_zededa.go
+++ b/aviatrix/resource_aviatrix_edge_zededa.go
@@ -157,12 +157,14 @@ func resourceAviatrixEdgeZededa() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Default:          defaultBgpNeighborStatusPollingTime,
-				ValidateFunc:     validation.IntBetween(1, 10),
-				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
-				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpNeighborStatusPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "0"
+				},
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_zededa.go
+++ b/aviatrix/resource_aviatrix_edge_zededa.go
@@ -157,11 +157,12 @@ func resourceAviatrixEdgeZededa() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      defaultBgpNeighborStatusPollingTime,
-				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          defaultBgpNeighborStatusPollingTime,
+				ValidateFunc:     validation.IntBetween(1, 10),
+				Description:      "BGP neighbor status polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -391,11 +391,12 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      defaultBgpNeighborStatusPollingTime,
-				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP neighbor status polling time. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          defaultBgpNeighborStatusPollingTime,
+				ValidateFunc:     validation.IntBetween(1, 10),
+				Description:      "BGP neighbor status polling time. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -391,12 +391,14 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description:  "BGP route polling time for BGP Spoke Gateway. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Default:          defaultBgpNeighborStatusPollingTime,
-				ValidateFunc:     validation.IntBetween(1, 10),
-				Description:      "BGP neighbor status polling time. Unit is in seconds. Valid values are between 1 and 10.",
-				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpNeighborStatusPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP neighbor status polling time. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "0"
+				},
 			},
 			"bgp_hold_time": {
 				Type:         schema.TypeInt,

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -298,12 +298,14 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Description:  "BGP route polling time. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:             schema.TypeInt,
-				Optional:         true,
-				Default:          defaultBgpNeighborStatusPollingTime,
-				ValidateFunc:     validation.IntBetween(1, 10),
-				Description:      "BGP neighbor status polling time for BGP Transit Gateway. Unit is in seconds. Valid values are between 1 and 10.",
-				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultBgpNeighborStatusPollingTime,
+				ValidateFunc: validation.IntBetween(1, 10),
+				Description:  "BGP neighbor status polling time for BGP Transit Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "0"
+				},
 			},
 			"prepend_as_path": {
 				Type:         schema.TypeList,

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -298,11 +298,12 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Description:  "BGP route polling time. Unit is in seconds. Valid values are between 10 and 50.",
 			},
 			"bgp_neighbor_status_polling_time": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      defaultBgpNeighborStatusPollingTime,
-				ValidateFunc: validation.IntBetween(1, 10),
-				Description:  "BGP neighbor status polling time for BGP Transit Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          defaultBgpNeighborStatusPollingTime,
+				ValidateFunc:     validation.IntBetween(1, 10),
+				Description:      "BGP neighbor status polling time for BGP Transit Gateway. Unit is in seconds. Valid values are between 1 and 10.",
+				DiffSuppressFunc: goaviatrix.DiffSuppressFuncBgpNeighborStatusPollingTime,
 			},
 			"prepend_as_path": {
 				Type:         schema.TypeList,

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1420,6 +1420,15 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			return fmt.Errorf("could not set bgp neighbor status polling time: %v", err)
 		}
 	}
+	if val, ok := d.GetOk("bgp_neighbor_status_polling_time"); ok {
+		bgp_neighbor_status_polling_time := val.(int)
+		if bgp_neighbor_status_polling_time >= 1 && bgp_neighbor_status_polling_time != defaultBgpNeighborStatusPollingTime {
+			err := client.SetBgpBfdPollingTime(gateway, bgp_neighbor_status_polling_time)
+			if err != nil {
+				return fmt.Errorf("could not set bgp neighbor status polling time: %v", err)
+			}
+		}
+	}
 
 	if val, ok := d.GetOk("local_as_number"); ok {
 		err := client.SetLocalASNumber(gateway, val.(string))

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -54,13 +54,27 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceNameAws, "subnet", os.Getenv("AWS_SUBNET")),
 						resource.TestCheckResourceAttr(resourceNameAws, "vpc_reg", os.Getenv("AWS_REGION")),
 						resource.TestCheckResourceAttr(resourceNameAws, "bgp_polling_time", "50"),
-						resource.TestCheckResourceAttr(resourceNameAws, "bgp_neighbor_status_polling_time", "5"),
+						resource.TestCheckResourceAttr(resourceNameAws, "bgp_neighbor_status_polling_time", "0"),
 					),
 				},
 				{
 					ResourceName:      resourceNameAws,
 					ImportState:       true,
 					ImportStateVerify: true,
+				},
+				{
+					Config: testAccTransitGatewayConfigAWSBasicBgpBfd(rName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckTransitGatewayExists(resourceNameAws, &gateway),
+						resource.TestCheckResourceAttr(resourceNameAws, "gw_name", fmt.Sprintf("tfg-aws-%s", rName)),
+						resource.TestCheckResourceAttr(resourceNameAws, "gw_size", "t2.micro"),
+						resource.TestCheckResourceAttr(resourceNameAws, "account_name", fmt.Sprintf("tfa-aws-%s", rName)),
+						resource.TestCheckResourceAttr(resourceNameAws, "vpc_id", os.Getenv("AWS_VPC_ID")),
+						resource.TestCheckResourceAttr(resourceNameAws, "subnet", os.Getenv("AWS_SUBNET")),
+						resource.TestCheckResourceAttr(resourceNameAws, "vpc_reg", os.Getenv("AWS_REGION")),
+						resource.TestCheckResourceAttr(resourceNameAws, "bgp_polling_time", "50"),
+						resource.TestCheckResourceAttr(resourceNameAws, "bgp_neighbor_status_polling_time", "7"),
+					),
 				},
 			},
 		})
@@ -208,6 +222,22 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_aws" {
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		os.Getenv("AWS_VPC_ID"), os.Getenv("AWS_REGION"), os.Getenv("AWS_SUBNET"))
+}
+
+func testAccTransitGatewayConfigAWSBasicBgpBfd(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_transit_gateway" "test_transit_gateway_aws" {
+	cloud_type                       = 1
+	account_name                     = aviatrix_account.test_acc_aws.account_name
+	gw_name                          = "tfg-aws-%s"
+	vpc_id                           = "%s"
+	vpc_reg                          = "%s"
+	gw_size                          = "t2.micro"
+	subnet                           = "%s"
+	bgp_polling_time                 = 50
+	bgp_neighbor_status_polling_time = 7
+}
+	`, rName, os.Getenv("AWS_VPC_ID"), os.Getenv("AWS_REGION"), os.Getenv("AWS_SUBNET"))
 }
 
 func testAccTransitGatewayConfigBasicAZURE(rName string) string {

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -3,8 +3,6 @@ package goaviatrix
 import (
 	"fmt"
 	"strings"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Spoke gateway simple struct to hold spoke details
@@ -514,9 +512,4 @@ func (c *Client) DisableGlobalVpc(gateway *Gateway) error {
 		"gateway_name": gateway.GwName,
 	}
 	return c.PostAPI(form["action"], form, BasicCheck)
-}
-
-// diff suppress function for bgp_neighbor_status_polling_time. Suppress the diff if old value is 0
-func DiffSuppressFuncBgpNeighborStatusPollingTime(k, old, new string, d *schema.ResourceData) bool {
-	return old == "0"
 }

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -3,6 +3,8 @@ package goaviatrix
 import (
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Spoke gateway simple struct to hold spoke details
@@ -512,4 +514,9 @@ func (c *Client) DisableGlobalVpc(gateway *Gateway) error {
 		"gateway_name": gateway.GwName,
 	}
 	return c.PostAPI(form["action"], form, BasicCheck)
+}
+
+// diff suppress function for bgp_neighbor_status_polling_time. Suppress the diff if old value is 0
+func DiffSuppressFuncBgpNeighborStatusPollingTime(k, old, new string, d *schema.ResourceData) bool {
+	return old == "0"
 }


### PR DESCRIPTION
Backport for https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2123

- Adding the check for bgp_neighbor_status_polling_time to avoid api call from older controller version and latest TF provider version.
- The api call will only take place if the bgp_neighbor_status_polling_time is set in the resource to a non-default value.
- Adding the diff suppress function for bgp_neighbor_status_polling_time where value of 0 is set for the parameter in the api. This will allow backward compatibility with the older 7.2 versions of the controller where the api call does not exist.