### PR TITLE
AVX-59753 Adding checks for bgp_neighbor_status_polling_time for backward compatibilty

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1418,12 +1418,6 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 	}
 
 	if val, ok := d.GetOk("bgp_neighbor_status_polling_time"); ok {
-		err := client.SetBgpBfdPollingTime(gateway, val.(int))
-		if err != nil {
-			return fmt.Errorf("could not set bgp neighbor status polling time: %v", err)
-		}
-	}
-	if val, ok := d.GetOk("bgp_neighbor_status_polling_time"); ok {
 		bgp_neighbor_status_polling_time := val.(int)
 		if bgp_neighbor_status_polling_time >= 1 && bgp_neighbor_status_polling_time != defaultBgpNeighborStatusPollingTime {
 			err := client.SetBgpBfdPollingTime(gateway, bgp_neighbor_status_polling_time)


### PR DESCRIPTION
Backport for - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2123
- Removing the older code for bgp_neighbor_status_polling_time