### PR TITLE
AVX-57244 Adding support for EAT Equinix

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -4078,9 +4078,12 @@ func getEipMapDetails(eipMap []interface{}, wanCount int) (string, error) {
 
 func getTransitHaGatewayDetails(d *schema.ResourceData, wanCount int, cloudType int) (*goaviatrix.TransitHaGateway, error) {
 	transitHaGw := &goaviatrix.TransitHaGateway{
-		PrimaryGwName: d.Get("gw_name").(string),
-		GwName:        d.Get("gw_name").(string) + "-hagw",
-		InsaneMode:    "yes",
+		PrimaryGwName:       d.Get("gw_name").(string),
+		GwName:              d.Get("gw_name").(string) + "-hagw",
+		VpcID:               d.Get("vpc_id").(string),
+		ZtpFileDownloadPath: d.Get("ztp_file_download_path").(string),
+		CloudType:           d.Get("cloud_type").(int),
+		InsaneMode:          "yes",
 	}
 	peerBackupPortType, ok := d.GetOk("peer_backup_port_type")
 	if !ok {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1359,7 +1359,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		defer resourceAviatrixTransitGatewayReadIfRequired(d, meta, &flag)
 		err := client.LaunchTransitVpc(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to create Aviatrix Transit Gateway: %s", err)
+			return fmt.Errorf("failed to create Aviatrix Transit Gateway: %w", err)
 		}
 
 		if !singleAZ {
@@ -1372,7 +1372,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 			err := client.DisableSingleAZGateway(singleAZGateway)
 			if err != nil {
-				return fmt.Errorf("failed to disable single AZ GW HA: %s", err)
+				return fmt.Errorf("failed to disable single AZ GW HA: %w", err)
 			}
 		}
 
@@ -1449,7 +1449,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 			_, err := client.CreateTransitHaGw(transitHaGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
+				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
 			}
 
 			// Resize HA Gateway
@@ -1471,7 +1471,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 				err = client.UpdateGateway(haGateway)
 				if err != nil {
-					return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %s", err)
+					return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %w", err)
 				}
 			}
 		}
@@ -1484,14 +1484,14 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 			err := client.AttachTransitGWForHybrid(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable transit GW for Hybrid: %s", err)
+				return fmt.Errorf("failed to enable transit GW for Hybrid: %w", err)
 			}
 		}
 
 		if connectedTransit {
 			err := client.EnableConnectedTransit(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable connected transit: %s", err)
+				return fmt.Errorf("failed to enable connected transit: %w", err)
 			}
 		}
 
@@ -1499,12 +1499,12 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			if enableGatewayLoadBalancer {
 				err := client.EnableGatewayFireNetInterfacesWithGWLB(gateway)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %s", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %w", err)
 				}
 			} else {
 				err := client.EnableGatewayFireNetInterfaces(gateway)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %s", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %w", err)
 				}
 			}
 		}
@@ -1519,7 +1519,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 			err := client.EnableVpcDnsServer(gwVpcDnsServer)
 			if err != nil {
-				return fmt.Errorf("failed to enable VPC DNS Server: %s", err)
+				return fmt.Errorf("failed to enable VPC DNS Server: %w", err)
 			}
 		} else if enableVpcDnsServer {
 			return fmt.Errorf("'enable_vpc_dns_server' only supported by AWS (1), Azure (8), AzureGov (32), AWSGov (256), AWSChina (1024), AzureChina (2048), Alibaba Cloud (8192), AWS Top Secret (16384) or AWS Secret (32768)")
@@ -1529,7 +1529,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		if enableAdvertiseTransitCidr {
 			err := client.EnableAdvertiseTransitCidr(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable advertise transit CIDR: %s", err)
+				return fmt.Errorf("failed to enable advertise transit CIDR: %w", err)
 			}
 		}
 
@@ -1538,7 +1538,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			gateway.BgpManualSpokeAdvertiseCidrs = bgpManualSpokeAdvertiseCidrs
 			err := client.SetBgpManualSpokeAdvertisedNetworks(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to set BGP Manual Spoke Advertise Cidrs: %s", err)
+				return fmt.Errorf("failed to set BGP Manual Spoke Advertise Cidrs: %w", err)
 			}
 		}
 
@@ -1556,7 +1556,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				if i <= 10 && strings.Contains(err.Error(), "when it is down") {
 					time.Sleep(10 * time.Second)
 				} else {
-					return fmt.Errorf("failed to customize spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
+					return fmt.Errorf("failed to customize spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
 				}
 			}
 		}
@@ -1575,7 +1575,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				if i <= 10 && strings.Contains(err.Error(), "when it is down") {
 					time.Sleep(10 * time.Second)
 				} else {
-					return fmt.Errorf("failed to edit filtered spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
+					return fmt.Errorf("failed to edit filtered spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
 				}
 			}
 		}
@@ -1594,7 +1594,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				if i <= 10 && strings.Contains(err.Error(), "when it is down") {
 					time.Sleep(10 * time.Second)
 				} else {
-					return fmt.Errorf("failed to edit advertised spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
+					return fmt.Errorf("failed to edit advertised spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
 				}
 			}
 		}
@@ -1611,7 +1611,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			} else {
 				err := client.EnableTransitFireNet(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
 				}
 			}
 		}
@@ -1695,7 +1695,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		if approvalMode != defaultLearnedCidrApprovalMode {
 			err := client.SetTransitLearnedCIDRsApprovalMode(gateway, approvalMode)
 			if err != nil {
-				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", approvalMode, err)
+				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %w", approvalMode, err)
 			}
 		}
 
@@ -1713,7 +1713,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		if len(customizedTransitVpcRoutes) != 0 {
 			err := client.UpdateTransitGatewayCustomizedVpcRoute(gateway.GwName, customizedTransitVpcRoutes)
 			if err != nil {
-				return fmt.Errorf("couldn't update transit gateway customized vpc route: %s", err)
+				return fmt.Errorf("couldn't update transit gateway customized vpc route: %w", err)
 			}
 		}
 
@@ -1741,7 +1741,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			}
 			err := client.DisableGroGso(gw)
 			if err != nil {
-				return fmt.Errorf("couldn't disable GRO/GSO on transit gateway: %s", err)
+				return fmt.Errorf("couldn't disable GRO/GSO on transit gateway: %w", err)
 			}
 		}
 
@@ -1770,7 +1770,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		if enableS2CRxBalancing {
 			err = client.EnableS2CRxBalancing(gateway.GwName)
 			if err != nil {
-				return fmt.Errorf("could not enable S2C receive packet CPU re-balancing on transit %s: %v", gateway.GwName, err)
+				return fmt.Errorf("could not enable S2C receive packet CPU re-balancing on transit %s: %w", gateway.GwName, err)
 			}
 		}
 
@@ -1788,7 +1788,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			}
 			err := client.SetRxQueueSize(gwRxQueueSize)
 			if err != nil {
-				return fmt.Errorf("failed to set rx queue size for transit %s: %s", gateway.GwName, err)
+				return fmt.Errorf("failed to set rx queue size for transit %s: %w", gateway.GwName, err)
 			}
 			if haSubnet != "" || haZone != "" {
 				haGwRxQueueSize := &goaviatrix.Gateway{
@@ -1797,7 +1797,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				}
 				err := client.SetRxQueueSize(haGwRxQueueSize)
 				if err != nil {
-					return fmt.Errorf("failed to set rx queue size for transit ha %s : %s", haGwRxQueueSize.GwName, err)
+					return fmt.Errorf("failed to set rx queue size for transit ha %s : %w", haGwRxQueueSize.GwName, err)
 				}
 			}
 		}
@@ -1839,7 +1839,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("couldn't find Aviatrix Transit Gateway: %s", err)
+		return fmt.Errorf("couldn't find Aviatrix Transit Gateway: %w", err)
 	}
 
 	log.Printf("[TRACE] reading gateway %s: %#v", d.Get("gw_name").(string), gw)
@@ -2020,7 +2020,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 
 			bgpLanIpInfo, err := client.GetBgpLanIPList(&goaviatrix.TransitVpc{GwName: gateway.GwName})
 			if err != nil {
-				return fmt.Errorf("could not get BGP LAN IP info for GCP transit gateway %s: %v", gateway.GwName, err)
+				return fmt.Errorf("could not get BGP LAN IP info for GCP transit gateway %s: %w", gateway.GwName, err)
 			}
 			if err = d.Set("bgp_lan_ip_list", bgpLanIpInfo.BgpLanIpList); err != nil {
 				return fmt.Errorf("could not set bgp_lan_ip_list into state: %w", err)
@@ -2035,7 +2035,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		} else if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) && gw.EnableBgpOverLan {
 			bgpLanIpInfo, err := client.GetBgpLanIPList(&goaviatrix.TransitVpc{GwName: gateway.GwName})
 			if err != nil {
-				return fmt.Errorf("could not get BGP LAN IP info for Azure transit gateway %s: %v", gateway.GwName, err)
+				return fmt.Errorf("could not get BGP LAN IP info for Azure transit gateway %s: %w", gateway.GwName, err)
 			}
 			if err = d.Set("bgp_lan_ip_list", bgpLanIpInfo.AzureBgpLanIpList); err != nil {
 				return fmt.Errorf("could not set bgp_lan_ip_list into state: %w", err)
@@ -2255,7 +2255,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 
 		enableGroGso, err := client.GetGroGsoStatus(gw)
 		if err != nil {
-			return fmt.Errorf("failed to get GRO/GSO status of transit gateway %s: %v", gw.GwName, err)
+			return fmt.Errorf("failed to get GRO/GSO status of transit gateway %s: %w", gw.GwName, err)
 		}
 		d.Set("enable_gro_gso", enableGroGso)
 		if gw.HaGw.GwSize == "" {
@@ -2648,7 +2648,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if newHaGwEnabled {
 			_, err := client.CreateTransitHaGw(transitHaGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
+				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
 			}
 			if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 				if d.Get("rx_queue_size").(string) != "" && !d.HasChange("rx_queue_size") {
@@ -2658,25 +2658,25 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					}
 					err := client.SetRxQueueSize(haGwRxQueueSize)
 					if err != nil {
-						return fmt.Errorf("could not set rx queue size for transit ha: %s during gateway update: %v", haGwRxQueueSize.GwName, err)
+						return fmt.Errorf("could not set rx queue size for transit ha: %s during gateway update: %w", haGwRxQueueSize.GwName, err)
 					}
 				}
 			}
 		} else if deleteHaGw {
 			err := client.DeleteGateway(haGateway)
 			if err != nil {
-				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %s", err)
+				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %w", err)
 			}
 		} else if changeHaGw {
 			err := client.DeleteGateway(haGateway)
 			if err != nil {
-				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %s", err)
+				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %w", err)
 			}
 
 			transitHaGw.Eip = ""
 			_, err = client.CreateTransitHaGw(transitHaGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
+				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
 			}
 			newHaGwEnabled = true
 		}
@@ -2701,7 +2701,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 
 			err := client.EnableSingleAZGateway(singleAZGateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGateway.GwName, err)
+				return fmt.Errorf("failed to enable single AZ GW HA for %s: %w", singleAZGateway.GwName, err)
 			}
 
 			if haEnabled {
@@ -2710,14 +2710,14 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err := client.EnableSingleAZGateway(singleAZGatewayHA)
 				if err != nil {
-					return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
+					return fmt.Errorf("failed to enable single AZ GW HA for %s: %w", singleAZGatewayHA.GwName, err)
 				}
 			}
 		} else {
 			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
 			err := client.DisableSingleAZGateway(singleAZGateway)
 			if err != nil {
-				return fmt.Errorf("failed to disable single AZ GW HA for %s: %s", singleAZGateway.GwName, err)
+				return fmt.Errorf("failed to disable single AZ GW HA for %s: %w", singleAZGateway.GwName, err)
 			}
 
 			if haEnabled {
@@ -2726,7 +2726,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err := client.DisableSingleAZGateway(singleAZGatewayHA)
 				if err != nil {
-					return fmt.Errorf("failed to disable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
+					return fmt.Errorf("failed to disable single AZ GW HA for %s: %w", singleAZGatewayHA.GwName, err)
 				}
 			}
 		}
@@ -2772,12 +2772,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if connectedTransit {
 			err := client.EnableConnectedTransit(transitGateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable connected transit: %s", err)
+				return fmt.Errorf("failed to enable connected transit: %w", err)
 			}
 		} else {
 			err := client.DisableConnectedTransit(transitGateway)
 			if err != nil {
-				return fmt.Errorf("failed to disable connected transit: %s", err)
+				return fmt.Errorf("failed to disable connected transit: %w", err)
 			}
 		}
 	}
@@ -2790,7 +2790,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			gateway.VpcSize = d.Get("gw_size").(string)
 			err := client.UpdateGateway(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to update Aviatrix Transit Gateway: %s", err)
+				return fmt.Errorf("failed to update Aviatrix Transit Gateway: %w", err)
 			}
 		}
 
@@ -2807,7 +2807,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					// If HA gateway does not exist, don't try to change HA gateway size and continue with the rest of the updates
 					// to the gateway
 					if err != goaviatrix.ErrNotFound {
-						return fmt.Errorf("couldn't find Aviatrix Transit HA Gateway while trying to update HA Gw size: %s", err)
+						return fmt.Errorf("couldn't find Aviatrix Transit HA Gateway while trying to update HA Gw size: %w", err)
 					}
 				} else {
 					if haGateway.VpcSize == "" {
@@ -2817,7 +2817,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					err = client.UpdateGateway(haGateway)
 					log.Printf("[INFO] Updating HA Gateway size to: %s ", haGateway.VpcSize)
 					if err != nil {
-						return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %s", err)
+						return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %w", err)
 					}
 				}
 			}
@@ -2834,12 +2834,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if enableNat {
 			err := client.EnableSNat(gw)
 			if err != nil {
-				return fmt.Errorf("failed to enable 'single_ip' mode SNAT feature: %s", err)
+				return fmt.Errorf("failed to enable 'single_ip' mode SNAT feature: %w", err)
 			}
 		} else {
 			err := client.DisableSNat(gw)
 			if err != nil {
-				return fmt.Errorf("failed to disable 'single_ip' mode SNAT: %s", err)
+				return fmt.Errorf("failed to disable 'single_ip' mode SNAT: %w", err)
 			}
 		}
 
@@ -2864,7 +2864,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			interfaces, err := getInterfaceDetails(interfaceList)
 			if err != nil {
-				return fmt.Errorf("failed to get interface details: %s", err)
+				return fmt.Errorf("failed to get interface details: %w", err)
 			}
 			gateway := &goaviatrix.TransitVpc{
 				GwName:     d.Get("gw_name").(string),
@@ -2872,7 +2872,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err = client.UpdateEdgeGateway(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to update edge gateway: %s", err)
+				return fmt.Errorf("failed to update edge gateway: %w", err)
 			}
 		}
 
@@ -2903,7 +2903,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err = client.UpdateEdgeGateway(gateway)
 				if err != nil {
-					return fmt.Errorf("failed to update edge gateway: %s", err)
+					return fmt.Errorf("failed to update edge gateway: %w", err)
 				}
 			}
 		}
@@ -2927,7 +2927,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			log.Printf("[INFO] Enabling HA on Transit Gateway")
 			_, err = client.CreateTransitHaGw(transitHaGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
+				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
 			}
 		}
 
@@ -2940,7 +2940,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if len(haInterfaceList) > 0 {
 				haInterfaces, err := getInterfaceDetails(haInterfaceList)
 				if err != nil {
-					return fmt.Errorf("failed to get interface details: %s", err)
+					return fmt.Errorf("failed to get interface details: %w", err)
 				}
 				gateway := &goaviatrix.TransitVpc{
 					GwName:     d.Get("gw_name").(string) + "-hagw",
@@ -2948,13 +2948,13 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err = client.UpdateEdgeGateway(gateway)
 				if err != nil {
-					return fmt.Errorf("failed to update edge gateway: %s", err)
+					return fmt.Errorf("failed to update edge gateway: %w", err)
 				}
 			} else {
 				// delete the HA gateway if ha_interfaces is empty
 				err := client.DeleteGateway(haGateway)
 				if err != nil {
-					return fmt.Errorf("failed to delete HA gateway: %s", err)
+					return fmt.Errorf("failed to delete HA gateway: %w", err)
 				}
 			}
 		}
@@ -2973,12 +2973,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if enableHybridConnection {
 				err := client.AttachTransitGWForHybrid(transitGateway)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for Hybrid: %s", err)
+					return fmt.Errorf("failed to enable transit GW for Hybrid: %w", err)
 				}
 			} else {
 				err := client.DetachTransitGWForHybrid(transitGateway)
 				if err != nil {
-					return fmt.Errorf("failed to disable transit GW for Hybrid: %s", err)
+					return fmt.Errorf("failed to disable transit GW for Hybrid: %w", err)
 				}
 			}
 		}
@@ -2998,34 +2998,34 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if learnedCidrsApproval {
 				err := client.EnableTransitLearnedCidrsApproval(gw)
 				if err != nil {
-					return fmt.Errorf("failed to enable learned cidrs approval: %s", err)
+					return fmt.Errorf("failed to enable learned cidrs approval: %w", err)
 				}
 			} else {
 				err := client.DisableTransitLearnedCidrsApproval(gw)
 				if err != nil {
-					return fmt.Errorf("failed to disable learned cidrs approval: %s", err)
+					return fmt.Errorf("failed to disable learned cidrs approval: %w", err)
 				}
 			}
 			mode := d.Get("learned_cidrs_approval_mode").(string)
 			err := client.SetTransitLearnedCIDRsApprovalMode(gw, mode)
 			if err != nil {
-				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", mode, err)
+				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %w", mode, err)
 			}
 		} else {
 			mode := d.Get("learned_cidrs_approval_mode").(string)
 			err := client.SetTransitLearnedCIDRsApprovalMode(gw, mode)
 			if err != nil {
-				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", mode, err)
+				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %w", mode, err)
 			}
 			if learnedCidrsApproval {
 				err = client.EnableTransitLearnedCidrsApproval(gw)
 				if err != nil {
-					return fmt.Errorf("failed to enable learned cidrs approval: %s", err)
+					return fmt.Errorf("failed to enable learned cidrs approval: %w", err)
 				}
 			} else {
 				err = client.DisableTransitLearnedCidrsApproval(gw)
 				if err != nil {
-					return fmt.Errorf("failed to disable learned cidrs approval: %s", err)
+					return fmt.Errorf("failed to disable learned cidrs approval: %w", err)
 				}
 			}
 		}
@@ -3036,7 +3036,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		mode := d.Get("learned_cidrs_approval_mode").(string)
 		err := client.SetTransitLearnedCIDRsApprovalMode(gw, mode)
 		if err != nil {
-			return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", mode, err)
+			return fmt.Errorf("could not set learned CIDRs approval mode to %q: %w", mode, err)
 		}
 	} else if d.HasChange("enable_learned_cidrs_approval") {
 		gw := &goaviatrix.TransitVpc{
@@ -3046,13 +3046,13 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			gw.LearnedCidrsApproval = "yes"
 			err := client.EnableTransitLearnedCidrsApproval(gw)
 			if err != nil {
-				return fmt.Errorf("failed to enable learned cidrs approval: %s", err)
+				return fmt.Errorf("failed to enable learned cidrs approval: %w", err)
 			}
 		} else {
 			gw.LearnedCidrsApproval = "no"
 			err := client.DisableTransitLearnedCidrsApproval(gw)
 			if err != nil {
-				return fmt.Errorf("failed to disable learned cidrs approval: %s", err)
+				return fmt.Errorf("failed to disable learned cidrs approval: %w", err)
 			}
 		}
 	}
@@ -3115,7 +3115,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if !enableFireNet {
 			err := client.DisableGatewayFireNetInterfaces(transitGW)
 			if err != nil {
-				return fmt.Errorf("failed to disable transit GW for FireNet Interfaces: %s", err)
+				return fmt.Errorf("failed to disable transit GW for FireNet Interfaces: %w", err)
 			}
 		}
 		if !enableTransitFireNet {
@@ -3124,19 +3124,19 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.DisableTransitFireNet(gwTransitFireNet)
 			if err != nil {
-				return fmt.Errorf("failed to disable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
+				return fmt.Errorf("failed to disable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
 			}
 		}
 		if enableFireNet {
 			if enableGatewayLoadBalancer {
 				err := client.EnableGatewayFireNetInterfacesWithGWLB(transitGW)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %s", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %w", err)
 				}
 			} else {
 				err := client.EnableGatewayFireNetInterfaces(transitGW)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %s", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %w", err)
 				}
 			}
 		}
@@ -3147,12 +3147,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if enableGatewayLoadBalancer {
 				err := client.EnableTransitFireNetWithGWLB(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet with Gateway Load Balancer for %s due to %s", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet with Gateway Load Balancer for %s due to %w", gwTransitFireNet.GwName, err)
 				}
 			} else {
 				err := client.EnableTransitFireNet(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
 				}
 			}
 		}
@@ -3165,18 +3165,18 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if enableGatewayLoadBalancer {
 				err := client.EnableGatewayFireNetInterfacesWithGWLB(transitGW)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %s", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %w", err)
 				}
 			} else {
 				err := client.EnableGatewayFireNetInterfaces(transitGW)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %s", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %w", err)
 				}
 			}
 		} else {
 			err := client.DisableGatewayFireNetInterfaces(transitGW)
 			if err != nil {
-				return fmt.Errorf("failed to disable transit GW for FireNet Interfaces: %s", err)
+				return fmt.Errorf("failed to disable transit GW for FireNet Interfaces: %w", err)
 			}
 		}
 	} else if d.HasChange("enable_transit_firenet") {
@@ -3187,12 +3187,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if enableGatewayLoadBalancer {
 				err := client.EnableTransitFireNetWithGWLB(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet with Gateway Load Balancer for %s due to %s", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet with Gateway Load Balancer for %s due to %w", gwTransitFireNet.GwName, err)
 				}
 			} else {
 				err := client.EnableTransitFireNet(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
 				}
 			}
 		} else {
@@ -3201,7 +3201,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.DisableTransitFireNet(gwTransitFireNet)
 			if err != nil {
-				return fmt.Errorf("failed to disable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
+				return fmt.Errorf("failed to disable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
 			}
 		}
 	} else if d.HasChange("enable_gateway_load_balancer") {
@@ -3227,7 +3227,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			gateway.VpcSize = d.Get("gw_size").(string)
 			err := client.UpdateGateway(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to update Aviatrix Transit Gateway: %s", err)
+				return fmt.Errorf("failed to update Aviatrix Transit Gateway: %w", err)
 			}
 		}
 
@@ -3244,7 +3244,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					// If HA gateway does not exist, don't try to change gateway size and continue with the rest of the updates
 					// to the gateway
 					if err != goaviatrix.ErrNotFound {
-						return fmt.Errorf("couldn't find Aviatrix Transit HA Gateway while trying to update HA Gw size: %s", err)
+						return fmt.Errorf("couldn't find Aviatrix Transit HA Gateway while trying to update HA Gw size: %w", err)
 					}
 				} else {
 					if haGateway.VpcSize == "" {
@@ -3254,7 +3254,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					err = client.UpdateGateway(haGateway)
 					log.Printf("[INFO] Updating HA Gateway size to: %s ", haGateway.VpcSize)
 					if err != nil {
-						return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %s", err)
+						return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %w", err)
 					}
 				}
 			}
@@ -3281,12 +3281,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if enableVpcDnsServer {
 			err := client.EnableVpcDnsServer(gw)
 			if err != nil {
-				return fmt.Errorf("failed to enable VPC DNS Server: %s", err)
+				return fmt.Errorf("failed to enable VPC DNS Server: %w", err)
 			}
 		} else {
 			err := client.DisableVpcDnsServer(gw)
 			if err != nil {
-				return fmt.Errorf("failed to disable VPC DNS Server: %s", err)
+				return fmt.Errorf("failed to disable VPC DNS Server: %w", err)
 			}
 		}
 	} else if d.HasChange("enable_vpc_dns_server") {
@@ -3302,13 +3302,13 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			transitGw.EnableAdvertiseTransitCidr = true
 			err := client.EnableAdvertiseTransitCidr(transitGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable advertise transit CIDR: %s", err)
+				return fmt.Errorf("failed to enable advertise transit CIDR: %w", err)
 			}
 		} else {
 			transitGw.EnableAdvertiseTransitCidr = false
 			err := client.DisableAdvertiseTransitCidr(transitGw)
 			if err != nil {
-				return fmt.Errorf("failed to disable advertise transit CIDR: %s", err)
+				return fmt.Errorf("failed to disable advertise transit CIDR: %w", err)
 			}
 		}
 	}
@@ -3321,7 +3321,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		transitGw.BgpManualSpokeAdvertiseCidrs = bgpManualSpokeAdvertiseCidrs
 		err := client.SetBgpManualSpokeAdvertisedNetworks(transitGw)
 		if err != nil {
-			return fmt.Errorf("failed to set bgp manual spoke advertise CIDRs: %s", err)
+			return fmt.Errorf("failed to set bgp manual spoke advertise CIDRs: %w", err)
 		}
 	}
 
@@ -3336,7 +3336,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.EnableEncryptVolume(gwEncVolume)
 			if err != nil {
-				return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwEncVolume.GwName, err)
+				return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %w", gwEncVolume.GwName, err)
 			}
 
 			haSubnet := d.Get("ha_subnet").(string)
@@ -3349,7 +3349,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err := client.EnableEncryptVolume(gwHAEncVolume)
 				if err != nil {
-					return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwHAEncVolume.GwName, err)
+					return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %w", gwHAEncVolume.GwName, err)
 				}
 			}
 		} else {
@@ -3371,7 +3371,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			err := client.EditGatewayCustomRoutes(transitGateway)
 			log.Printf("[INFO] Customizeing routes of transit gateway: %s ", transitGateway.GwName)
 			if err != nil {
-				return fmt.Errorf("failed to customize spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
+				return fmt.Errorf("failed to customize spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
 			}
 		}
 	}
@@ -3388,7 +3388,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			err := client.EditGatewayFilterRoutes(transitGateway)
 			log.Printf("[INFO] Editing filtered spoke vpc routes of transit gateway: %s ", transitGateway.GwName)
 			if err != nil {
-				return fmt.Errorf("failed to edit filtered spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
+				return fmt.Errorf("failed to edit filtered spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
 			}
 		}
 	}
@@ -3405,7 +3405,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			err := client.EditGatewayAdvertisedCidr(transitGateway)
 			log.Printf("[INFO] Editing excluded advertised spoke vpc routes of transit gateway: %s ", transitGateway.GwName)
 			if err != nil {
-				return fmt.Errorf("failed to edit excluded advertised spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
+				return fmt.Errorf("failed to edit excluded advertised spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
 			}
 		}
 	}
@@ -3525,7 +3525,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 
 		err := client.UpdateTransitGatewayCustomizedVpcRoute(gateway.GwName, customizedTransitVpcRoutes)
 		if err != nil {
-			return fmt.Errorf("couldn't update transit gateway customized vpc route: %s", err)
+			return fmt.Errorf("couldn't update transit gateway customized vpc route: %w", err)
 		}
 	}
 
@@ -3578,12 +3578,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if d.Get("enable_gro_gso").(bool) {
 			err := client.EnableGroGso(gateway)
 			if err != nil {
-				return fmt.Errorf("couldn't enable GRO/GSO on transit gateway when updating: %s", err)
+				return fmt.Errorf("couldn't enable GRO/GSO on transit gateway when updating: %w", err)
 			}
 		} else {
 			err := client.DisableGroGso(gateway)
 			if err != nil {
-				return fmt.Errorf("couldn't disable GRO/GSO on transit gateway when updating: %s", err)
+				return fmt.Errorf("couldn't disable GRO/GSO on transit gateway when updating: %w", err)
 			}
 		}
 	}
@@ -3668,7 +3668,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		}
 		err := client.SetRxQueueSize(gw)
 		if err != nil {
-			return fmt.Errorf("could not modify rx queue size for transit: %s during gateway update: %v", gw.GatewayName, err)
+			return fmt.Errorf("could not modify rx queue size for transit: %s during gateway update: %w", gw.GatewayName, err)
 		}
 		if haSubnet != "" || haZone != "" {
 			haGwRxQueueSize := &goaviatrix.Gateway{
@@ -3677,7 +3677,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.SetRxQueueSize(haGwRxQueueSize)
 			if err != nil {
-				return fmt.Errorf("could not modify rx queue size for transit ha: %s during gateway update: %v", haGwRxQueueSize.GwName, err)
+				return fmt.Errorf("could not modify rx queue size for transit ha: %s during gateway update: %w", haGwRxQueueSize.GwName, err)
 			}
 		}
 	}
@@ -3709,7 +3709,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		}
 		err := client.ChangeBgpOverLanIntfCnt(gw)
 		if err != nil {
-			return fmt.Errorf("could not modify BGP over LAN interface count for transit: %s during gateway update: %v", gw.GatewayName, err)
+			return fmt.Errorf("could not modify BGP over LAN interface count for transit: %s during gateway update: %w", gw.GatewayName, err)
 		}
 		if haSubnet != "" {
 			haGw := &goaviatrix.Gateway{
@@ -3718,7 +3718,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.ChangeBgpOverLanIntfCnt(haGw)
 			if err != nil {
-				return fmt.Errorf("could not modify BGP over LAN interface count for transit ha: %s during gateway update: %v", haGw.GwName, err)
+				return fmt.Errorf("could not modify BGP over LAN interface count for transit ha: %s during gateway update: %w", haGw.GwName, err)
 			}
 		}
 	}
@@ -3763,7 +3763,7 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 
 		err := client.DisableGatewayFireNetInterfaces(gw)
 		if err != nil {
-			return fmt.Errorf("failed to disable Aviatrix Transit Gateway for FireNet Interfaces: %s", err)
+			return fmt.Errorf("failed to disable Aviatrix Transit Gateway for FireNet Interfaces: %w", err)
 		}
 	}
 
@@ -3771,12 +3771,12 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 	if enableTransitFireNet && goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.OCIRelatedCloudTypes) {
 		err := client.DisableTransitFireNet(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to disable transit firenet for %s due to %s", gateway.GwName, err)
+			return fmt.Errorf("failed to disable transit firenet for %s due to %w", gateway.GwName, err)
 		}
 	} else if enableTransitFireNet && goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes) {
 		err := client.IsTransitFireNetReadyToBeDisabled(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to disable transit firenet for %s due to %s", gateway.GwName, err)
+			return fmt.Errorf("failed to disable transit firenet for %s due to %w", gateway.GwName, err)
 		}
 	}
 
@@ -3799,14 +3799,14 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 				}
 
 				if !strings.Contains(err.Error(), "EOF") {
-					return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway HA gateway: %s", err)
+					return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway HA gateway: %w", err)
 				}
 			} else {
 				break
 			}
 
 			if try == maxTries {
-				return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway HA gateway: %s", err)
+				return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway HA gateway: %w", err)
 			}
 			time.Sleep(backoff)
 			// Double the backoff time after each failed try
@@ -3815,19 +3815,19 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 		if cloudType == goaviatrix.EDGEEQUINIX {
 			err := deleteZtpFile(gateway.GwName, d.Get("vpc_id").(string), d.Get("ztp_file_download_path").(string))
 			if err != nil {
-				return fmt.Errorf("failed to delete ZTP file: %s", err)
+				return fmt.Errorf("failed to delete ZTP file: %w", err)
 			}
 		}
 	}
 	gateway.GwName = d.Get("gw_name").(string)
 	err := client.DeleteGateway(gateway)
 	if err != nil {
-		return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway: %s", err)
+		return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway: %w", err)
 	}
 	if cloudType == goaviatrix.EDGEEQUINIX {
 		err := deleteZtpFile(gateway.GwName, d.Get("vpc_id").(string), d.Get("ztp_file_download_path").(string))
 		if err != nil {
-			return fmt.Errorf("failed to delete ZTP file: %s", err)
+			return fmt.Errorf("failed to delete ZTP file: %w", err)
 		}
 	}
 
@@ -3842,7 +3842,7 @@ func deleteZtpFile(gatewayName, vpcId, ztpFileDownloadPath string) error {
 	}
 	err := os.Remove(fileName)
 	if err != nil {
-		return fmt.Errorf("could not remove the ztp file: %v", err)
+		return fmt.Errorf("could not remove the ztp file: %w", err)
 	}
 	return nil
 }
@@ -3898,7 +3898,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 	d.SetId(gateway.GwName)
 	err = client.LaunchTransitVpc(gateway)
 	if err != nil {
-		return fmt.Errorf("failed to create Aviatrix Transit Gateway: %s", err)
+		return fmt.Errorf("failed to create Aviatrix Transit Gateway: %w", err)
 	}
 	// create ha transit gateway if ha_interfaces are provided
 	ha_interfaces, ok := d.Get("ha_interfaces").([]interface{})
@@ -3911,7 +3911,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 		log.Printf("[INFO] Creating HA Aviatrix Transit Gateway: %#v", transitHaGw)
 		_, err = client.CreateTransitHaGw(transitHaGw)
 		if err != nil {
-			return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
+			return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
 		}
 	}
 
@@ -3929,7 +3929,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 		// update EIP map
 		err = client.UpdateEdgeGateway(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to update edge gateway: %s", err)
+			return fmt.Errorf("failed to update edge gateway: %w", err)
 		}
 	}
 
@@ -4112,7 +4112,7 @@ func getTransitHaGatewayDetails(d *schema.ResourceData, wanCount int, cloudType 
 	transitHaGw.BackupLinkList = append(transitHaGw.BackupLinkList, backupLinkData)
 	backupLinkConfig, err := json.Marshal(transitHaGw.BackupLinkList)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create backup link configuration: %s", err)
+		return nil, fmt.Errorf("failed to create backup link configuration: %w", err)
 	}
 	transitHaGw.BackupLinkConfig = b64.StdEncoding.EncodeToString(backupLinkConfig)
 	// get the HA interfaces
@@ -4366,7 +4366,7 @@ func setEipMapDetails(eipMap map[string][]goaviatrix.EipMap, ifNameTranslation m
 		interfaceType := strings.ToUpper(interfaceDetails[0])
 		interfaceIndex, err := strconv.Atoi(interfaceDetails[1])
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert interface index to integer for %s: %v", interfaceName, err)
+			return nil, fmt.Errorf("failed to convert interface index to integer for %s: %w", interfaceName, err)
 		}
 
 		for _, eip := range eipList {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -4128,7 +4128,10 @@ func getTransitHaGatewayDetails(d *schema.ResourceData, wanCount int, cloudType 
 		}
 		transitHaGw.InterfaceMapping = interfaceMapping
 		// set device_id for AEP ha gateway
-		transitHaGw.DeviceID = d.Get("ha_device_id").(string)
+		transitHaGw.DeviceID, ok = d.Get("ha_device_id").(string)
+		if !ok {
+			return nil, fmt.Errorf("ha_device_id is required for AEP HA Edge Transit Gateway")
+		}
 	}
 	return transitHaGw, nil
 }

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"sort"
@@ -3852,12 +3853,7 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 
 func deleteZtpFile(gatewayName, vpcID, ztpFileDownloadPath string) error {
 	fileName := ztpFileDownloadPath + "/" + gatewayName + "-" + vpcID + "-cloud-init.txt"
-	// check if the file exists
-	if _, err := os.Stat(fileName); os.IsNotExist(err) {
-		return nil
-	}
-	err := os.Remove(fileName)
-	if err != nil {
+	if err := os.Remove(fileName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("could not remove the ztp file: %w", err)
 	}
 	return nil

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1359,7 +1359,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		defer resourceAviatrixTransitGatewayReadIfRequired(d, meta, &flag)
 		err := client.LaunchTransitVpc(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to create Aviatrix Transit Gateway: %w", err)
+			return fmt.Errorf("failed to create Aviatrix Transit Gateway: %s", err)
 		}
 
 		if !singleAZ {
@@ -1372,7 +1372,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 			err := client.DisableSingleAZGateway(singleAZGateway)
 			if err != nil {
-				return fmt.Errorf("failed to disable single AZ GW HA: %w", err)
+				return fmt.Errorf("failed to disable single AZ GW HA: %s", err)
 			}
 		}
 
@@ -1449,7 +1449,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 			_, err := client.CreateTransitHaGw(transitHaGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
+				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
 			}
 
 			// Resize HA Gateway
@@ -1471,7 +1471,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 				err = client.UpdateGateway(haGateway)
 				if err != nil {
-					return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %w", err)
+					return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %s", err)
 				}
 			}
 		}
@@ -1484,14 +1484,14 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 			err := client.AttachTransitGWForHybrid(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable transit GW for Hybrid: %w", err)
+				return fmt.Errorf("failed to enable transit GW for Hybrid: %s", err)
 			}
 		}
 
 		if connectedTransit {
 			err := client.EnableConnectedTransit(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable connected transit: %w", err)
+				return fmt.Errorf("failed to enable connected transit: %s", err)
 			}
 		}
 
@@ -1499,12 +1499,12 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			if enableGatewayLoadBalancer {
 				err := client.EnableGatewayFireNetInterfacesWithGWLB(gateway)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %w", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %s", err)
 				}
 			} else {
 				err := client.EnableGatewayFireNetInterfaces(gateway)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %w", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %s", err)
 				}
 			}
 		}
@@ -1519,7 +1519,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 			err := client.EnableVpcDnsServer(gwVpcDnsServer)
 			if err != nil {
-				return fmt.Errorf("failed to enable VPC DNS Server: %w", err)
+				return fmt.Errorf("failed to enable VPC DNS Server: %s", err)
 			}
 		} else if enableVpcDnsServer {
 			return fmt.Errorf("'enable_vpc_dns_server' only supported by AWS (1), Azure (8), AzureGov (32), AWSGov (256), AWSChina (1024), AzureChina (2048), Alibaba Cloud (8192), AWS Top Secret (16384) or AWS Secret (32768)")
@@ -1529,7 +1529,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		if enableAdvertiseTransitCidr {
 			err := client.EnableAdvertiseTransitCidr(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable advertise transit CIDR: %w", err)
+				return fmt.Errorf("failed to enable advertise transit CIDR: %s", err)
 			}
 		}
 
@@ -1538,7 +1538,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			gateway.BgpManualSpokeAdvertiseCidrs = bgpManualSpokeAdvertiseCidrs
 			err := client.SetBgpManualSpokeAdvertisedNetworks(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to set BGP Manual Spoke Advertise Cidrs: %w", err)
+				return fmt.Errorf("failed to set BGP Manual Spoke Advertise Cidrs: %s", err)
 			}
 		}
 
@@ -1556,7 +1556,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				if i <= 10 && strings.Contains(err.Error(), "when it is down") {
 					time.Sleep(10 * time.Second)
 				} else {
-					return fmt.Errorf("failed to customize spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
+					return fmt.Errorf("failed to customize spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
 				}
 			}
 		}
@@ -1575,7 +1575,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				if i <= 10 && strings.Contains(err.Error(), "when it is down") {
 					time.Sleep(10 * time.Second)
 				} else {
-					return fmt.Errorf("failed to edit filtered spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
+					return fmt.Errorf("failed to edit filtered spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
 				}
 			}
 		}
@@ -1594,7 +1594,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				if i <= 10 && strings.Contains(err.Error(), "when it is down") {
 					time.Sleep(10 * time.Second)
 				} else {
-					return fmt.Errorf("failed to edit advertised spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
+					return fmt.Errorf("failed to edit advertised spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
 				}
 			}
 		}
@@ -1611,7 +1611,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			} else {
 				err := client.EnableTransitFireNet(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
 				}
 			}
 		}
@@ -1695,7 +1695,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		if approvalMode != defaultLearnedCidrApprovalMode {
 			err := client.SetTransitLearnedCIDRsApprovalMode(gateway, approvalMode)
 			if err != nil {
-				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %w", approvalMode, err)
+				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", approvalMode, err)
 			}
 		}
 
@@ -1713,7 +1713,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		if len(customizedTransitVpcRoutes) != 0 {
 			err := client.UpdateTransitGatewayCustomizedVpcRoute(gateway.GwName, customizedTransitVpcRoutes)
 			if err != nil {
-				return fmt.Errorf("couldn't update transit gateway customized vpc route: %w", err)
+				return fmt.Errorf("couldn't update transit gateway customized vpc route: %s", err)
 			}
 		}
 
@@ -1741,7 +1741,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			}
 			err := client.DisableGroGso(gw)
 			if err != nil {
-				return fmt.Errorf("couldn't disable GRO/GSO on transit gateway: %w", err)
+				return fmt.Errorf("couldn't disable GRO/GSO on transit gateway: %s", err)
 			}
 		}
 
@@ -1770,7 +1770,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 		if enableS2CRxBalancing {
 			err = client.EnableS2CRxBalancing(gateway.GwName)
 			if err != nil {
-				return fmt.Errorf("could not enable S2C receive packet CPU re-balancing on transit %s: %w", gateway.GwName, err)
+				return fmt.Errorf("could not enable S2C receive packet CPU re-balancing on transit %s: %v", gateway.GwName, err)
 			}
 		}
 
@@ -1788,7 +1788,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			}
 			err := client.SetRxQueueSize(gwRxQueueSize)
 			if err != nil {
-				return fmt.Errorf("failed to set rx queue size for transit %s: %w", gateway.GwName, err)
+				return fmt.Errorf("failed to set rx queue size for transit %s: %s", gateway.GwName, err)
 			}
 			if haSubnet != "" || haZone != "" {
 				haGwRxQueueSize := &goaviatrix.Gateway{
@@ -1797,7 +1797,7 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				}
 				err := client.SetRxQueueSize(haGwRxQueueSize)
 				if err != nil {
-					return fmt.Errorf("failed to set rx queue size for transit ha %s : %w", haGwRxQueueSize.GwName, err)
+					return fmt.Errorf("failed to set rx queue size for transit ha %s : %s", haGwRxQueueSize.GwName, err)
 				}
 			}
 		}
@@ -1839,7 +1839,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("couldn't find Aviatrix Transit Gateway: %w", err)
+		return fmt.Errorf("couldn't find Aviatrix Transit Gateway: %s", err)
 	}
 
 	log.Printf("[TRACE] reading gateway %s: %#v", d.Get("gw_name").(string), gw)
@@ -2020,7 +2020,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 
 			bgpLanIpInfo, err := client.GetBgpLanIPList(&goaviatrix.TransitVpc{GwName: gateway.GwName})
 			if err != nil {
-				return fmt.Errorf("could not get BGP LAN IP info for GCP transit gateway %s: %w", gateway.GwName, err)
+				return fmt.Errorf("could not get BGP LAN IP info for GCP transit gateway %s: %v", gateway.GwName, err)
 			}
 			if err = d.Set("bgp_lan_ip_list", bgpLanIpInfo.BgpLanIpList); err != nil {
 				return fmt.Errorf("could not set bgp_lan_ip_list into state: %w", err)
@@ -2035,7 +2035,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		} else if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) && gw.EnableBgpOverLan {
 			bgpLanIpInfo, err := client.GetBgpLanIPList(&goaviatrix.TransitVpc{GwName: gateway.GwName})
 			if err != nil {
-				return fmt.Errorf("could not get BGP LAN IP info for Azure transit gateway %s: %w", gateway.GwName, err)
+				return fmt.Errorf("could not get BGP LAN IP info for Azure transit gateway %s: %v", gateway.GwName, err)
 			}
 			if err = d.Set("bgp_lan_ip_list", bgpLanIpInfo.AzureBgpLanIpList); err != nil {
 				return fmt.Errorf("could not set bgp_lan_ip_list into state: %w", err)
@@ -2255,7 +2255,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 
 		enableGroGso, err := client.GetGroGsoStatus(gw)
 		if err != nil {
-			return fmt.Errorf("failed to get GRO/GSO status of transit gateway %s: %w", gw.GwName, err)
+			return fmt.Errorf("failed to get GRO/GSO status of transit gateway %s: %v", gw.GwName, err)
 		}
 		d.Set("enable_gro_gso", enableGroGso)
 		if gw.HaGw.GwSize == "" {
@@ -2648,7 +2648,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if newHaGwEnabled {
 			_, err := client.CreateTransitHaGw(transitHaGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
+				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
 			}
 			if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 				if d.Get("rx_queue_size").(string) != "" && !d.HasChange("rx_queue_size") {
@@ -2658,25 +2658,25 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					}
 					err := client.SetRxQueueSize(haGwRxQueueSize)
 					if err != nil {
-						return fmt.Errorf("could not set rx queue size for transit ha: %s during gateway update: %w", haGwRxQueueSize.GwName, err)
+						return fmt.Errorf("could not set rx queue size for transit ha: %s during gateway update: %v", haGwRxQueueSize.GwName, err)
 					}
 				}
 			}
 		} else if deleteHaGw {
 			err := client.DeleteGateway(haGateway)
 			if err != nil {
-				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %w", err)
+				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %s", err)
 			}
 		} else if changeHaGw {
 			err := client.DeleteGateway(haGateway)
 			if err != nil {
-				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %w", err)
+				return fmt.Errorf("failed to delete Aviatrix Transit HA gateway: %s", err)
 			}
 
 			transitHaGw.Eip = ""
 			_, err = client.CreateTransitHaGw(transitHaGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
+				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
 			}
 			newHaGwEnabled = true
 		}
@@ -2701,7 +2701,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 
 			err := client.EnableSingleAZGateway(singleAZGateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable single AZ GW HA for %s: %w", singleAZGateway.GwName, err)
+				return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGateway.GwName, err)
 			}
 
 			if haEnabled {
@@ -2710,14 +2710,14 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err := client.EnableSingleAZGateway(singleAZGatewayHA)
 				if err != nil {
-					return fmt.Errorf("failed to enable single AZ GW HA for %s: %w", singleAZGatewayHA.GwName, err)
+					return fmt.Errorf("failed to enable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
 				}
 			}
 		} else {
 			log.Printf("[INFO] Disable Single AZ GW HA: %#v", singleAZGateway)
 			err := client.DisableSingleAZGateway(singleAZGateway)
 			if err != nil {
-				return fmt.Errorf("failed to disable single AZ GW HA for %s: %w", singleAZGateway.GwName, err)
+				return fmt.Errorf("failed to disable single AZ GW HA for %s: %s", singleAZGateway.GwName, err)
 			}
 
 			if haEnabled {
@@ -2726,7 +2726,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err := client.DisableSingleAZGateway(singleAZGatewayHA)
 				if err != nil {
-					return fmt.Errorf("failed to disable single AZ GW HA for %s: %w", singleAZGatewayHA.GwName, err)
+					return fmt.Errorf("failed to disable single AZ GW HA for %s: %s", singleAZGatewayHA.GwName, err)
 				}
 			}
 		}
@@ -2772,12 +2772,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if connectedTransit {
 			err := client.EnableConnectedTransit(transitGateway)
 			if err != nil {
-				return fmt.Errorf("failed to enable connected transit: %w", err)
+				return fmt.Errorf("failed to enable connected transit: %s", err)
 			}
 		} else {
 			err := client.DisableConnectedTransit(transitGateway)
 			if err != nil {
-				return fmt.Errorf("failed to disable connected transit: %w", err)
+				return fmt.Errorf("failed to disable connected transit: %s", err)
 			}
 		}
 	}
@@ -2790,7 +2790,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			gateway.VpcSize = d.Get("gw_size").(string)
 			err := client.UpdateGateway(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to update Aviatrix Transit Gateway: %w", err)
+				return fmt.Errorf("failed to update Aviatrix Transit Gateway: %s", err)
 			}
 		}
 
@@ -2807,7 +2807,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					// If HA gateway does not exist, don't try to change HA gateway size and continue with the rest of the updates
 					// to the gateway
 					if err != goaviatrix.ErrNotFound {
-						return fmt.Errorf("couldn't find Aviatrix Transit HA Gateway while trying to update HA Gw size: %w", err)
+						return fmt.Errorf("couldn't find Aviatrix Transit HA Gateway while trying to update HA Gw size: %s", err)
 					}
 				} else {
 					if haGateway.VpcSize == "" {
@@ -2817,7 +2817,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					err = client.UpdateGateway(haGateway)
 					log.Printf("[INFO] Updating HA Gateway size to: %s ", haGateway.VpcSize)
 					if err != nil {
-						return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %w", err)
+						return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %s", err)
 					}
 				}
 			}
@@ -2834,12 +2834,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if enableNat {
 			err := client.EnableSNat(gw)
 			if err != nil {
-				return fmt.Errorf("failed to enable 'single_ip' mode SNAT feature: %w", err)
+				return fmt.Errorf("failed to enable 'single_ip' mode SNAT feature: %s", err)
 			}
 		} else {
 			err := client.DisableSNat(gw)
 			if err != nil {
-				return fmt.Errorf("failed to disable 'single_ip' mode SNAT: %w", err)
+				return fmt.Errorf("failed to disable 'single_ip' mode SNAT: %s", err)
 			}
 		}
 
@@ -2864,7 +2864,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			interfaces, err := getInterfaceDetails(interfaceList)
 			if err != nil {
-				return fmt.Errorf("failed to get interface details: %w", err)
+				return fmt.Errorf("failed to get interface details: %s", err)
 			}
 			gateway := &goaviatrix.TransitVpc{
 				GwName:     d.Get("gw_name").(string),
@@ -2872,7 +2872,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err = client.UpdateEdgeGateway(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to update edge gateway: %w", err)
+				return fmt.Errorf("failed to update edge gateway: %s", err)
 			}
 		}
 
@@ -2903,7 +2903,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err = client.UpdateEdgeGateway(gateway)
 				if err != nil {
-					return fmt.Errorf("failed to update edge gateway: %w", err)
+					return fmt.Errorf("failed to update edge gateway: %s", err)
 				}
 			}
 		}
@@ -2927,7 +2927,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			log.Printf("[INFO] Enabling HA on Transit Gateway")
 			_, err = client.CreateTransitHaGw(transitHaGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
+				return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
 			}
 		}
 
@@ -2940,7 +2940,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if len(haInterfaceList) > 0 {
 				haInterfaces, err := getInterfaceDetails(haInterfaceList)
 				if err != nil {
-					return fmt.Errorf("failed to get interface details: %w", err)
+					return fmt.Errorf("failed to get interface details: %s", err)
 				}
 				gateway := &goaviatrix.TransitVpc{
 					GwName:     d.Get("gw_name").(string) + "-hagw",
@@ -2948,13 +2948,13 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err = client.UpdateEdgeGateway(gateway)
 				if err != nil {
-					return fmt.Errorf("failed to update edge gateway: %w", err)
+					return fmt.Errorf("failed to update edge gateway: %s", err)
 				}
 			} else {
 				// delete the HA gateway if ha_interfaces is empty
 				err := client.DeleteGateway(haGateway)
 				if err != nil {
-					return fmt.Errorf("failed to delete HA gateway: %w", err)
+					return fmt.Errorf("failed to delete HA gateway: %s", err)
 				}
 			}
 		}
@@ -2973,12 +2973,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if enableHybridConnection {
 				err := client.AttachTransitGWForHybrid(transitGateway)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for Hybrid: %w", err)
+					return fmt.Errorf("failed to enable transit GW for Hybrid: %s", err)
 				}
 			} else {
 				err := client.DetachTransitGWForHybrid(transitGateway)
 				if err != nil {
-					return fmt.Errorf("failed to disable transit GW for Hybrid: %w", err)
+					return fmt.Errorf("failed to disable transit GW for Hybrid: %s", err)
 				}
 			}
 		}
@@ -2998,34 +2998,34 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if learnedCidrsApproval {
 				err := client.EnableTransitLearnedCidrsApproval(gw)
 				if err != nil {
-					return fmt.Errorf("failed to enable learned cidrs approval: %w", err)
+					return fmt.Errorf("failed to enable learned cidrs approval: %s", err)
 				}
 			} else {
 				err := client.DisableTransitLearnedCidrsApproval(gw)
 				if err != nil {
-					return fmt.Errorf("failed to disable learned cidrs approval: %w", err)
+					return fmt.Errorf("failed to disable learned cidrs approval: %s", err)
 				}
 			}
 			mode := d.Get("learned_cidrs_approval_mode").(string)
 			err := client.SetTransitLearnedCIDRsApprovalMode(gw, mode)
 			if err != nil {
-				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %w", mode, err)
+				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", mode, err)
 			}
 		} else {
 			mode := d.Get("learned_cidrs_approval_mode").(string)
 			err := client.SetTransitLearnedCIDRsApprovalMode(gw, mode)
 			if err != nil {
-				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %w", mode, err)
+				return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", mode, err)
 			}
 			if learnedCidrsApproval {
 				err = client.EnableTransitLearnedCidrsApproval(gw)
 				if err != nil {
-					return fmt.Errorf("failed to enable learned cidrs approval: %w", err)
+					return fmt.Errorf("failed to enable learned cidrs approval: %s", err)
 				}
 			} else {
 				err = client.DisableTransitLearnedCidrsApproval(gw)
 				if err != nil {
-					return fmt.Errorf("failed to disable learned cidrs approval: %w", err)
+					return fmt.Errorf("failed to disable learned cidrs approval: %s", err)
 				}
 			}
 		}
@@ -3036,7 +3036,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		mode := d.Get("learned_cidrs_approval_mode").(string)
 		err := client.SetTransitLearnedCIDRsApprovalMode(gw, mode)
 		if err != nil {
-			return fmt.Errorf("could not set learned CIDRs approval mode to %q: %w", mode, err)
+			return fmt.Errorf("could not set learned CIDRs approval mode to %q: %v", mode, err)
 		}
 	} else if d.HasChange("enable_learned_cidrs_approval") {
 		gw := &goaviatrix.TransitVpc{
@@ -3046,13 +3046,13 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			gw.LearnedCidrsApproval = "yes"
 			err := client.EnableTransitLearnedCidrsApproval(gw)
 			if err != nil {
-				return fmt.Errorf("failed to enable learned cidrs approval: %w", err)
+				return fmt.Errorf("failed to enable learned cidrs approval: %s", err)
 			}
 		} else {
 			gw.LearnedCidrsApproval = "no"
 			err := client.DisableTransitLearnedCidrsApproval(gw)
 			if err != nil {
-				return fmt.Errorf("failed to disable learned cidrs approval: %w", err)
+				return fmt.Errorf("failed to disable learned cidrs approval: %s", err)
 			}
 		}
 	}
@@ -3115,7 +3115,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if !enableFireNet {
 			err := client.DisableGatewayFireNetInterfaces(transitGW)
 			if err != nil {
-				return fmt.Errorf("failed to disable transit GW for FireNet Interfaces: %w", err)
+				return fmt.Errorf("failed to disable transit GW for FireNet Interfaces: %s", err)
 			}
 		}
 		if !enableTransitFireNet {
@@ -3124,19 +3124,19 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.DisableTransitFireNet(gwTransitFireNet)
 			if err != nil {
-				return fmt.Errorf("failed to disable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
+				return fmt.Errorf("failed to disable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
 			}
 		}
 		if enableFireNet {
 			if enableGatewayLoadBalancer {
 				err := client.EnableGatewayFireNetInterfacesWithGWLB(transitGW)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %w", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %s", err)
 				}
 			} else {
 				err := client.EnableGatewayFireNetInterfaces(transitGW)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %w", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %s", err)
 				}
 			}
 		}
@@ -3147,12 +3147,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if enableGatewayLoadBalancer {
 				err := client.EnableTransitFireNetWithGWLB(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet with Gateway Load Balancer for %s due to %w", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet with Gateway Load Balancer for %s due to %s", gwTransitFireNet.GwName, err)
 				}
 			} else {
 				err := client.EnableTransitFireNet(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
 				}
 			}
 		}
@@ -3165,18 +3165,18 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if enableGatewayLoadBalancer {
 				err := client.EnableGatewayFireNetInterfacesWithGWLB(transitGW)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %w", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces with Gateway Load Balancer enabled: %s", err)
 				}
 			} else {
 				err := client.EnableGatewayFireNetInterfaces(transitGW)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %w", err)
+					return fmt.Errorf("failed to enable transit GW for FireNet Interfaces: %s", err)
 				}
 			}
 		} else {
 			err := client.DisableGatewayFireNetInterfaces(transitGW)
 			if err != nil {
-				return fmt.Errorf("failed to disable transit GW for FireNet Interfaces: %w", err)
+				return fmt.Errorf("failed to disable transit GW for FireNet Interfaces: %s", err)
 			}
 		}
 	} else if d.HasChange("enable_transit_firenet") {
@@ -3187,12 +3187,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			if enableGatewayLoadBalancer {
 				err := client.EnableTransitFireNetWithGWLB(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet with Gateway Load Balancer for %s due to %w", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet with Gateway Load Balancer for %s due to %s", gwTransitFireNet.GwName, err)
 				}
 			} else {
 				err := client.EnableTransitFireNet(gwTransitFireNet)
 				if err != nil {
-					return fmt.Errorf("failed to enable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
+					return fmt.Errorf("failed to enable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
 				}
 			}
 		} else {
@@ -3201,7 +3201,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.DisableTransitFireNet(gwTransitFireNet)
 			if err != nil {
-				return fmt.Errorf("failed to disable transit firenet for %s due to %w", gwTransitFireNet.GwName, err)
+				return fmt.Errorf("failed to disable transit firenet for %s due to %s", gwTransitFireNet.GwName, err)
 			}
 		}
 	} else if d.HasChange("enable_gateway_load_balancer") {
@@ -3227,7 +3227,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			gateway.VpcSize = d.Get("gw_size").(string)
 			err := client.UpdateGateway(gateway)
 			if err != nil {
-				return fmt.Errorf("failed to update Aviatrix Transit Gateway: %w", err)
+				return fmt.Errorf("failed to update Aviatrix Transit Gateway: %s", err)
 			}
 		}
 
@@ -3244,7 +3244,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					// If HA gateway does not exist, don't try to change gateway size and continue with the rest of the updates
 					// to the gateway
 					if err != goaviatrix.ErrNotFound {
-						return fmt.Errorf("couldn't find Aviatrix Transit HA Gateway while trying to update HA Gw size: %w", err)
+						return fmt.Errorf("couldn't find Aviatrix Transit HA Gateway while trying to update HA Gw size: %s", err)
 					}
 				} else {
 					if haGateway.VpcSize == "" {
@@ -3254,7 +3254,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					err = client.UpdateGateway(haGateway)
 					log.Printf("[INFO] Updating HA Gateway size to: %s ", haGateway.VpcSize)
 					if err != nil {
-						return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %w", err)
+						return fmt.Errorf("failed to update Aviatrix Transit HA Gateway size: %s", err)
 					}
 				}
 			}
@@ -3281,12 +3281,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if enableVpcDnsServer {
 			err := client.EnableVpcDnsServer(gw)
 			if err != nil {
-				return fmt.Errorf("failed to enable VPC DNS Server: %w", err)
+				return fmt.Errorf("failed to enable VPC DNS Server: %s", err)
 			}
 		} else {
 			err := client.DisableVpcDnsServer(gw)
 			if err != nil {
-				return fmt.Errorf("failed to disable VPC DNS Server: %w", err)
+				return fmt.Errorf("failed to disable VPC DNS Server: %s", err)
 			}
 		}
 	} else if d.HasChange("enable_vpc_dns_server") {
@@ -3302,13 +3302,13 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			transitGw.EnableAdvertiseTransitCidr = true
 			err := client.EnableAdvertiseTransitCidr(transitGw)
 			if err != nil {
-				return fmt.Errorf("failed to enable advertise transit CIDR: %w", err)
+				return fmt.Errorf("failed to enable advertise transit CIDR: %s", err)
 			}
 		} else {
 			transitGw.EnableAdvertiseTransitCidr = false
 			err := client.DisableAdvertiseTransitCidr(transitGw)
 			if err != nil {
-				return fmt.Errorf("failed to disable advertise transit CIDR: %w", err)
+				return fmt.Errorf("failed to disable advertise transit CIDR: %s", err)
 			}
 		}
 	}
@@ -3321,7 +3321,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		transitGw.BgpManualSpokeAdvertiseCidrs = bgpManualSpokeAdvertiseCidrs
 		err := client.SetBgpManualSpokeAdvertisedNetworks(transitGw)
 		if err != nil {
-			return fmt.Errorf("failed to set bgp manual spoke advertise CIDRs: %w", err)
+			return fmt.Errorf("failed to set bgp manual spoke advertise CIDRs: %s", err)
 		}
 	}
 
@@ -3336,7 +3336,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.EnableEncryptVolume(gwEncVolume)
 			if err != nil {
-				return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %w", gwEncVolume.GwName, err)
+				return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwEncVolume.GwName, err)
 			}
 
 			haSubnet := d.Get("ha_subnet").(string)
@@ -3349,7 +3349,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				}
 				err := client.EnableEncryptVolume(gwHAEncVolume)
 				if err != nil {
-					return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %w", gwHAEncVolume.GwName, err)
+					return fmt.Errorf("failed to enable encrypt gateway volume for %s due to %s", gwHAEncVolume.GwName, err)
 				}
 			}
 		} else {
@@ -3371,7 +3371,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			err := client.EditGatewayCustomRoutes(transitGateway)
 			log.Printf("[INFO] Customizeing routes of transit gateway: %s ", transitGateway.GwName)
 			if err != nil {
-				return fmt.Errorf("failed to customize spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
+				return fmt.Errorf("failed to customize spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
 			}
 		}
 	}
@@ -3388,7 +3388,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			err := client.EditGatewayFilterRoutes(transitGateway)
 			log.Printf("[INFO] Editing filtered spoke vpc routes of transit gateway: %s ", transitGateway.GwName)
 			if err != nil {
-				return fmt.Errorf("failed to edit filtered spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
+				return fmt.Errorf("failed to edit filtered spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
 			}
 		}
 	}
@@ -3405,7 +3405,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			err := client.EditGatewayAdvertisedCidr(transitGateway)
 			log.Printf("[INFO] Editing excluded advertised spoke vpc routes of transit gateway: %s ", transitGateway.GwName)
 			if err != nil {
-				return fmt.Errorf("failed to edit excluded advertised spoke vpc routes of transit gateway: %s due to: %w", transitGateway.GwName, err)
+				return fmt.Errorf("failed to edit excluded advertised spoke vpc routes of transit gateway: %s due to: %s", transitGateway.GwName, err)
 			}
 		}
 	}
@@ -3525,7 +3525,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 
 		err := client.UpdateTransitGatewayCustomizedVpcRoute(gateway.GwName, customizedTransitVpcRoutes)
 		if err != nil {
-			return fmt.Errorf("couldn't update transit gateway customized vpc route: %w", err)
+			return fmt.Errorf("couldn't update transit gateway customized vpc route: %s", err)
 		}
 	}
 
@@ -3578,12 +3578,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if d.Get("enable_gro_gso").(bool) {
 			err := client.EnableGroGso(gateway)
 			if err != nil {
-				return fmt.Errorf("couldn't enable GRO/GSO on transit gateway when updating: %w", err)
+				return fmt.Errorf("couldn't enable GRO/GSO on transit gateway when updating: %s", err)
 			}
 		} else {
 			err := client.DisableGroGso(gateway)
 			if err != nil {
-				return fmt.Errorf("couldn't disable GRO/GSO on transit gateway when updating: %w", err)
+				return fmt.Errorf("couldn't disable GRO/GSO on transit gateway when updating: %s", err)
 			}
 		}
 	}
@@ -3668,7 +3668,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		}
 		err := client.SetRxQueueSize(gw)
 		if err != nil {
-			return fmt.Errorf("could not modify rx queue size for transit: %s during gateway update: %w", gw.GatewayName, err)
+			return fmt.Errorf("could not modify rx queue size for transit: %s during gateway update: %v", gw.GatewayName, err)
 		}
 		if haSubnet != "" || haZone != "" {
 			haGwRxQueueSize := &goaviatrix.Gateway{
@@ -3677,7 +3677,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.SetRxQueueSize(haGwRxQueueSize)
 			if err != nil {
-				return fmt.Errorf("could not modify rx queue size for transit ha: %s during gateway update: %w", haGwRxQueueSize.GwName, err)
+				return fmt.Errorf("could not modify rx queue size for transit ha: %s during gateway update: %v", haGwRxQueueSize.GwName, err)
 			}
 		}
 	}
@@ -3709,7 +3709,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		}
 		err := client.ChangeBgpOverLanIntfCnt(gw)
 		if err != nil {
-			return fmt.Errorf("could not modify BGP over LAN interface count for transit: %s during gateway update: %w", gw.GatewayName, err)
+			return fmt.Errorf("could not modify BGP over LAN interface count for transit: %s during gateway update: %v", gw.GatewayName, err)
 		}
 		if haSubnet != "" {
 			haGw := &goaviatrix.Gateway{
@@ -3718,7 +3718,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 			err := client.ChangeBgpOverLanIntfCnt(haGw)
 			if err != nil {
-				return fmt.Errorf("could not modify BGP over LAN interface count for transit ha: %s during gateway update: %w", haGw.GwName, err)
+				return fmt.Errorf("could not modify BGP over LAN interface count for transit ha: %s during gateway update: %v", haGw.GwName, err)
 			}
 		}
 	}
@@ -3763,7 +3763,7 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 
 		err := client.DisableGatewayFireNetInterfaces(gw)
 		if err != nil {
-			return fmt.Errorf("failed to disable Aviatrix Transit Gateway for FireNet Interfaces: %w", err)
+			return fmt.Errorf("failed to disable Aviatrix Transit Gateway for FireNet Interfaces: %s", err)
 		}
 	}
 
@@ -3771,12 +3771,12 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 	if enableTransitFireNet && goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.OCIRelatedCloudTypes) {
 		err := client.DisableTransitFireNet(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to disable transit firenet for %s due to %w", gateway.GwName, err)
+			return fmt.Errorf("failed to disable transit firenet for %s due to %s", gateway.GwName, err)
 		}
 	} else if enableTransitFireNet && goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes) {
 		err := client.IsTransitFireNetReadyToBeDisabled(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to disable transit firenet for %s due to %w", gateway.GwName, err)
+			return fmt.Errorf("failed to disable transit firenet for %s due to %s", gateway.GwName, err)
 		}
 	}
 
@@ -3799,14 +3799,14 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 				}
 
 				if !strings.Contains(err.Error(), "EOF") {
-					return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway HA gateway: %w", err)
+					return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway HA gateway: %s", err)
 				}
 			} else {
 				break
 			}
 
 			if try == maxTries {
-				return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway HA gateway: %w", err)
+				return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway HA gateway: %s", err)
 			}
 			time.Sleep(backoff)
 			// Double the backoff time after each failed try
@@ -3815,19 +3815,19 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 		if cloudType == goaviatrix.EDGEEQUINIX {
 			err := deleteZtpFile(gateway.GwName, d.Get("vpc_id").(string), d.Get("ztp_file_download_path").(string))
 			if err != nil {
-				return fmt.Errorf("failed to delete ZTP file: %w", err)
+				return fmt.Errorf("failed to delete ZTP file: %s", err)
 			}
 		}
 	}
 	gateway.GwName = d.Get("gw_name").(string)
 	err := client.DeleteGateway(gateway)
 	if err != nil {
-		return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway: %w", err)
+		return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway: %s", err)
 	}
 	if cloudType == goaviatrix.EDGEEQUINIX {
 		err := deleteZtpFile(gateway.GwName, d.Get("vpc_id").(string), d.Get("ztp_file_download_path").(string))
 		if err != nil {
-			return fmt.Errorf("failed to delete ZTP file: %w", err)
+			return fmt.Errorf("failed to delete ZTP file: %s", err)
 		}
 	}
 
@@ -3842,7 +3842,7 @@ func deleteZtpFile(gatewayName, vpcId, ztpFileDownloadPath string) error {
 	}
 	err := os.Remove(fileName)
 	if err != nil {
-		return fmt.Errorf("could not remove the ztp file: %w", err)
+		return fmt.Errorf("could not remove the ztp file: %v", err)
 	}
 	return nil
 }
@@ -3898,7 +3898,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 	d.SetId(gateway.GwName)
 	err = client.LaunchTransitVpc(gateway)
 	if err != nil {
-		return fmt.Errorf("failed to create Aviatrix Transit Gateway: %w", err)
+		return fmt.Errorf("failed to create Aviatrix Transit Gateway: %s", err)
 	}
 	// create ha transit gateway if ha_interfaces are provided
 	ha_interfaces, ok := d.Get("ha_interfaces").([]interface{})
@@ -3911,7 +3911,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 		log.Printf("[INFO] Creating HA Aviatrix Transit Gateway: %#v", transitHaGw)
 		_, err = client.CreateTransitHaGw(transitHaGw)
 		if err != nil {
-			return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %w", err)
+			return fmt.Errorf("failed to enable HA Aviatrix Transit Gateway: %s", err)
 		}
 	}
 
@@ -3929,7 +3929,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 		// update EIP map
 		err = client.UpdateEdgeGateway(gateway)
 		if err != nil {
-			return fmt.Errorf("failed to update edge gateway: %w", err)
+			return fmt.Errorf("failed to update edge gateway: %s", err)
 		}
 	}
 
@@ -4112,7 +4112,7 @@ func getTransitHaGatewayDetails(d *schema.ResourceData, wanCount int, cloudType 
 	transitHaGw.BackupLinkList = append(transitHaGw.BackupLinkList, backupLinkData)
 	backupLinkConfig, err := json.Marshal(transitHaGw.BackupLinkList)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create backup link configuration: %w", err)
+		return nil, fmt.Errorf("failed to create backup link configuration: %s", err)
 	}
 	transitHaGw.BackupLinkConfig = b64.StdEncoding.EncodeToString(backupLinkConfig)
 	// get the HA interfaces
@@ -4366,7 +4366,7 @@ func setEipMapDetails(eipMap map[string][]goaviatrix.EipMap, ifNameTranslation m
 		interfaceType := strings.ToUpper(interfaceDetails[0])
 		interfaceIndex, err := strconv.Atoi(interfaceDetails[1])
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert interface index to integer for %s: %w", interfaceName, err)
+			return nil, fmt.Errorf("failed to convert interface index to integer for %s: %v", interfaceName, err)
 		}
 
 		for _, eip := range eipList {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -3836,6 +3836,10 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 
 func deleteZtpFile(gatewayName, vpcId, ztpFileDownloadPath string) error {
 	fileName := ztpFileDownloadPath + "/" + gatewayName + "-" + vpcId + "-cloud-init.txt"
+	// check if the file exists
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		return nil
+	}
 	err := os.Remove(fileName)
 	if err != nil {
 		return fmt.Errorf("could not remove the ztp file: %v", err)
@@ -3898,7 +3902,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 	}
 	// create ha transit gateway if ha_interfaces are provided
 	ha_interfaces, ok := d.Get("ha_interfaces").([]interface{})
-	if ok && ha_interfaces != nil {
+	if ok && len(ha_interfaces) > 0 {
 		transitHaGw, err := getTransitHaGatewayDetails(d, wanCount, cloudType)
 		if err != nil {
 			return fmt.Errorf("failed to get the HA gateway details: %w", err)

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -1046,7 +1046,7 @@ func TestSetEipMapDetails(t *testing.T) {
 			result, err := setEipMapDetails(tt.eipMap, tt.ifNameTranslation)
 
 			if tt.expectedErr != "" {
-				assert.Error(t, err)
+				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.NoError(t, err)

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -1194,11 +1194,11 @@ func TestDeleteZtpFile(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir) // Cleanup the temp directory after test
 	gatewayName := "test-gateway"
-	vpcId := "vpc-123456"
+	vpcID := "vpc-123456"
 	ztpFileDownloadPath := tempDir
-	fileName := filepath.Join(ztpFileDownloadPath, fmt.Sprintf("%s-%s-cloud-init.txt", gatewayName, vpcId))
+	fileName := filepath.Join(ztpFileDownloadPath, fmt.Sprintf("%s-%s-cloud-init.txt", gatewayName, vpcID))
 	// Create a temporary file to simulate the ztp file
-	if err := os.WriteFile(fileName, []byte("test content"), 0644); err != nil {
+	if err := os.WriteFile(fileName, []byte("test content"), 0o644); err != nil {
 		t.Fatalf("Failed to create temporary file: %v", err)
 	}
 
@@ -1206,7 +1206,7 @@ func TestDeleteZtpFile(t *testing.T) {
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		t.Fatalf("File does not exist before deletion: %v", fileName)
 	}
-	err = deleteZtpFile(gatewayName, vpcId, ztpFileDownloadPath)
+	err = deleteZtpFile(gatewayName, vpcID, ztpFileDownloadPath)
 	if err != nil {
 		t.Errorf("deleteZtpFile returned an error: %v", err)
 	}

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
@@ -1183,5 +1184,35 @@ func TestSetInterfaceDetails(t *testing.T) {
 			result := setInterfaceDetails(tt.interfaces)
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func TestDeleteZtpFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "ztp_test")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir) // Cleanup the temp directory after test
+	gatewayName := "test-gateway"
+	vpcId := "vpc-123456"
+	ztpFileDownloadPath := tempDir
+	fileName := filepath.Join(ztpFileDownloadPath, fmt.Sprintf("%s-%s-cloud-init.txt", gatewayName, vpcId))
+	// Create a temporary file to simulate the ztp file
+	if err := os.WriteFile(fileName, []byte("test content"), 0644); err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+
+	// Ensure the file exists before calling the function
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		t.Fatalf("File does not exist before deletion: %v", fileName)
+	}
+	err = deleteZtpFile(gatewayName, vpcId, ztpFileDownloadPath)
+	if err != nil {
+		t.Errorf("deleteZtpFile returned an error: %v", err)
+	}
+
+	// Verify the file is deleted
+	if _, err := os.Stat(fileName); err == nil || !os.IsNotExist(err) {
+		t.Errorf("File was not deleted: %v", fileName)
 	}
 }

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -1046,7 +1046,7 @@ func TestSetEipMapDetails(t *testing.T) {
 			result, err := setEipMapDetails(tt.eipMap, tt.ifNameTranslation)
 
 			if tt.expectedErr != "" {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.NoError(t, err)

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -1201,7 +1201,7 @@ func TestDeleteZtpFile(t *testing.T) {
 	if err := os.WriteFile(fileName, []byte("test content"), 0o644); err != nil {
 		t.Fatalf("Failed to create temporary file: %v", err)
 	}
-
+	// Test Case 1: File exists and is successfully deleted
 	// Ensure the file exists before calling the function
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		t.Fatalf("File does not exist before deletion: %v", fileName)
@@ -1214,5 +1214,12 @@ func TestDeleteZtpFile(t *testing.T) {
 	// Verify the file is deleted
 	if _, err := os.Stat(fileName); err == nil || !os.IsNotExist(err) {
 		t.Errorf("File was not deleted: %v", fileName)
+	}
+
+	// Test Case 2: File does not exist and no error should be returned
+	// Try to delete the file again (it doesn't exist now)
+	err = deleteZtpFile(gatewayName, vpcID, ztpFileDownloadPath)
+	if err != nil {
+		t.Errorf("deleteZtpFile returned an error when file does not exist: %v", err)
 	}
 }

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -422,7 +422,8 @@ The following arguments are supported:
 * `subnet` - (Required) A VPC Network address range selected from one of the available network ranges. Example: "172.31.0.0/20". **NOTE: If using `insane_mode`, please see notes [here](#insane_mode).**
 * `availability_domain` - (Optional) Availability domain. Required and valid only for OCI. Available as of provider version R2.19.3.
 * `fault_domain` - (Optional) Fault domain. Required and valid only for OCI. Available as of provider version R2.19.3.
-* `site_id` - (Optional) Site id for the EAT gateway. Required and valid only for edge transit gateways AEP and Equinix.
+* `ztp_file_download_path` - (Optional) Ztp file download path where the cloud init file will be stored locally. Required only for Equinix EAT gateway.
+* `device_id` - (Optional) Device ID for AEP EAT gateway. Required only for AEP gateway.
 * `interfaces` - (Optional) A list of WAN/Management interfaces, each represented as a map. Required and valid only for edge transit gateways AEP and Equinix. Each interface has the following attributes:
   * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
   * `index` - (Required) Interface index. Valid values are 0,1,2 etc.
@@ -452,6 +453,7 @@ The following arguments are supported:
 * `ha_gw_size` - (Optional) HA Gateway Size. Mandatory if enabling HA. Example: "t2.micro".
 * `ha_availability_domain` - (Optional) HA gateway availability domain. Required and valid only for OCI. Available as of provider version R2.19.3.
 * `ha_fault_domain` - (Optional) HA gateway fault domain. Required and valid only for OCI. Available as of provider version R2.19.3.
+* `ha_device_id` - (Optional) Device ID for HA AEP EAT gateway. Required only for AEP HA gateway.
 * `peer_backup_port_type` - (Optional) Peer backup port type for edge transit gateway. Required and valid only for edge gateways AEP and Equinix.
 * `peer_backup_port_index` - (Optional) Peer backup port index for edge transit gateway. Required and valid only for edge gateways AEP and Equinix.
 * `peer_connection_type` - (Optional) Connection type for edge transit gateway e.g., "private", "public". Required and valid only for edge gateways AEP and Equinix.

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -52,7 +52,7 @@ func (c *Client) CreateTransitHaGw(transitHaGateway *TransitHaGateway) (string, 
 	// create the ZTP file for Equinix Edge transit gateway
 	if transitHaGateway.CloudType == EDGEEQUINIX {
 		fileName := getFileName(transitHaGateway.ZtpFileDownloadPath, transitHaGateway.GwName, transitHaGateway.VpcID)
-		err := createOrReplaceFile(fileName, data.Result)
+		err := createZtpFile(fileName, data.Result)
 		if err != nil {
 			return "", err
 		}

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -51,7 +51,7 @@ func (c *Client) CreateTransitHaGw(transitHaGateway *TransitHaGateway) (string, 
 	}
 	// create the ZTP file for Equinix Edge transit gateway
 	if transitHaGateway.CloudType == EDGEEQUINIX {
-		fileName := transitHaGateway.ZtpFileDownloadPath + "/" + transitHaGateway.GwName + "-" + transitHaGateway.VpcID + "-cloud-init.txt"
+		fileName := getFileName(transitHaGateway.ZtpFileDownloadPath, transitHaGateway.GwName, transitHaGateway.VpcID)
 		err := createOrReplaceFile(fileName, data.Result)
 		if err != nil {
 			return "", err

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -1,6 +1,10 @@
 package goaviatrix
 
-import "golang.org/x/net/context"
+import (
+	"os"
+
+	"golang.org/x/net/context"
+)
 
 type TransitHaGateway struct {
 	Action                string `json:"action"`
@@ -29,6 +33,7 @@ type TransitHaGateway struct {
 	InterfaceMapping      string `json:"interface_mapping,omitempty"`
 	Interfaces            string `json:"interfaces,omitempty"`
 	DeviceID              string `json:"device_id,omitempty"`
+	ZtpFileDownloadPath   string `json:"-"`
 }
 
 type BackupLinkInterface struct {
@@ -41,6 +46,23 @@ type BackupLinkInterface struct {
 func (c *Client) CreateTransitHaGw(transitHaGateway *TransitHaGateway) (string, error) {
 	transitHaGateway.CID = c.CID
 	transitHaGateway.Action = "create_multicloud_ha_gateway"
+	var data CreateEdgeEquinixResp
+	resp, err := c.PostAPIContext2HaGw(context.Background(), nil, transitHaGateway.Action, transitHaGateway, BasicCheck)
+	if err != nil {
+		return "", err
+	}
+	// create the ZTP file for Equinix Edge transit gateway
+	if transitHaGateway.CloudType == EDGEEQUINIX {
+		fileName := transitHaGateway.ZtpFileDownloadPath + "/" + transitHaGateway.GwName + "-" + transitHaGateway.VpcID + "-cloud-init.txt"
+		outFile, err := os.Create(fileName)
+		if err != nil {
+			return "", err
+		}
 
-	return c.PostAPIContext2HaGw(context.Background(), nil, transitHaGateway.Action, transitHaGateway, BasicCheck)
+		_, err = outFile.WriteString(data.Result)
+		if err != nil {
+			return "", err
+		}
+	}
+	return resp, nil
 }

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -45,14 +45,14 @@ func (c *Client) CreateTransitHaGw(transitHaGateway *TransitHaGateway) (string, 
 	transitHaGateway.CID = c.CID
 	transitHaGateway.Action = "create_multicloud_ha_gateway"
 	var data CreateEdgeEquinixResp
-	resp, err := c.PostAPIContext2HaGw(context.Background(), nil, transitHaGateway.Action, transitHaGateway, BasicCheck)
+	resp, err := c.PostAPIContext2HaGw(context.Background(), &data, transitHaGateway.Action, transitHaGateway, BasicCheck)
 	if err != nil {
 		return "", err
 	}
 	// create the ZTP file for Equinix Edge transit gateway
 	if transitHaGateway.CloudType == EDGEEQUINIX {
 		fileName := getFileName(transitHaGateway.ZtpFileDownloadPath, transitHaGateway.GwName, transitHaGateway.VpcID)
-		err := createZtpFile(fileName, data.Result)
+		err = createZtpFile(fileName, data.Result)
 		if err != nil {
 			return "", err
 		}

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -1,8 +1,6 @@
 package goaviatrix
 
 import (
-	"os"
-
 	"golang.org/x/net/context"
 )
 
@@ -54,12 +52,7 @@ func (c *Client) CreateTransitHaGw(transitHaGateway *TransitHaGateway) (string, 
 	// create the ZTP file for Equinix Edge transit gateway
 	if transitHaGateway.CloudType == EDGEEQUINIX {
 		fileName := transitHaGateway.ZtpFileDownloadPath + "/" + transitHaGateway.GwName + "-" + transitHaGateway.VpcID + "-cloud-init.txt"
-		outFile, err := os.Create(fileName)
-		if err != nil {
-			return "", err
-		}
-
-		_, err = outFile.WriteString(data.Result)
+		err := createOrReplaceFile(fileName, data.Result)
 		if err != nil {
 			return "", err
 		}

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -737,7 +737,7 @@ func processZtpFileContent(cloudInitTransit string) (string, error) {
 	var jsonCloudInit map[string]interface{}
 	err := json.Unmarshal([]byte(cloudInitTransit), &jsonCloudInit)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse cloud_init_transit as JSON: %v", err)
+		return "", fmt.Errorf("failed to parse cloud_init_transit as JSON: %w", err)
 	}
 
 	// Extract the 'text' field from the cloudinit data
@@ -752,14 +752,14 @@ func processZtpFileContent(cloudInitTransit string) (string, error) {
 func createZtpFile(filePath, content string) error {
 	outFile, err := os.Create(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to create the file: %v", err)
+		return fmt.Errorf("failed to create the file: %w", err)
 	}
 	defer outFile.Close()
 
 	// Write the content to the file
 	_, err = outFile.WriteString(content)
 	if err != nil {
-		return fmt.Errorf("failed to write to the file: %v", err)
+		return fmt.Errorf("failed to write to the file: %w", err)
 	}
 	return nil
 }

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -737,7 +737,7 @@ func processZtpFileContent(cloudInitTransit string) (string, error) {
 	var jsonCloudInit map[string]interface{}
 	err := json.Unmarshal([]byte(cloudInitTransit), &jsonCloudInit)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse cloud_init_transit as JSON: %w", err)
+		return "", fmt.Errorf("failed to parse cloud_init_transit as JSON: %v", err)
 	}
 
 	// Extract the 'text' field from the cloudinit data
@@ -752,14 +752,14 @@ func processZtpFileContent(cloudInitTransit string) (string, error) {
 func createZtpFile(filePath, content string) error {
 	outFile, err := os.Create(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to create the file: %w", err)
+		return fmt.Errorf("failed to create the file: %v", err)
 	}
 	defer outFile.Close()
 
 	// Write the content to the file
 	_, err = outFile.WriteString(content)
 	if err != nil {
-		return fmt.Errorf("failed to write to the file: %w", err)
+		return fmt.Errorf("failed to write to the file: %v", err)
 	}
 	return nil
 }

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -184,7 +184,7 @@ func (c *Client) LaunchTransitVpc(gateway *TransitVpc) error {
 	// create the ZTP file for Equinix edge transit gateway
 	if gateway.CloudType == EDGEEQUINIX {
 		fileName := getFileName(gateway.ZtpFileDownloadPath, gateway.GwName, gateway.VpcID)
-		err := createOrReplaceFile(fileName, data.Result)
+		err := createZtpFile(fileName, data.Result)
 		if err != nil {
 			return err
 		}
@@ -729,20 +729,8 @@ func (c *Client) DisableTransitPreserveAsPath(transitGateway *TransitVpc) error 
 	return c.PostAPI(action, data, BasicCheck)
 }
 
-// createOrReplaceFile deletes a file if it exists, then creates a new one and writes the given content.
-func createOrReplaceFile(filePath, content string) error {
-	// Check if the file exists
-	if _, err := os.Stat(filePath); err == nil {
-		// File exists; delete it
-		if err := os.Remove(filePath); err != nil {
-			return fmt.Errorf("failed to delete the existing file: %v", err)
-		}
-	} else if !os.IsNotExist(err) {
-		// Some other error occurred while checking for the file
-		return fmt.Errorf("failed to check file existence: %v", err)
-	}
-
-	// Create a new file
+// createZtpFile creates a new ztp file and writes the given content.
+func createZtpFile(filePath, content string) error {
 	outFile, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create the file: %v", err)

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -183,7 +183,7 @@ func (c *Client) LaunchTransitVpc(gateway *TransitVpc) error {
 	}
 	// create the ZTP file for Equinix edge transit gateway
 	if gateway.CloudType == EDGEEQUINIX {
-		fileName := gateway.ZtpFileDownloadPath + "/" + gateway.GwName + "-" + gateway.VpcID + "-cloud-init.txt"
+		fileName := getFileName(gateway.ZtpFileDownloadPath, gateway.GwName, gateway.VpcID)
 		err := createOrReplaceFile(fileName, data.Result)
 		if err != nil {
 			return err
@@ -755,4 +755,8 @@ func createOrReplaceFile(filePath, content string) error {
 		return fmt.Errorf("failed to write to the file: %v", err)
 	}
 	return nil
+}
+
+func getFileName(ztpFileDownloadPath, gwName, vpcID string) string {
+	return ztpFileDownloadPath + "/" + gwName + "-" + vpcID + "-cloud-init.txt"
 }

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -89,10 +89,24 @@ func TestCreateZtpFile(t *testing.T) {
 			content:     "",
 			expectedErr: "",
 		},
+		{
+			name:        "File truncation (overwriting with new content)",
+			filePath:    "test-file.txt",
+			content:     "This is new content.",
+			expectedErr: "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "File truncation (overwriting with new content)" {
+				// Create a file with initial content
+				initialContent := "This is old content."
+				err := os.WriteFile(tt.filePath, []byte(initialContent), 0o644)
+				if err != nil {
+					t.Fatalf("Failed to create initial file: %v", err)
+				}
+			}
 			// Run the createZtpFile function
 			err := createZtpFile(tt.filePath, tt.content)
 

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -97,7 +97,7 @@ func TestCreateZtpFile(t *testing.T) {
 			err := createZtpFile(tt.filePath, tt.content)
 
 			if tt.expectedErr != "" {
-				assert.Error(t, err)
+				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.NoError(t, err)
@@ -159,7 +159,7 @@ func TestProcessZtpFileContent(t *testing.T) {
 			text, err := processZtpFileContent(tt.cloudInitTransit)
 
 			if tt.expectedErr != "" {
-				assert.Error(t, err)
+				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.NoError(t, err)

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -97,7 +97,7 @@ func TestCreateZtpFile(t *testing.T) {
 			err := createZtpFile(tt.filePath, tt.content)
 
 			if tt.expectedErr != "" {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.NoError(t, err)
@@ -159,7 +159,7 @@ func TestProcessZtpFileContent(t *testing.T) {
 			text, err := processZtpFileContent(tt.cloudInitTransit)
 
 			if tt.expectedErr != "" {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				assert.NoError(t, err)

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -1,6 +1,7 @@
 package goaviatrix
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,4 +62,56 @@ func TestMapContains(t *testing.T) {
 	}
 	assert.True(t, MapContains(testMap, "one"))
 	assert.False(t, MapContains(testMap, "Random"))
+}
+
+func TestCreateZtpFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		filePath    string
+		content     string
+		expectedErr string
+	}{
+		{
+			name:        "Successful file creation and writing",
+			filePath:    "test-file.txt",
+			content:     "This is a test file.",
+			expectedErr: "",
+		},
+		{
+			name:        "Error creating file (invalid path)",
+			filePath:    "/invalid/path/test-file.txt",
+			content:     "This content should not be written.",
+			expectedErr: "failed to create the file",
+		},
+		{
+			name:        "Error writing to file (empty content)",
+			filePath:    "test-file.txt",
+			content:     "",
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Run the createZtpFile function
+			err := createZtpFile(tt.filePath, tt.content)
+
+			if tt.expectedErr != "" {
+				assert.NotNil(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+
+				// Check if the file is created and the content is written (if no error occurred)
+				if _, err := os.Stat(tt.filePath); err == nil {
+					// File exists, check the content
+					data, err := os.ReadFile(tt.filePath)
+					assert.NoError(t, err)
+					assert.Equal(t, tt.content, string(data))
+					// Clean up the file after test
+					os.Remove(tt.filePath)
+				}
+			}
+		})
+	}
 }

--- a/goaviatrix/utils_test.go
+++ b/goaviatrix/utils_test.go
@@ -115,3 +115,56 @@ func TestCreateZtpFile(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessZtpFileContent(t *testing.T) {
+	tests := []struct {
+		name             string
+		cloudInitTransit string
+		expectedText     string
+		expectedErr      string
+	}{
+		{
+			name: "Valid JSON with text field",
+			cloudInitTransit: `{
+				"text": "sample cloud-init content"
+			}`,
+			expectedText: "sample cloud-init content",
+			expectedErr:  "",
+		},
+		{
+			name: "Valid JSON without text field",
+			cloudInitTransit: `{
+				"other_field": "some value"
+			}`,
+			expectedText: "",
+			expectedErr:  "'text' field not found or is not a string in cloud_init_transit",
+		},
+		{
+			name: "Invalid JSON format",
+			cloudInitTransit: `{
+				"text": "sample cloud-init content"`,
+			expectedText: "",
+			expectedErr:  "failed to parse cloud_init_transit as JSON",
+		},
+		{
+			name:             "Empty JSON input",
+			cloudInitTransit: `{}`,
+			expectedText:     "",
+			expectedErr:      "'text' field not found or is not a string in cloud_init_transit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, err := processZtpFileContent(tt.cloudInitTransit)
+
+			if tt.expectedErr != "" {
+				assert.NotNil(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedText, text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Adding the ztp_file_download_path param to the transit gateway where the cloud init file will be stored locally.
- Sorting the eip_map keys in the setEipMapDetails function
- Adding UT for Equinix EAT