### PR TITLE
AVX-60780: adding terraform support for DCF TLS profile

### DIFF
--- a/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
@@ -210,8 +210,12 @@ func marshalDistributedFirewallingPolicyListInput(d *schema.ResourceData) (*goav
 			distributedFirewallingPolicy.UUID = uuid.(string)
 		}
 
-		if tlsProfileUuid, ok := policy["tls_profile"]; ok {
-			distributedFirewallingPolicy.TLSProfile = tlsProfileUuid.(string)
+		if tlsProfileUUID, ok := policy["tls_profile"]; ok {
+			uuidStr, ok := tlsProfileUUID.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid type for tls_profile, should be a string")
+			}
+			distributedFirewallingPolicy.TLSProfile = uuidStr
 		}
 
 		policyList.Policies = append(policyList.Policies, *distributedFirewallingPolicy)

--- a/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
@@ -210,8 +210,8 @@ func marshalDistributedFirewallingPolicyListInput(d *schema.ResourceData) (*goav
 			distributedFirewallingPolicy.UUID = uuid.(string)
 		}
 
-		if uuid, uuidOk := policy["tls_profile"]; uuidOk {
-			distributedFirewallingPolicy.TlsProfile = uuid.(string)
+		if tlsProfileUuid, ok := policy["tls_profile"]; ok {
+			distributedFirewallingPolicy.TLSProfile = tlsProfileUuid.(string)
 		}
 
 		policyList.Policies = append(policyList.Policies, *distributedFirewallingPolicy)
@@ -295,7 +295,7 @@ func resourceAviatrixDistributedFirewallingPolicyListRead(ctx context.Context, d
 			}
 			p["port_ranges"] = portRanges
 		}
-		p["tls_profile"] = policy.TlsProfile
+		p["tls_profile"] = policy.TLSProfile
 
 		policies = append(policies, p)
 	}

--- a/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
@@ -136,7 +136,7 @@ func resourceAviatrixDistributedFirewallingPolicyList() *schema.Resource {
 						"tls_profile": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "TLS profile for the policy.",
+							Description: "TLS profile UUID for the policy.",
 						},
 					},
 				},

--- a/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_policy_list.go
@@ -133,6 +133,11 @@ func resourceAviatrixDistributedFirewallingPolicyList() *schema.Resource {
 							Computed:    true,
 							Description: "UUID of the policy.",
 						},
+						"tls_profile": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "TLS profile for the policy.",
+						},
 					},
 				},
 			},
@@ -203,6 +208,10 @@ func marshalDistributedFirewallingPolicyListInput(d *schema.ResourceData) (*goav
 
 		if uuid, uuidOk := policy["uuid"]; uuidOk {
 			distributedFirewallingPolicy.UUID = uuid.(string)
+		}
+
+		if uuid, uuidOk := policy["tls_profile"]; uuidOk {
+			distributedFirewallingPolicy.TlsProfile = uuid.(string)
 		}
 
 		policyList.Policies = append(policyList.Policies, *distributedFirewallingPolicy)
@@ -286,6 +295,7 @@ func resourceAviatrixDistributedFirewallingPolicyListRead(ctx context.Context, d
 			}
 			p["port_ranges"] = portRanges
 		}
+		p["tls_profile"] = policy.TlsProfile
 
 		policies = append(policies, p)
 	}

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -16,6 +16,14 @@ Track all Aviatrix Terraform provider's releases. New resources, features, and b
 
 ---
 
+## 8.0
+### Notes:
+- Supported Controller version: **UserConnect-8.0.0**
+
+### Enhancements:
+1. Added field tls_profile to **aviatrix_distributed_firewalling_policy_list** to be able specify a TLS profile is a DCF policy.
+
+
 ## 3.2.1
 ### Notes:
 - Supported Controller version: **UserConnect-7.2.4996**

--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -21,7 +21,7 @@ Track all Aviatrix Terraform provider's releases. New resources, features, and b
 - Supported Controller version: **UserConnect-8.0.0**
 
 ### Enhancements:
-1. Added field tls_profile to **aviatrix_distributed_firewalling_policy_list** to be able specify a TLS profile is a DCF policy.
+1. Added field tls_profile to **aviatrix_distributed_firewalling_policy_list** to be able specify a TLS profile in a DCF policy.
 
 
 ## 3.2.1

--- a/docs/resources/aviatrix_distributed_firewalling_policy_list.md
+++ b/docs/resources/aviatrix_distributed_firewalling_policy_list.md
@@ -122,7 +122,7 @@ The following arguments are supported:
     * `watch` - (Optional) Whether to enforce the policy or only watch packets. If "true" packets are only watched. This allows you to observe if the traffic impacted by this rule causes any inadvertent issues (such as traffic being dropped). Type: Boolean.
     * `logging` - (Optional) Whether to enable logging for packets that match the policy. Type: Boolean.
     * `uuid` - (Computed) UUID for the Policy.
-    * `tls_profile` - (Optional) TLS profile for policy.
+    * `tls_profile` - (Optional) TLS profile UUID for the policy.
 
 ## Import
 

--- a/docs/resources/aviatrix_distributed_firewalling_policy_list.md
+++ b/docs/resources/aviatrix_distributed_firewalling_policy_list.md
@@ -121,6 +121,7 @@ The following arguments are supported:
     * `watch` - (Optional) Whether to enforce the policy or only watch packets. If "true" packets are only watched. This allows you to observe if the traffic impacted by this rule causes any inadvertent issues (such as traffic being dropped). Type: Boolean.
     * `logging` - (Optional) Whether to enable logging for packets that match the policy. Type: Boolean.
     * `uuid` - (Computed) UUID for the Policy.
+    * `tls_profile` - (Optional) TLS profile for policy.
 
 ## Import
 

--- a/docs/resources/aviatrix_distributed_firewalling_policy_list.md
+++ b/docs/resources/aviatrix_distributed_firewalling_policy_list.md
@@ -28,6 +28,7 @@ resource "aviatrix_distributed_firewalling_policy_list" "test" {
     dst_smart_groups = [
       "82e50c85-82bf-4b3b-b9da-aaed34a3aa53"
     ]
+    tls_profile = "def000ad-6000-0000-0000-000000000001"
   }
 
   policies {

--- a/goaviatrix/distributed_firewalling_policy_list.go
+++ b/goaviatrix/distributed_firewalling_policy_list.go
@@ -23,7 +23,7 @@ type DistributedFirewallingPolicy struct {
 	ExcludeSgOrchestration bool                              `json:"exclude_sg_orchestration,omitempty"`
 	UUID                   string                            `json:"uuid,omitempty"`
 	SystemResource         bool                              `json:"system_resource,omitempty"`
-	TlsProfile             string                            `json:"tls_profile,omitempty"`
+	TLSProfile             string                            `json:"tls_profile,omitempty"`
 }
 
 type DistributedFirewallingPolicyList struct {

--- a/goaviatrix/distributed_firewalling_policy_list.go
+++ b/goaviatrix/distributed_firewalling_policy_list.go
@@ -23,6 +23,7 @@ type DistributedFirewallingPolicy struct {
 	ExcludeSgOrchestration bool                              `json:"exclude_sg_orchestration,omitempty"`
 	UUID                   string                            `json:"uuid,omitempty"`
 	SystemResource         bool                              `json:"system_resource,omitempty"`
+	TlsProfile             string                            `json:"tls_profile,omitempty"`
 }
 
 type DistributedFirewallingPolicyList struct {


### PR DESCRIPTION
TLS profile is introduced in controller version 8.0.0, only profile supported will be default profile "def000ad-6000-0000-0000-000000000001".