### PR TITLE
AVX-60268 - Reenable funlen

### DIFF
--- a/.golangci_strict.toml
+++ b/.golangci_strict.toml
@@ -24,7 +24,7 @@
     "errname",
     "errorlint",
     "forcetypeassert",
-    # "funlen", # Disable temporarily
+    "funlen",
     "gofumpt",
     "goimports",
     "gosec",


### PR DESCRIPTION
I had disabled the funlen check because I was touching too many files in the bulk update PR and didn't have time to refactor that number of functions. 

Reenabling it now. This means that in the future if someone touches an excessively long function, they will need to refactor it into smaller components to satisfy the linter -- we don't need 4k line functions. 

Most of our long functions are just repeating the same pattern over and over again, anyhow -- this will encourage those patterns to be factored out into helper functions that we can add proper tests to.

Exception: it is acceptable to nolint this checker for functions like https://github.com/AviatrixSystems/terraform-provider-aviatrix/blob/master/aviatrix/provider.go#L15 that are just verbose boilerplate. Business logic functions should always adhere to funlen and cyclop, though.