### PR TITLE
AVX-56145 [Equinix Edge] Use TF 'edge_underlay' option to provision Edge BGP Underlay for both primary and ha

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -117,13 +117,9 @@ func resourceAviatrixEdgeSpokeExternalDeviceConn() *schema.Resource {
 				Description:  "Remote cloud type.",
 			},
 			"ha_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return d.Get("enable_edge_underlay").(bool)
-				},
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
 				Description: "Set as true if there are two external devices.",
 			},
 			"backup_bgp_remote_as_num": {
@@ -288,10 +284,6 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 		if externalDeviceConn.BackupBgpRemoteAsNum != 0 {
 			return diag.Errorf("ha is not enabled, and 'connection_type' is 'bgp', please specify 'backup_bgp_remote_as_num' to empty")
 		}
-	}
-
-	if externalDeviceConn.EnableEdgeUnderlay && externalDeviceConn.HAEnabled == "true" {
-		return diag.Errorf("please use a separate edge_spoke_external_device_conn to create WAN underlay connection for Edge HA")
 	}
 
 	flag := false

--- a/goaviatrix/client_2.go
+++ b/goaviatrix/client_2.go
@@ -246,9 +246,9 @@ func (c *Client) DoAPIContext2WithResult(ctx context.Context, verb string, v int
 
 func checkAndReturnAPIResp2WithResult(resp *http.Response, v interface{}, method, action string, checkFunc CheckAPIResponseFunc) (string, error) {
 	type apiresp struct {
-		Return  bool   `json:"return"`
-		Results string `json:"results"`
-		Reason  string `json:"reason"`
+		Return  bool              `json:"return"`
+		Results map[string]string `json:"results"`
+		Reason  string            `json:"reason"`
 	}
 
 	var data apiresp
@@ -272,5 +272,5 @@ func checkAndReturnAPIResp2WithResult(resp *http.Response, v interface{}, method
 		}
 	}
 
-	return data.Results, nil
+	return data.Results["status"], nil
 }

--- a/goaviatrix/edge_external_device_conn.go
+++ b/goaviatrix/edge_external_device_conn.go
@@ -26,7 +26,7 @@ type EdgeExternalDeviceConn struct {
 	Phase2Encryption       string `json:"phase2_encryption,omitempty"`
 	HAEnabled              string `json:"enable_ha,omitempty"`
 	BackupRemoteGatewayIP  string `json:"backup_external_device_ip_address,omitempty"`
-	BackupBgpRemoteAsNum   int    `json:"backup_external_device_as_number,omitempty"`
+	BackupBgpRemoteAsNum   int    `json:"external_device_backup_asn,omitempty"`
 	BackupPreSharedKey     string `json:"backup_pre_shared_key,omitempty"`
 	BackupLocalTunnelCidr  string `json:"backup_local_tunnel_ip,omitempty"`
 	BackupRemoteTunnelCidr string `json:"backup_remote_tunnel_ip,omitempty"`


### PR DESCRIPTION
1. Removed the restriction which prevented TF from create edge underlay primary and HA by one resource.
2. Updated the underlay response handler with correct expected response. 
3. Corrected one API parameter

Testing:
Tested on QA's setup.