### PR TITLE
AVX-58679 Backport for Megaport EAT and HA 

### DIFF
--- a/aviatrix/resource_aviatrix_edge_megaport.go
+++ b/aviatrix/resource_aviatrix_edge_megaport.go
@@ -270,10 +270,10 @@ func resourceAviatrixEdgeMegaport() *schema.Resource {
 				Description: "VLAN configuration.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"parent_interface_name": {
+						"parent_logical_interface_name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Parent interface name.",
+							Description: "Parent logical interface name e.g. lan0",
 						},
 						"vlan_id": {
 							Type:        schema.TypeInt,
@@ -430,16 +430,20 @@ func marshalEdgeMegaportInput(d *schema.ResourceData) (*goaviatrix.EdgeMegaport,
 		vlan1 := vlan0.(map[string]interface{})
 
 		vlan2 := &goaviatrix.EdgeMegaportVlan{
-			ParentInterface: vlan1["parent_interface_name"].(string),
-			IPAddr:          vlan1["ip_address"].(string),
-			GatewayIP:       vlan1["gateway_ip"].(string),
-			PeerIPAddr:      vlan1["peer_ip_address"].(string),
-			PeerGatewayIP:   vlan1["peer_gateway_ip"].(string),
-			VirtualIP:       vlan1["vrrp_virtual_ip"].(string),
-			Tag:             vlan1["tag"].(string),
+			ParentLogicalInterface: vlan1["parent_logical_interface_name"].(string),
+			IPAddr:                 vlan1["ip_address"].(string),
+			GatewayIP:              vlan1["gateway_ip"].(string),
+			PeerIPAddr:             vlan1["peer_ip_address"].(string),
+			PeerGatewayIP:          vlan1["peer_gateway_ip"].(string),
+			VirtualIP:              vlan1["vrrp_virtual_ip"].(string),
+			Tag:                    vlan1["tag"].(string),
 		}
 
-		vlan2.VlanId = strconv.Itoa(vlan1["vlan_id"].(int))
+		vlandID, ok := vlan1["vlan_id"].(int)
+		if !ok {
+			return nil, fmt.Errorf("invalid or missing value for 'vlan_id'")
+		}
+		vlan2.VlanID = strconv.Itoa(vlandID)
 
 		edgeMegaport.VlanList = append(edgeMegaport.VlanList, vlan2)
 	}
@@ -794,7 +798,7 @@ func resourceAviatrixEdgeMegaportRead(ctx context.Context, d *schema.ResourceDat
 		if strings.HasPrefix(interface0.LogicalInterfaceName, "lan") && interface0.SubInterfaces != nil {
 			for _, vlan0 := range interface0.SubInterfaces {
 				vlan1 := make(map[string]interface{})
-				vlan1["parent_interface_name"] = vlan0.ParentInterface
+				vlan1["parent_logical_interface_name"] = vlan0.ParentInterface
 				vlan1["ip_address"] = vlan0.IpAddr
 				vlan1["gateway_ip"] = vlan0.GatewayIp
 				vlan1["peer_ip_address"] = vlan0.PeerIpAddr

--- a/aviatrix/resource_aviatrix_edge_megaport_test.go
+++ b/aviatrix/resource_aviatrix_edge_megaport_test.go
@@ -45,6 +45,9 @@ func TestAccAviatrixEdgeMegaport_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.3.ip_address", "192.168.77.14/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.3.logical_ifname", "wan2"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.4.logical_ifname", "mgmt0"),
+					resource.TestCheckResourceAttr(resourceName, "vlan.0.parent_logical_interface_name", "lan0"),
+					resource.TestCheckResourceAttr(resourceName, "vlan.0.vlan_id", "21"),
+					resource.TestCheckResourceAttr(resourceName, "vlan.0.ip_address", "10.220.21.11/24"),
 				),
 			},
 			{
@@ -99,6 +102,12 @@ func testAccEdgeMegaportBasic(accountName, gwName, siteId, path string) string {
 		interfaces {
 			enable_dhcp   = true
 			logical_ifname = "mgmt0"
+		}
+
+		vlan {
+			parent_logical_interface_name = "lan0"
+			vlan_id                        = 21
+			ip_address                     = "10.220.21.11/24"
 		}
 	}
  `, accountName, gwName, siteId, path)

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -744,7 +744,7 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 							Description: "Logical interface name e.g., wan0, mgmt0.",
 							ValidateFunc: validation.StringMatch(
 								regexp.MustCompile(`^(wan|mgmt)[0-9]+$`),
-								"Logical interface name must start with 'wan', or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt2').",
+								"Logical interface name must start with 'wan', or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt0').",
 							),
 						},
 						"gateway_ip": {
@@ -790,7 +790,7 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 							Description: "Logical interface name e.g., wan0, mgmt0.",
 							ValidateFunc: validation.StringMatch(
 								regexp.MustCompile(`^(wan|mgmt)[0-9]+$`),
-								"Logical interface name must start with 'wan', or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt2').",
+								"Logical interface name must start with 'wan', or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt0').",
 							),
 						},
 						"gateway_ip": {
@@ -871,7 +871,7 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 							Description: "Logical interface name e.g., wan0, mgmt0.",
 							ValidateFunc: validation.StringMatch(
 								regexp.MustCompile(`^(wan|mgmt)[0-9]+$`),
-								"Logical interface name must start with 'wan', or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt2').",
+								"Logical interface name must start with 'wan', or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt0').",
 							),
 						},
 						"private_ip": {
@@ -3894,7 +3894,8 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 		}
 	}
 
-	if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGEEQUINIX) {
+	// ztp file download path is required for Equinix and Megaport edge gateways
+	if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGEEQUINIX|goaviatrix.EDGEMEGAPORT) {
 		gateway.ZtpFileDownloadPath, ok = d.Get("ztp_file_download_path").(string)
 		if !ok {
 			return fmt.Errorf("ztp_file_download_path attribute is required for Edge Transit Gateway")

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1958,9 +1958,9 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		}
 		// set ha management egress ip prefix list
 		if gw.HaGw.ManagementEgressIPPrefix == "" {
-			_ = d.Set("management_egress_ip_prefix_list", nil)
+			_ = d.Set("ha_management_egress_ip_prefix_list", nil)
 		} else {
-			_ = d.Set("management_egress_ip_prefix_list", strings.Split(gw.HaGw.ManagementEgressIPPrefix, ","))
+			_ = d.Set("ha_management_egress_ip_prefix_list", strings.Split(gw.HaGw.ManagementEgressIPPrefix, ","))
 		}
 	} else {
 		d.Set("enable_encrypt_volume", gw.EnableEncryptVolume)
@@ -2973,9 +2973,9 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					GwName:     d.Get("gw_name").(string) + "-hagw",
 					Interfaces: haInterfaces,
 				}
-				managementEgressIPPrefixList := getStringSet(d, "ha_management_egress_ip_prefix_list")
-				if len(managementEgressIPPrefixList) > 0 {
-					gateway.ManagementEgressIPPrefix = strings.Join(managementEgressIPPrefixList, ",")
+				haManagementEgressIPPrefixList := getStringSet(d, "ha_management_egress_ip_prefix_list")
+				if len(haManagementEgressIPPrefixList) > 0 {
+					gateway.ManagementEgressIPPrefix = strings.Join(haManagementEgressIPPrefixList, ",")
 				}
 				err = client.UpdateEdgeGateway(gateway)
 				if err != nil {

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -1198,7 +1198,7 @@ func TestCreateBackupLinkConfig(t *testing.T) {
 	tests := []struct {
 		name                   string
 		gwName                 string
-		peerBackupLogicalNames []string
+		peerBackupLogicalNames []interface{}
 		connectionType         string
 		wanCount               int
 		cloudType              int
@@ -1208,7 +1208,7 @@ func TestCreateBackupLinkConfig(t *testing.T) {
 		{
 			name:                   "Valid backup link config for AEP",
 			gwName:                 "gw1",
-			peerBackupLogicalNames: []string{"wan0", "wan1"},
+			peerBackupLogicalNames: []interface{}{"wan0", "wan1"},
 			connectionType:         "private",
 			wanCount:               3,
 			cloudType:              goaviatrix.EDGENEO,
@@ -1218,17 +1218,17 @@ func TestCreateBackupLinkConfig(t *testing.T) {
 		{
 			name:                   "Valid backup link config for Megaport",
 			gwName:                 "gw2",
-			peerBackupLogicalNames: []string{"wan2", "wan3"},
+			peerBackupLogicalNames: []interface{}{"wan2", "wan3"},
 			connectionType:         "public",
 			wanCount:               4,
 			cloudType:              goaviatrix.EDGEMEGAPORT,
-			expected:               `[{"peer_gw_name":"gw2","peer_backup_port":"eth3,eth4","self_backup_port":"eth3,eth4","connection_type":"public","peer_backup_logical_ifnames":["wan2","wan3"],"self_backup_logical_ifnames":["wan2","wan3"]}]`,
+			expected:               `[{"peer_gw_name":"gw2","connection_type":"public","peer_backup_logical_ifnames":["wan2","wan3"],"self_backup_logical_ifnames":["wan2","wan3"]}]`,
 			expectedErr:            nil,
 		},
 		{
 			name:                   "Invalid logical name in backup link config",
 			gwName:                 "gw3",
-			peerBackupLogicalNames: []string{"wan0", "invalid_eth"},
+			peerBackupLogicalNames: []interface{}{"wan0", "invalid_eth"},
 			connectionType:         "private",
 			wanCount:               3,
 			cloudType:              goaviatrix.EDGENEO,
@@ -1238,11 +1238,11 @@ func TestCreateBackupLinkConfig(t *testing.T) {
 		{
 			name:                   "Empty logical names in backup link config",
 			gwName:                 "gw4",
-			peerBackupLogicalNames: []string{},
+			peerBackupLogicalNames: []interface{}{},
 			connectionType:         "private",
 			wanCount:               3,
 			cloudType:              goaviatrix.EDGENEO,
-			expected:               `[{"peer_gw_name":"gw4","peer_backup_port":"","self_backup_port":"","connection_type":"private"}]`,
+			expected:               `[{"peer_gw_name":"gw4","connection_type":"private"}]`,
 			expectedErr:            nil,
 		},
 	}

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -20,33 +20,28 @@ var interfaces = []interface{}{
 	map[string]interface{}{
 		"gateway_ip":                  "192.168.20.1",
 		"ip_address":                  "192.168.20.11/24",
-		"type":                        "WAN",
-		"index":                       0,
+		"logical_ifname":              "wan0",
 		"secondary_private_cidr_list": []interface{}{"192.168.19.16/29"},
 	},
 	map[string]interface{}{
 		"gateway_ip":                  "192.168.21.1",
 		"ip_address":                  "192.168.21.11/24",
-		"type":                        "WAN",
-		"index":                       1,
+		"logical_ifname":              "wan1",
 		"secondary_private_cidr_list": []interface{}{"192.168.21.16/29"},
 	},
 	map[string]interface{}{
-		"dhcp":  true,
-		"type":  "MANAGEMENT",
-		"index": 0,
+		"dhcp":           true,
+		"logical_ifname": "mgmt0",
 	},
 	map[string]interface{}{
-		"gateway_ip": "192.168.22.1",
-		"ip_address": "192.168.22.11/24",
-		"type":       "WAN",
-		"index":      2,
+		"gateway_ip":     "192.168.22.1",
+		"ip_address":     "192.168.22.11/24",
+		"logical_ifname": "wan2",
 	},
 	map[string]interface{}{
-		"gateway_ip": "192.168.23.1",
-		"ip_address": "192.168.23.11/24",
-		"type":       "WAN",
-		"index":      3,
+		"gateway_ip":     "192.168.23.1",
+		"ip_address":     "192.168.23.11/24",
+		"logical_ifname": "wan3",
 	},
 }
 
@@ -56,6 +51,7 @@ var expectedInterfaceDetails = []goaviatrix.EdgeTransitInterface{
 		IpAddress:      "192.168.20.11/24",
 		Name:           "eth0",
 		Type:           "WAN",
+		LogicalIfName:  "wan0",
 		SecondaryCIDRs: []string{"192.168.19.16/29"},
 	},
 	{
@@ -63,24 +59,28 @@ var expectedInterfaceDetails = []goaviatrix.EdgeTransitInterface{
 		IpAddress:      "192.168.21.11/24",
 		Name:           "eth1",
 		Type:           "WAN",
+		LogicalIfName:  "wan1",
 		SecondaryCIDRs: []string{"192.168.21.16/29"},
 	},
 	{
-		Dhcp: true,
-		Name: "eth2",
-		Type: "MANAGEMENT",
+		Dhcp:          true,
+		Name:          "eth2",
+		LogicalIfName: "mgmt0",
+		Type:          "MANAGEMENT",
 	},
 	{
-		GatewayIp: "192.168.22.1",
-		IpAddress: "192.168.22.11/24",
-		Name:      "eth3",
-		Type:      "WAN",
+		GatewayIp:     "192.168.22.1",
+		IpAddress:     "192.168.22.11/24",
+		Name:          "eth3",
+		Type:          "WAN",
+		LogicalIfName: "wan2",
 	},
 	{
-		GatewayIp: "192.168.23.1",
-		IpAddress: "192.168.23.11/24",
-		Name:      "eth4",
-		Type:      "WAN",
+		GatewayIp:     "192.168.23.1",
+		IpAddress:     "192.168.23.11/24",
+		Name:          "eth4",
+		Type:          "WAN",
+		LogicalIfName: "wan3",
 	},
 }
 
@@ -295,14 +295,11 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceNameAEP, "device_id", os.Getenv("AEP_DEVICE_ID")),
 						resource.TestCheckResourceAttr(resourceNameAEP, "interfaces.0.gateway_ip", "192.168.20.1"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "interfaces.0.ip_address", "192.168.20.11/24"),
-						resource.TestCheckResourceAttr(resourceNameAEP, "interfaces.0.type", "WAN"),
-						resource.TestCheckResourceAttr(resourceNameAEP, "interfaces.0.index", "0"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "interfaces.0.logical_ifname", "wan0"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "ha_interfaces.0.gateway_ip", "192.168.20.1"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "ha_interfaces.0.ip_address", "192.168.20.12/24"),
-						resource.TestCheckResourceAttr(resourceNameAEP, "ha_interfaces.0.type", "WAN"),
-						resource.TestCheckResourceAttr(resourceNameAEP, "ha_interfaces.0.index", "0"),
-						resource.TestCheckResourceAttr(resourceNameAEP, "peer_backup_port_type", "WAN"),
-						resource.TestCheckResourceAttr(resourceNameAEP, "peer_backup_port_index", "1"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "ha_interfaces.0.logical_ifname", "wan0"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "peer_backup_logical_ifname", "wan1"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "peer_connection_type", "private"),
 					),
 				},
@@ -339,14 +336,11 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceNameEquinix, "ztp_file_download_path", "/tmp"),
 						resource.TestCheckResourceAttr(resourceNameEquinix, "interfaces.0.gateway_ip", "192.168.20.1"),
 						resource.TestCheckResourceAttr(resourceNameEquinix, "interfaces.0.ip_address", "192.168.20.11/24"),
-						resource.TestCheckResourceAttr(resourceNameEquinix, "interfaces.0.type", "WAN"),
-						resource.TestCheckResourceAttr(resourceNameEquinix, "interfaces.0.index", "0"),
+						resource.TestCheckResourceAttr(resourceNameEquinix, "interfaces.0.logical_ifname", "wan0"),
 						resource.TestCheckResourceAttr(resourceNameEquinix, "ha_interfaces.0.gateway_ip", "192.168.20.1"),
 						resource.TestCheckResourceAttr(resourceNameEquinix, "ha_interfaces.0.ip_address", "192.168.20.12/24"),
-						resource.TestCheckResourceAttr(resourceNameEquinix, "ha_interfaces.0.type", "WAN"),
-						resource.TestCheckResourceAttr(resourceNameEquinix, "ha_interfaces.0.index", "0"),
-						resource.TestCheckResourceAttr(resourceNameEquinix, "peer_backup_port_type", "WAN"),
-						resource.TestCheckResourceAttr(resourceNameEquinix, "peer_backup_port_index", "1"),
+						resource.TestCheckResourceAttr(resourceNameEquinix, "ha_interfaces.0.logical_ifname", "wan0"),
+						resource.TestCheckResourceAttr(resourceNameEquinix, "peer_backup_logical_ifname", "wan1"),
 						resource.TestCheckResourceAttr(resourceNameEquinix, "peer_connection_type", "private"),
 					),
 				},
@@ -494,78 +488,67 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_aep" {
 	device_id = "%[3]s"
 	gw_size      = "SMALL"
 	interfaces {
-        gateway_ip    = "192.168.20.1"
-        ip_address    = "192.168.20.11/24"
-        type          = "WAN"
-        index         = 0
+        gateway_ip     = "192.168.20.1"
+        ip_address     = "192.168.20.11/24"
+        logical_ifname = "wan0"
         secondary_private_cidr_list = ["192.168.19.16/29"]
     }
 
     interfaces {
-        gateway_ip    = "192.168.21.1"
-        ip_address    = "192.168.21.11/24"
-        type          = "WAN"
-        index         = 1
+        gateway_ip     = "192.168.21.1"
+        ip_address     = "192.168.21.11/24"
+        logical_ifname = "wan1"
         secondary_private_cidr_list = ["192.168.21.16/29"]
     }
 
     interfaces {
         dhcp   = true
-        type   = "MANAGEMENT"
-        index  = 0
+        logical_ifname = "mgmt0"
     }
 
     interfaces {
-        gateway_ip  = "192.168.22.1"
-        ip_address  = "192.168.22.11/24"
-        type        = "WAN"
-        index       = 2
+        gateway_ip     = "192.168.22.1"
+        ip_address     = "192.168.22.11/24"
+        logical_ifname = "wan2"
     }
 
     interfaces {
-        gateway_ip = "192.168.23.1"
-        ip_address = "192.168.23.11/24"
-        type       = "WAN"
-        index      = 3
+        gateway_ip     = "192.168.23.1"
+        ip_address     = "192.168.23.11/24"
+        logical_ifname = "wan3"
     }
 
 	ha_device_id = "a20c75c0-06c2-4102-9df1-b00b85e89eac"
-    peer_backup_port_type = "WAN"
-    peer_backup_port_index = 1
+    peer_backup_logical_ifname = "wan1"
     peer_connection_type = "private"
     ha_interfaces {
         gateway_ip    = "192.168.20.1"
-        index         = 0
         ip_address    = "192.168.20.12/24"
-        type          = "WAN"
+		logical_ifname = "wan0"
     }
 
     ha_interfaces {
-        gateway_ip   = "192.168.21.1"
-        index        = 1
-        ip_address   = "192.168.21.12/24"
-        type         = "WAN"
+        gateway_ip     = "192.168.21.1"
+        ip_address     = "192.168.21.12/24"
+        logical_ifname = "wan1"
         secondary_private_cidr_list = ["192.168.21.32/29"]
     }
 
     ha_interfaces {
-        dhcp   = true
-        index  = 0
-        type   = "MANAGEMENT"
+        dhcp           = true
+        logical_ifname = "mgmt0"
     }
 
     ha_interfaces {
-        gateway_ip   = "192.168.22.1"
-        index        = 2
-        ip_address   = "192.168.22.12/24"
-        type         = "WAN"
+        gateway_ip     = "192.168.22.1"
+        ip_address     = "192.168.22.12/24"
+        logical_ifname = "wan2"
     }
 
     ha_interfaces {
         gateway_ip     = "192.168.23.1"
-        index          = 3
         ip_address     = "192.168.23.12/24"
-        type           = "WAN"
+        logical_ifname = "wan3"
     }
 }
 	`, rName, os.Getenv("AEP_VPC_ID"), os.Getenv("AEP_DEVICE_ID"))
@@ -585,77 +568,66 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_equinix" {
 	gw_size      = "SMALL"
 	ztp_file_download_path = "/tmp"
 	interfaces {
-        gateway_ip    = "192.168.20.1"
-        ip_address    = "192.168.20.11/24"
-        type          = "WAN"
-        index         = 0
+        gateway_ip     = "192.168.20.1"
+        ip_address     = "192.168.20.11/24"
+        logical_ifname = "wan0"
         secondary_private_cidr_list = ["192.168.19.16/29"]
     }
 
     interfaces {
-        gateway_ip    = "192.168.21.1"
-        ip_address    = "192.168.21.11/24"
-        type          = "WAN"
-        index         = 1
+        gateway_ip     = "192.168.21.1"
+        ip_address     = "192.168.21.11/24"
+        logical_ifname = "wan1"
         secondary_private_cidr_list = ["192.168.21.16/29"]
     }
 
     interfaces {
-        dhcp   = true
-        type   = "MANAGEMENT"
-        index  = 0
+        dhcp           = true
+        logical_ifname = "mgmt0"
     }
 
     interfaces {
-        gateway_ip  = "192.168.22.1"
-        ip_address  = "192.168.22.11/24"
-        type        = "WAN"
-        index       = 2
+        gateway_ip     = "192.168.22.1"
+        ip_address     = "192.168.22.11/24"
+        logical_ifname = "wan2"
     }
 
     interfaces {
-        gateway_ip = "192.168.23.1"
-        ip_address = "192.168.23.11/24"
-        type       = "WAN"
-        index      = 3
+        gateway_ip     = "192.168.23.1"
+        ip_address     = "192.168.23.11/24"
+        logical_ifname = "wan3"
     }
 
-    peer_backup_port_type = "WAN"
-    peer_backup_port_index = 1
+    peer_backup_logical_ifname = "wan1"
     peer_connection_type = "private"
     ha_interfaces {
         gateway_ip    = "192.168.20.1"
-        index         = 0
         ip_address    = "192.168.20.12/24"
-        type          = "WAN"
+		logical_ifname = "wan0"
     }
 
     ha_interfaces {
         gateway_ip   = "192.168.21.1"
-        index        = 1
         ip_address   = "192.168.21.12/24"
-        type         = "WAN"
+		logical_ifname = "wan1"
         secondary_private_cidr_list = ["192.168.21.32/29"]
     }
 
     ha_interfaces {
         dhcp   = true
-        index  = 0
-        type   = "MANAGEMENT"
+		logical_ifname = "mgmt0"
     }
 
     ha_interfaces {
         gateway_ip   = "192.168.22.1"
-        index        = 2
         ip_address   = "192.168.22.12/24"
-        type         = "WAN"
+		logical_ifname = "wan2"
     }
 
     ha_interfaces {
         gateway_ip     = "192.168.23.1"
-        index          = 3
         ip_address     = "192.168.23.12/24"
-        type           = "WAN"
+		logical_ifname = "wan3"
     }
 }
 	`, rName, os.Getenv("EQUINIX_VPC_ID"))
@@ -824,7 +796,7 @@ func TestGetInterfaceName(t *testing.T) {
 			intfType:    "INVALID",
 			wanCount:    3,
 			expected:    "",
-			expectedErr: errors.New("invalid interface type INVALID"),
+			expectedErr: errors.New("invalid logical interface name: INVALID"),
 		},
 	}
 
@@ -859,59 +831,75 @@ func TestGetEipMapDetails(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "Valid EIP map with WAN and MANAGEMENT interfaces",
+			name: "Valid EIP map with WAN and MANAGEMENT interfaces for AEP",
 			eipMap: []interface{}{
 				map[string]interface{}{
-					"interface_type":  "WAN",
-					"interface_index": 0,
-					"private_ip":      "192.168.0.10",
-					"public_ip":       "203.0.113.10",
+					"logical_ifname": "wan0",
+					"private_ip":     "192.168.0.10",
+					"public_ip":      "203.0.113.10",
 				},
 				map[string]interface{}{
-					"interface_type":  "MANAGEMENT",
-					"interface_index": 0,
-					"private_ip":      "192.168.1.10",
-					"public_ip":       "203.0.113.11",
+					"logical_ifname": "mgmt0",
+					"private_ip":     "192.168.1.10",
+					"public_ip":      "203.0.113.11",
 				},
 			},
 			wanCount:    3,
-			cloudType:   1048576,
+			cloudType:   262144,
 			expected:    `{"eth0":[{"private_ip":"192.168.0.10","public_ip":"203.0.113.10"}],"eth2":[{"private_ip":"192.168.1.10","public_ip":"203.0.113.11"}]}`,
 			expectedErr: nil,
 		},
 		{
-			name: "Invalid EIP map: missing interface type",
+			name: "Valid EIP map with WAN and MANAGEMENT interfaces for Megaport",
 			eipMap: []interface{}{
 				map[string]interface{}{
-					"interface_index": 0,
-					"private_ip":      "192.168.0.10",
-					"public_ip":       "203.0.113.10",
+					"logical_ifname": "wan0",
+					"private_ip":     "192.168.0.10",
+					"public_ip":      "203.0.113.10",
+				},
+				map[string]interface{}{
+					"logical_ifname": "mgmt0",
+					"private_ip":     "192.168.1.10",
+					"public_ip":      "203.0.113.11",
 				},
 			},
 			wanCount:    3,
 			cloudType:   1048576,
-			expected:    "",
-			expectedErr: errors.New("interface_type must be a string"),
+			expected:    `{"mgmt0":[{"private_ip":"192.168.1.10","public_ip":"203.0.113.11"}],"wan0":[{"private_ip":"192.168.0.10","public_ip":"203.0.113.10"}]}`,
+			expectedErr: nil,
 		},
 		{
-			name: "Invalid EIP map: invalid interface type",
+			name: "Invalid EIP map: missing logical interface name",
 			eipMap: []interface{}{
 				map[string]interface{}{
-					"interface_type":  "INVALID",
-					"interface_index": 0,
-					"private_ip":      "192.168.0.10",
-					"public_ip":       "203.0.113.10",
+					"private_ip": "192.168.0.10",
+					"public_ip":  "203.0.113.10",
 				},
 			},
 			wanCount:    3,
 			cloudType:   1048576,
 			expected:    "",
-			expectedErr: errors.New("failed to get the interface name using type and index for eip_map: invalid interface type INVALID"),
+			expectedErr: errors.New("logical interface name must be a string"),
+		},
+		{
+			name: "Invalid EIP map: invalid logical interface name",
+			eipMap: []interface{}{
+				map[string]interface{}{
+					"logical_ifname": 123,
+					"private_ip":     "192.168.0.10",
+					"public_ip":      "203.0.113.10",
+				},
+			},
+			wanCount:    3,
+			cloudType:   1048576,
+			expected:    "",
+			expectedErr: errors.New("logical interface name must be a string"),
 		},
 		{
 			name:        "Empty EIP map",
 			eipMap:      []interface{}{},
 			wanCount:    3,
+			cloudType:   1048576,
 			expected:    `{}`,
 			expectedErr: nil,
 		},
@@ -998,22 +986,19 @@ func TestSetEipMapDetails(t *testing.T) {
 			},
 			expectedResult: []map[string]interface{}{
 				{
-					"interface_type":  "WAN",
-					"interface_index": 0,
-					"private_ip":      "192.168.1.10",
-					"public_ip":       "34.123.45.67",
+					"logical_ifname": "wan0",
+					"private_ip":     "192.168.1.10",
+					"public_ip":      "34.123.45.67",
 				},
 				{
-					"interface_type":  "WAN",
-					"interface_index": 1,
-					"private_ip":      "192.168.1.11",
-					"public_ip":       "34.123.45.68",
+					"logical_ifname": "wan1",
+					"private_ip":     "192.168.1.11",
+					"public_ip":      "34.123.45.68",
 				},
 				{
-					"interface_type":  "WAN",
-					"interface_index": 1,
-					"private_ip":      "192.168.1.12",
-					"public_ip":       "34.123.45.69",
+					"logical_ifname": "wan1",
+					"private_ip":     "192.168.1.12",
+					"public_ip":      "34.123.45.69",
 				},
 			},
 			expectedErr: "",
@@ -1110,47 +1095,44 @@ func TestSetInterfaceDetails(t *testing.T) {
 		{
 			name: "Single WAN interface",
 			interfaces: []goaviatrix.EdgeTransitInterface{
-				{Type: "WAN", PublicIp: "1.1.1.1", Dhcp: true, IpAddress: "10.0.0.1", GatewayIp: "10.0.0.254"},
+				{LogicalIfName: "wan0", PublicIp: "1.1.1.1", Dhcp: true, IpAddress: "10.0.0.1", GatewayIp: "10.0.0.254"},
 			},
 			expected: []map[string]interface{}{
 				{
-					"type":       "WAN",
-					"index":      0,
-					"public_ip":  "1.1.1.1",
-					"dhcp":       true,
-					"ip_address": "10.0.0.1",
-					"gateway_ip": "10.0.0.254",
+					"logical_ifname": "wan0",
+					"public_ip":      "1.1.1.1",
+					"dhcp":           true,
+					"ip_address":     "10.0.0.1",
+					"gateway_ip":     "10.0.0.254",
 				},
 			},
 		},
 		{
 			name: "Multiple WAN and MANAGEMENT interfaces",
 			interfaces: []goaviatrix.EdgeTransitInterface{
-				{Type: "WAN", IpAddress: "10.0.0.2"},
-				{Type: "WAN", IpAddress: "10.0.0.3"},
-				{Type: "MANAGEMENT", GatewayIp: "192.168.1.1"},
-				{Type: "MANAGEMENT", Dhcp: true},
+				{LogicalIfName: "wan0", IpAddress: "10.0.0.2"},
+				{LogicalIfName: "wan1", IpAddress: "10.0.0.3"},
+				{LogicalIfName: "wan2", GatewayIp: "192.168.1.1"},
+				{LogicalIfName: "mgmt0", Dhcp: true},
 			},
 			expected: []map[string]interface{}{
-				{"type": "WAN", "index": 0, "ip_address": "10.0.0.2"},
-				{"type": "WAN", "index": 1, "ip_address": "10.0.0.3"},
-				{"type": "MANAGEMENT", "index": 0, "gateway_ip": "192.168.1.1"},
-				{"type": "MANAGEMENT", "index": 1, "dhcp": true},
+				{"logical_ifname": "wan0", "ip_address": "10.0.0.2"},
+				{"logical_ifname": "wan1", "ip_address": "10.0.0.3"},
+				{"logical_ifname": "wan2", "gateway_ip": "192.168.1.1"},
+				{"logical_ifname": "mgmt0", "dhcp": true},
 			},
 		},
 		{
 			name: "Custom interface with Secondary CIDRs",
 			interfaces: []goaviatrix.EdgeTransitInterface{
 				{
-					Type:           "CUSTOM",
-					Index:          5,
+					LogicalIfName:  "mgmt0",
 					SecondaryCIDRs: []string{"10.0.1.0/24", "10.0.2.0/24"},
 				},
 			},
 			expected: []map[string]interface{}{
 				{
-					"type":                        "CUSTOM",
-					"index":                       5,
+					"logical_ifname":              "mgmt0",
 					"secondary_private_cidr_list": []string{"10.0.1.0/24", "10.0.2.0/24"},
 				},
 			},
@@ -1164,14 +1146,13 @@ func TestSetInterfaceDetails(t *testing.T) {
 			name: "Ignore empty SecondaryCIDRs",
 			interfaces: []goaviatrix.EdgeTransitInterface{
 				{
-					Type:           "WAN",
+					LogicalIfName:  "wan0",
 					SecondaryCIDRs: []string{"", "10.0.3.0/24", ""},
 				},
 			},
 			expected: []map[string]interface{}{
 				{
-					"type":                        "WAN",
-					"index":                       0,
+					"logical_ifname":              "wan0",
 					"secondary_private_cidr_list": []string{"10.0.3.0/24"},
 				},
 			},
@@ -1220,5 +1201,75 @@ func TestDeleteZtpFile(t *testing.T) {
 	err = deleteZtpFile(gatewayName, vpcID, ztpFileDownloadPath)
 	if err != nil {
 		t.Errorf("deleteZtpFile returned an error when file does not exist: %v", err)
+	}
+}
+
+func TestCreateBackupLinkConfig(t *testing.T) {
+	tests := []struct {
+		name                   string
+		gwName                 string
+		peerBackupLogicalNames []string
+		connectionType         string
+		wanCount               int
+		cloudType              int
+		expected               string
+		expectedErr            error
+	}{
+		{
+			name:                   "Valid backup link config for AEP",
+			gwName:                 "gw1",
+			peerBackupLogicalNames: []string{"wan0", "wan1"},
+			connectionType:         "private",
+			wanCount:               3,
+			cloudType:              goaviatrix.EDGENEO,
+			expected:               `[{"peer_gw_name":"gw1","peer_backup_port":"eth0,eth1","self_backup_port":"eth0,eth1","connection_type":"private"}]`,
+			expectedErr:            nil,
+		},
+		{
+			name:                   "Valid backup link config for Megaport",
+			gwName:                 "gw2",
+			peerBackupLogicalNames: []string{"wan2", "wan3"},
+			connectionType:         "public",
+			wanCount:               4,
+			cloudType:              goaviatrix.EDGEMEGAPORT,
+			expected:               `[{"peer_gw_name":"gw2","peer_backup_port":"eth3,eth4","self_backup_port":"eth3,eth4","connection_type":"public","peer_backup_logical_ifnames":["wan2","wan3"],"self_backup_logical_ifnames":["wan2","wan3"]}]`,
+			expectedErr:            nil,
+		},
+		{
+			name:                   "Invalid logical name in backup link config",
+			gwName:                 "gw3",
+			peerBackupLogicalNames: []string{"wan0", "invalid_eth"},
+			connectionType:         "private",
+			wanCount:               3,
+			cloudType:              goaviatrix.EDGENEO,
+			expected:               "",
+			expectedErr:            fmt.Errorf("failed to get the peer backup port name for logical name invalid_eth: invalid logical interface name: invalid_eth"),
+		},
+		{
+			name:                   "Empty logical names in backup link config",
+			gwName:                 "gw4",
+			peerBackupLogicalNames: []string{},
+			connectionType:         "private",
+			wanCount:               3,
+			cloudType:              goaviatrix.EDGENEO,
+			expected:               `[{"peer_gw_name":"gw4","peer_backup_port":"","self_backup_port":"","connection_type":"private"}]`,
+			expectedErr:            nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := createBackupLinkConfig(tt.gwName, tt.peerBackupLogicalNames, tt.connectionType, tt.wanCount, tt.cloudType)
+
+			// Check for expected error
+			if (err != nil || tt.expectedErr != nil) && (err == nil || err.Error() != tt.expectedErr.Error()) {
+				t.Errorf("expected error: %v, got: %v", tt.expectedErr, err)
+			}
+
+			// Check the result
+			if result != tt.expected {
+				t.Errorf("expected result: %s, got: %s", tt.expected, result)
+			}
+		})
 	}
 }

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
@@ -817,7 +818,7 @@ func TestGetEipMapDetails(t *testing.T) {
 		eipMap      []interface{}
 		wanCount    int
 		cloudType   int
-		expected    string
+		expected    map[string][]goaviatrix.EipMap
 		expectedErr error
 	}{
 		{
@@ -834,9 +835,16 @@ func TestGetEipMapDetails(t *testing.T) {
 					"public_ip":      "203.0.113.11",
 				},
 			},
-			wanCount:    3,
-			cloudType:   262144,
-			expected:    `{"eth0":[{"private_ip":"192.168.0.10","public_ip":"203.0.113.10"}],"eth2":[{"private_ip":"192.168.1.10","public_ip":"203.0.113.11"}]}`,
+			wanCount:  3,
+			cloudType: 262144,
+			expected: map[string][]goaviatrix.EipMap{
+				"eth0": {
+					{PrivateIP: "192.168.0.10", PublicIP: "203.0.113.10"},
+				},
+				"eth2": {
+					{PrivateIP: "192.168.1.10", PublicIP: "203.0.113.11"},
+				},
+			},
 			expectedErr: nil,
 		},
 		{
@@ -853,9 +861,16 @@ func TestGetEipMapDetails(t *testing.T) {
 					"public_ip":      "203.0.113.11",
 				},
 			},
-			wanCount:    3,
-			cloudType:   1048576,
-			expected:    `{"mgmt0":[{"private_ip":"192.168.1.10","public_ip":"203.0.113.11"}],"wan0":[{"private_ip":"192.168.0.10","public_ip":"203.0.113.10"}]}`,
+			wanCount:  3,
+			cloudType: 1048576,
+			expected: map[string][]goaviatrix.EipMap{
+				"wan0": {
+					{PrivateIP: "192.168.0.10", PublicIP: "203.0.113.10"},
+				},
+				"mgmt0": {
+					{PrivateIP: "192.168.1.10", PublicIP: "203.0.113.11"},
+				},
+			},
 			expectedErr: nil,
 		},
 		{
@@ -868,7 +883,7 @@ func TestGetEipMapDetails(t *testing.T) {
 			},
 			wanCount:    3,
 			cloudType:   1048576,
-			expected:    "",
+			expected:    nil,
 			expectedErr: errors.New("logical interface name must be a string"),
 		},
 		{
@@ -882,7 +897,7 @@ func TestGetEipMapDetails(t *testing.T) {
 			},
 			wanCount:    3,
 			cloudType:   1048576,
-			expected:    "",
+			expected:    nil,
 			expectedErr: errors.New("logical interface name must be a string"),
 		},
 		{
@@ -890,7 +905,7 @@ func TestGetEipMapDetails(t *testing.T) {
 			eipMap:      []interface{}{},
 			wanCount:    3,
 			cloudType:   1048576,
-			expected:    `{}`,
+			expected:    map[string][]goaviatrix.EipMap{},
 			expectedErr: nil,
 		},
 	}
@@ -909,8 +924,8 @@ func TestGetEipMapDetails(t *testing.T) {
 			}
 
 			// Check result
-			if result != tt.expected {
-				t.Errorf("expected result: %s, got: %s", tt.expected, result)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected result: %v, got: %v", tt.expected, result)
 			}
 		})
 	}

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -49,37 +49,27 @@ var expectedInterfaceDetails = []goaviatrix.EdgeTransitInterface{
 	{
 		GatewayIp:      "192.168.20.1",
 		IpAddress:      "192.168.20.11/24",
-		Name:           "eth0",
-		Type:           "WAN",
 		LogicalIfName:  "wan0",
 		SecondaryCIDRs: []string{"192.168.19.16/29"},
 	},
 	{
 		GatewayIp:      "192.168.21.1",
 		IpAddress:      "192.168.21.11/24",
-		Name:           "eth1",
-		Type:           "WAN",
 		LogicalIfName:  "wan1",
 		SecondaryCIDRs: []string{"192.168.21.16/29"},
 	},
 	{
 		Dhcp:          true,
-		Name:          "eth2",
 		LogicalIfName: "mgmt0",
-		Type:          "MANAGEMENT",
 	},
 	{
 		GatewayIp:     "192.168.22.1",
 		IpAddress:     "192.168.22.11/24",
-		Name:          "eth3",
-		Type:          "WAN",
 		LogicalIfName: "wan2",
 	},
 	{
 		GatewayIp:     "192.168.23.1",
 		IpAddress:     "192.168.23.11/24",
-		Name:          "eth4",
-		Type:          "WAN",
 		LogicalIfName: "wan3",
 	},
 }

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -786,40 +786,35 @@ func TestGetInterfaceName(t *testing.T) {
 	}{
 		{
 			name:        "Valid WAN interface with index 0",
-			intfType:    "WAN",
-			intfIndex:   0,
+			intfType:    "wan0",
 			wanCount:    3,
 			expected:    "eth0",
 			expectedErr: nil,
 		},
 		{
 			name:        "Valid WAN interface with index 1",
-			intfType:    "WAN",
-			intfIndex:   1,
+			intfType:    "wan1",
 			wanCount:    3,
 			expected:    "eth1",
 			expectedErr: nil,
 		},
 		{
 			name:        "Valid WAN interface with index 2",
-			intfType:    "WAN",
-			intfIndex:   2,
+			intfType:    "wan2",
 			wanCount:    3,
 			expected:    "eth3",
 			expectedErr: nil,
 		},
 		{
 			name:        "Valid MANAGEMENT interface with index 0",
-			intfType:    "MANAGEMENT",
-			intfIndex:   0,
+			intfType:    "mgmt0",
 			wanCount:    3,
 			expected:    "eth2",
 			expectedErr: nil,
 		},
 		{
 			name:        "Valid MANAGEMENT interface with index 1",
-			intfType:    "MANAGEMENT",
-			intfIndex:   1,
+			intfType:    "mgmt1",
 			wanCount:    3,
 			expected:    "eth4",
 			expectedErr: nil,
@@ -827,7 +822,6 @@ func TestGetInterfaceName(t *testing.T) {
 		{
 			name:        "Invalid interface type",
 			intfType:    "INVALID",
-			intfIndex:   0,
 			wanCount:    3,
 			expected:    "",
 			expectedErr: errors.New("invalid interface type INVALID"),
@@ -836,7 +830,7 @@ func TestGetInterfaceName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := getInterfaceName(tt.intfType, tt.intfIndex, tt.wanCount)
+			result, err := getInterfaceName(tt.intfType, tt.wanCount)
 
 			// Check error
 			if err != nil && tt.expectedErr != nil {
@@ -860,6 +854,7 @@ func TestGetEipMapDetails(t *testing.T) {
 		name        string
 		eipMap      []interface{}
 		wanCount    int
+		cloudType   int
 		expected    string
 		expectedErr error
 	}{
@@ -880,6 +875,7 @@ func TestGetEipMapDetails(t *testing.T) {
 				},
 			},
 			wanCount:    3,
+			cloudType:   1048576,
 			expected:    `{"eth0":[{"private_ip":"192.168.0.10","public_ip":"203.0.113.10"}],"eth2":[{"private_ip":"192.168.1.10","public_ip":"203.0.113.11"}]}`,
 			expectedErr: nil,
 		},
@@ -893,6 +889,7 @@ func TestGetEipMapDetails(t *testing.T) {
 				},
 			},
 			wanCount:    3,
+			cloudType:   1048576,
 			expected:    "",
 			expectedErr: errors.New("interface_type must be a string"),
 		},
@@ -907,6 +904,7 @@ func TestGetEipMapDetails(t *testing.T) {
 				},
 			},
 			wanCount:    3,
+			cloudType:   1048576,
 			expected:    "",
 			expectedErr: errors.New("failed to get the interface name using type and index for eip_map: invalid interface type INVALID"),
 		},
@@ -921,7 +919,7 @@ func TestGetEipMapDetails(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := getEipMapDetails(tt.eipMap, tt.wanCount)
+			result, err := getEipMapDetails(tt.eipMap, tt.wanCount, tt.cloudType)
 
 			// Check for errors
 			if err != nil && tt.expectedErr != nil {
@@ -957,7 +955,8 @@ func TestCountInterfaceTypes(t *testing.T) {
 // test to get the interface details from the resource
 func TestGetInterfaceDetails(t *testing.T) {
 	// get the interface details
-	interfaceDetails, err := getInterfaceDetails(interfaces)
+	cloudType := 1048576
+	interfaceDetails, err := getInterfaceDetails(interfaces, cloudType)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -380,8 +380,8 @@ func createOrderMap(order []string) map[string]int {
 func sortInterfacesByCustomOrder(interfaces []goaviatrix.EdgeTransitInterface) []goaviatrix.EdgeTransitInterface {
 	orderMap := createOrderMap(interfaceOrder)
 	sort.SliceStable(interfaces, func(i, j int) bool {
-		iIndex, iExists := orderMap[interfaces[i].Name]
-		jIndex, jExists := orderMap[interfaces[j].Name]
+		iIndex, iExists := orderMap[interfaces[i].LogicalIfName]
+		jIndex, jExists := orderMap[interfaces[j].LogicalIfName]
 		if !iExists {
 			iIndex = len(orderMap)
 		}

--- a/docs/resources/aviatrix_edge_megaport.md
+++ b/docs/resources/aviatrix_edge_megaport.md
@@ -102,7 +102,7 @@ The following arguments are supported:
 * `longitude` - (Optional) Longitude of Edge Megaport. Valid values are between -180 and 180. Example: "120.7401".
 * `rx_queue_size` - (Optional) Ethernet interface RX queue size. Once set, can't be deleted or disabled. Valid values: "1K", "2K", "4K".
 * `vlan` - (Optional) VLAN configuration.
-  * `parent_interface_name` - (Required) Parent interface name.
+  * `parent_logical_interface_name` - (Required) Parent logical interface name e.g. lan0.
   * `vlan_id` - (Required) VLAN ID.
   * `ip_address` - (Optional) LAN sub-interface IP address.
   * `gateway_ip` - (Optional) LAN sub-interface gateway IP.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -425,8 +425,7 @@ The following arguments are supported:
 * `ztp_file_download_path` - (Optional) Ztp file download path where the cloud init file will be stored locally. Required only for Equinix EAT gateway.
 * `device_id` - (Optional) Device ID for AEP EAT gateway. Required only for AEP gateway.
 * `interfaces` - (Optional) A list of WAN/Management interfaces, each represented as a map. Required and valid only for edge transit gateways AEP and Equinix. Each interface has the following attributes:
-  * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
-  * `index` - (Required) Interface index. Valid values are 0,1,2 etc.
+  * `logical_ifname` - (Required) Logical interface name e.g., wan0, mgmt0.
   * `gateway_ip` - (Optional) The gateway IP address associated with this interface.
   * `ip_address` - (Optional) The static IP address assigned to this interface.
   * `public_ip` - (Optional) The public IP address associated with this interface.
@@ -437,8 +436,7 @@ The following arguments are supported:
   * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
   * `index` - (Required) Interface index e.g. 0, 1 etc.
 * `eip_map` - (Optional) A list of mappings between interface names and their associated private and public IPs.
-  * `interface_type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
-  * `interface_index` - (Required) Interface index. Valid values are 0,1,2 etc.
+  * `logical_ifname` - (Required) Logical interface name e.g., wan0, mgmt0.
   * `private_ip` - (Required) The private IP address associated with the interface.
   * `public_ip` - (Required) The public IP address associated with the interface.
 
@@ -454,12 +452,10 @@ The following arguments are supported:
 * `ha_availability_domain` - (Optional) HA gateway availability domain. Required and valid only for OCI. Available as of provider version R2.19.3.
 * `ha_fault_domain` - (Optional) HA gateway fault domain. Required and valid only for OCI. Available as of provider version R2.19.3.
 * `ha_device_id` - (Optional) Device ID for HA AEP EAT gateway. Required only for AEP HA gateway.
-* `peer_backup_port_type` - (Optional) Peer backup port type for edge transit gateway. Required and valid only for edge gateways AEP and Equinix.
-* `peer_backup_port_index` - (Optional) Peer backup port index for edge transit gateway. Required and valid only for edge gateways AEP and Equinix.
+* `peer_backup_logical_ifname` - (Optional) Peer backup logical interface name for the edge transit gateway (e.g., 'wan0', 'wan1').
 * `peer_connection_type` - (Optional) Connection type for edge transit gateway e.g., "private", "public". Required and valid only for edge gateways AEP and Equinix.
 * `ha_interfaces` - (Optional) A list of WAN/Management interfaces, each represented as a map. Required and valid only for edge transit gateways AEP and Equinix. Each interface has the following attributes:
-  * `type` - (Required) Interface type. Valid values are 'WAN' or 'MANAGEMENT'.
-  * `index` - (Required) Interface index. Valid values are 0,1,2 etc.
+  * `logical_ifname` - (Required) Logical interface name e.g., wan0, mgmt0.
   * `gateway_ip` - (Optional) The gateway IP address associated with this interface.
   * `ip_address` - (Optional) The static IP address assigned to this interface.
   * `public_ip` - (Optional) The public IP address associated with this interface.

--- a/goaviatrix/const.go
+++ b/goaviatrix/const.go
@@ -33,7 +33,7 @@ const (
 	AzureArmRelatedCloudTypes = Azure | AzureGov | AzureChina
 	OCIRelatedCloudTypes      = OCI
 	AliCloudRelatedCloudTypes = AliCloud
-	EdgeRelatedCloudTypes     = EDGEEQUINIX | EDGENEO
+	EdgeRelatedCloudTypes     = EDGEEQUINIX | EDGENEO | EDGEMEGAPORT
 )
 
 // GetSupportedClouds returns the list of currently supported cloud IDs

--- a/goaviatrix/edge_megaport.go
+++ b/goaviatrix/edge_megaport.go
@@ -68,14 +68,14 @@ type EdgeMegaportInterface struct {
 }
 
 type EdgeMegaportVlan struct {
-	ParentInterface string `json:"parent_interface"`
-	VlanId          string `json:"vlan_id"`
-	IPAddr          string `json:"ipaddr"`
-	GatewayIP       string `json:"gateway_ip,omitempty"`
-	PeerIPAddr      string `json:"peer_ipaddr,omitempty"`
-	PeerGatewayIP   string `json:"peer_gateway_ip,omitempty"`
-	VirtualIP       string `json:"virtual_ip,omitempty"`
-	Tag             string `json:"tag,omitempty"`
+	ParentLogicalInterface string `json:"parent_logical_interface"`
+	VlanID                 string `json:"vlan_id"`
+	IPAddr                 string `json:"ipaddr"`
+	GatewayIP              string `json:"gateway_ip,omitempty"`
+	PeerIPAddr             string `json:"peer_ipaddr,omitempty"`
+	PeerGatewayIP          string `json:"peer_gateway_ip,omitempty"`
+	VirtualIP              string `json:"virtual_ip,omitempty"`
+	Tag                    string `json:"tag,omitempty"`
 }
 
 type EdgeMegaportResp struct {

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -230,25 +230,26 @@ type Gateway struct {
 }
 
 type HaGateway struct {
-	GwName              string                 `json:"vpc_name"`
-	CloudType           int                    `json:"cloud_type"`
-	GwSize              string                 `json:"vpc_size"`
-	VpcNet              string                 `json:"public_subnet"`
-	PublicIP            string                 `json:"public_ip"`
-	PrivateIP           string                 `json:"private_ip"`
-	ReuseEip            string                 `json:"reuse_eip,omitempty"`
-	CloudnGatewayInstID string                 `json:"cloudn_gateway_inst_id"`
-	GatewayZone         string                 `json:"gateway_zone"`
-	InsaneMode          string                 `json:"high_perf"`
-	EnablePrivateOob    bool                   `json:"private_oob"`
-	OobManagementSubnet string                 `json:"oob_mgmt_subnet"`
-	GwSecurityGroupID   string                 `json:"gw_security_group_id"`
-	FaultDomain         string                 `json:"fault_domain"`
-	ImageVersion        string                 `json:"gw_image_name"`
-	SoftwareVersion     string                 `json:"gw_software_version"`
-	HaBgpLanInterfaces  []BundleVpcLanInfo     `json:"gce_ha_bgp_lan_info,omitempty"`
-	DeviceID            string                 `json:"edge_csp_device_id,omitempty"`
-	Interfaces          []EdgeTransitInterface `json:"interfaces,omitempty"`
+	GwName                   string                 `json:"vpc_name"`
+	CloudType                int                    `json:"cloud_type"`
+	GwSize                   string                 `json:"vpc_size"`
+	VpcNet                   string                 `json:"public_subnet"`
+	PublicIP                 string                 `json:"public_ip"`
+	PrivateIP                string                 `json:"private_ip"`
+	ReuseEip                 string                 `json:"reuse_eip,omitempty"`
+	CloudnGatewayInstID      string                 `json:"cloudn_gateway_inst_id"`
+	GatewayZone              string                 `json:"gateway_zone"`
+	InsaneMode               string                 `json:"high_perf"`
+	EnablePrivateOob         bool                   `json:"private_oob"`
+	OobManagementSubnet      string                 `json:"oob_mgmt_subnet"`
+	GwSecurityGroupID        string                 `json:"gw_security_group_id"`
+	FaultDomain              string                 `json:"fault_domain"`
+	ImageVersion             string                 `json:"gw_image_name"`
+	SoftwareVersion          string                 `json:"gw_software_version"`
+	HaBgpLanInterfaces       []BundleVpcLanInfo     `json:"gce_ha_bgp_lan_info,omitempty"`
+	DeviceID                 string                 `json:"edge_csp_device_id,omitempty"`
+	Interfaces               []EdgeTransitInterface `json:"interfaces,omitempty"`
+	ManagementEgressIPPrefix string                 `json:"mgmt_egress_ip,omitempty"`
 }
 
 type BackupLinkInfo struct {

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -226,6 +226,7 @@ type Gateway struct {
 	BackupLinkInfo                  map[string]BackupLinkInfo           `json:"backup_link_info,omitempty"`
 	EipMap                          map[string][]EipMap                 `json:"eip_map,omitempty"`
 	IfNamesTranslation              map[string]string                   `json:"ifnames_translation,omitempty"`
+	ManagementEgressIPPrefix        string                              `json:"mgmt_egress_ip,omitempty"`
 }
 
 type HaGateway struct {

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -225,6 +225,7 @@ type Gateway struct {
 	InterfaceMapping                []InterfaceMapping                  `json:"interface_mapping,omitempty"`
 	BackupLinkInfo                  map[string]BackupLinkInfo           `json:"backup_link_info,omitempty"`
 	EipMap                          map[string][]EipMap                 `json:"eip_map,omitempty"`
+	LogicalEipMap                   map[string][]EipMap                 `json:"logical_intf_eip_map,omitempty"`
 	IfNamesTranslation              map[string]string                   `json:"ifnames_translation,omitempty"`
 	ManagementEgressIPPrefix        string                              `json:"mgmt_egress_ip,omitempty"`
 }

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -252,9 +252,11 @@ type HaGateway struct {
 }
 
 type BackupLinkInfo struct {
-	ConnectionTypePublic bool   `json:"connection_type_public,omitempty"`
-	PeerIntfName         string `json:"peer_intf_name,omitempty"`
-	SelfIntfName         string `json:"self_intf_name,omitempty"`
+	ConnectionTypePublic bool     `json:"connection_type_public,omitempty"`
+	PeerIntfName         string   `json:"peer_intf_name,omitempty"`
+	SelfIntfName         string   `json:"self_intf_name,omitempty"`
+	PeerLogicalIntfName  []string `json:"peer_backup_logical_ifnames,omitempty"`
+	SelfLogicalIntfName  []string `json:"self_backup_logical_ifnames,omitempty"`
 }
 
 type PolicyRule struct {

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -36,8 +36,8 @@ type TransitHaGateway struct {
 
 type BackupLinkInterface struct {
 	PeerGwName               string   `json:"peer_gw_name"`
-	PeerBackupPort           string   `json:"peer_backup_port"`
-	SelfBackupPort           string   `json:"self_backup_port"`
+	PeerBackupPort           string   `json:"peer_backup_port,omitempty"`
+	SelfBackupPort           string   `json:"self_backup_port,omitempty"`
 	ConnectionType           string   `json:"connection_type"`
 	PeerBackupLogicalIfNames []string `json:"peer_backup_logical_ifnames,omitempty"`
 	SelfBackupLogicalIfNames []string `json:"self_backup_logical_ifnames,omitempty"`
@@ -52,7 +52,7 @@ func (c *Client) CreateTransitHaGw(transitHaGateway *TransitHaGateway) (string, 
 		return "", err
 	}
 	// create the ZTP file for Equinix Edge transit gateway
-	if transitHaGateway.CloudType == EDGEEQUINIX {
+	if transitHaGateway.CloudType == EDGEEQUINIX || transitHaGateway.CloudType == EDGEMEGAPORT {
 		fileName := getFileName(transitHaGateway.ZtpFileDownloadPath, transitHaGateway.GwName, transitHaGateway.VpcID)
 		err = createZtpFile(fileName, data.Result)
 		if err != nil {

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -5,33 +5,34 @@ import (
 )
 
 type TransitHaGateway struct {
-	Action                string `json:"action"`
-	CID                   string `json:"CID"`
-	AccountName           string `json:"account_name"`
-	CloudType             int    `json:"cloud_type"`
-	VpcID                 string `json:"vpc_id,omitempty"`
-	VNetNameResourceGroup string `json:"vnet_and_resource_group_names"`
-	PrimaryGwName         string `json:"primary_gw_name"`
-	GwName                string `json:"ha_gw_name"`
-	GwSize                string `json:"gw_size"`
-	Subnet                string `json:"gw_subnet"`
-	VpcRegion             string `json:"region"`
-	Zone                  string `json:"zone"`
-	AvailabilityDomain    string `json:"availability_domain"`
-	FaultDomain           string `json:"fault_domain"`
-	BgpLanVpcId           string `json:"bgp_lan_vpc"`
-	BgpLanSubnet          string `json:"bgp_lan_specify_subnet"`
-	Eip                   string `json:"eip,omitempty"`
-	InsaneMode            string `json:"insane_mode"`
-	TagList               string `json:"tag_string"`
-	TagJson               string `json:"tag_json"`
-	AutoGenHaGwName       string `json:"autogen_hagw_name"`
-	BackupLinkList        []BackupLinkInterface
-	BackupLinkConfig      string `json:"backup_link_config,omitempty"`
-	InterfaceMapping      string `json:"interface_mapping,omitempty"`
-	Interfaces            string `json:"interfaces,omitempty"`
-	DeviceID              string `json:"device_id,omitempty"`
-	ZtpFileDownloadPath   string `json:"-"`
+	Action                   string `json:"action"`
+	CID                      string `json:"CID"`
+	AccountName              string `json:"account_name"`
+	CloudType                int    `json:"cloud_type"`
+	VpcID                    string `json:"vpc_id,omitempty"`
+	VNetNameResourceGroup    string `json:"vnet_and_resource_group_names"`
+	PrimaryGwName            string `json:"primary_gw_name"`
+	GwName                   string `json:"ha_gw_name"`
+	GwSize                   string `json:"gw_size"`
+	Subnet                   string `json:"gw_subnet"`
+	VpcRegion                string `json:"region"`
+	Zone                     string `json:"zone"`
+	AvailabilityDomain       string `json:"availability_domain"`
+	FaultDomain              string `json:"fault_domain"`
+	BgpLanVpcID              string `json:"bgp_lan_vpc"`
+	BgpLanSubnet             string `json:"bgp_lan_specify_subnet"`
+	Eip                      string `json:"eip,omitempty"`
+	InsaneMode               string `json:"insane_mode"`
+	TagList                  string `json:"tag_string"`
+	TagJSON                  string `json:"tag_json"`
+	AutoGenHaGwName          string `json:"autogen_hagw_name"`
+	BackupLinkList           []BackupLinkInterface
+	BackupLinkConfig         string `json:"backup_link_config,omitempty"`
+	InterfaceMapping         string `json:"interface_mapping,omitempty"`
+	Interfaces               string `json:"interfaces,omitempty"`
+	DeviceID                 string `json:"device_id,omitempty"`
+	ZtpFileDownloadPath      string `json:"-"`
+	ManagementEgressIPPrefix string `json:"mgmt_egress_ip,omitempty"`
 }
 
 type BackupLinkInterface struct {

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -35,10 +35,12 @@ type TransitHaGateway struct {
 }
 
 type BackupLinkInterface struct {
-	PeerGwName     string `json:"peer_gw_name"`
-	PeerBackupPort string `json:"peer_backup_port"`
-	SelfBackupPort string `json:"self_backup_port"`
-	ConnectionType string `json:"connection_type"`
+	PeerGwName               string   `json:"peer_gw_name"`
+	PeerBackupPort           string   `json:"peer_backup_port"`
+	SelfBackupPort           string   `json:"self_backup_port"`
+	ConnectionType           string   `json:"connection_type"`
+	PeerBackupLogicalIfNames []string `json:"peer_backup_logical_ifnames,omitempty"`
+	SelfBackupLogicalIfNames []string `json:"self_backup_logical_ifnames,omitempty"`
 }
 
 func (c *Client) CreateTransitHaGw(transitHaGateway *TransitHaGateway) (string, error) {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -184,8 +184,8 @@ func (c *Client) LaunchTransitVpc(gateway *TransitVpc) error {
 	if err != nil {
 		return err
 	}
-	// create the ZTP file for Equinix edge transit gateway
-	if gateway.CloudType == EDGEEQUINIX {
+	// create the ZTP file for Equinix and Megaport edge transit gateway
+	if gateway.CloudType == EDGEEQUINIX || gateway.CloudType == EDGEMEGAPORT {
 		fileName := getFileName(gateway.ZtpFileDownloadPath, gateway.GwName, gateway.VpcID)
 		fileContent, err := processZtpFileContent(data.Result)
 		if err != nil {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -67,6 +67,7 @@ type TransitVpc struct {
 	Interfaces                   string   `json:"interfaces,omitempty"`
 	InterfaceMapping             string   `json:"interface_mapping,omitempty"`
 	EipMap                       string   `json:"eip_map,omitempty"`
+	LogicalEipMap                string   `json:"logical_intf_eip_map,omitempty"`
 	ZtpFileDownloadPath          string   `json:"-"`
 }
 
@@ -146,6 +147,7 @@ type EdgeTransitInterface struct {
 	IpAddress      string   `json:"ipaddr,omitempty"`
 	GatewayIp      string   `json:"gateway_ip,omitempty"`
 	SecondaryCIDRs []string `json:"secondary_private_cidr_list,omitempty"`
+	LogicalIfName  string   `json:"logical_ifname,omitempty"`
 }
 
 type EipMap struct {
@@ -264,6 +266,10 @@ func (c *Client) UpdateEdgeGateway(gateway *TransitVpc) error {
 
 	if gateway.EipMap != "" {
 		form["eip_map"] = gateway.EipMap
+	}
+
+	if gateway.LogicalEipMap != "" {
+		form["logical_intf_eip_map"] = gateway.LogicalEipMap
 	}
 	return c.PostAPI(form["action"], form, BasicCheck)
 }

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -69,6 +69,7 @@ type TransitVpc struct {
 	EipMap                       string   `json:"eip_map,omitempty"`
 	LogicalEipMap                string   `json:"logical_intf_eip_map,omitempty"`
 	ZtpFileDownloadPath          string   `json:"-"`
+	ManagementEgressIpPrefix     string   `json:"mgmt_egress_ip,omitempty"`
 }
 
 type TransitGatewayAdvancedConfig struct {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -69,7 +69,7 @@ type TransitVpc struct {
 	EipMap                       string   `json:"eip_map,omitempty"`
 	LogicalEipMap                string   `json:"logical_intf_eip_map,omitempty"`
 	ZtpFileDownloadPath          string   `json:"-"`
-	ManagementEgressIpPrefix     string   `json:"mgmt_egress_ip,omitempty"`
+	ManagementEgressIPPrefix     string   `json:"mgmt_egress_ip,omitempty"`
 }
 
 type TransitGatewayAdvancedConfig struct {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -1,8 +1,10 @@
 package goaviatrix
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -50,26 +52,26 @@ type TransitVpc struct {
 	OobManagementSubnet          string `form:"oob_mgmt_subnet,omitempty"`
 	HAOobManagementSubnet        string
 	EnableSummarizeCidrToTgw     bool
-	AvailabilityDomain           string   `form:"availability_domain,omitempty"`
-	FaultDomain                  string   `form:"fault_domain,omitempty"`
-	EnableSpotInstance           bool     `form:"spot_instance,omitempty"`
-	SpotPrice                    string   `form:"spot_price,omitempty"`
-	DeleteSpot                   bool     `form:"delete_spot,omitempty"`
-	ApprovedLearnedCidrs         []string `form:"approved_learned_cidrs"`
-	BgpLanVpcID                  string   `form:"bgp_lan_vpc"`
-	BgpLanSpecifySubnet          string   `form:"bgp_lan_subnet"`
-	Async                        bool     `form:"async,omitempty"`
-	BgpLanInterfacesCount        int      `form:"bgp_lan_intf_count,omitempty"`
-	LbVpcId                      string   `form:"lb_vpc_id,omitempty"`
-	Transit                      bool     `form:"transit,omitempty"`
-	DeviceID                     string   `form:"device_id,omitempty"`
-	SiteID                       string   `form:"site_id,omitempty"`
-	Interfaces                   string   `json:"interfaces,omitempty"`
-	InterfaceMapping             string   `json:"interface_mapping,omitempty"`
-	EipMap                       string   `json:"eip_map,omitempty"`
-	LogicalEipMap                string   `json:"logical_intf_eip_map,omitempty"`
-	ZtpFileDownloadPath          string   `json:"-"`
-	ManagementEgressIPPrefix     string   `json:"mgmt_egress_ip,omitempty"`
+	AvailabilityDomain           string              `form:"availability_domain,omitempty"`
+	FaultDomain                  string              `form:"fault_domain,omitempty"`
+	EnableSpotInstance           bool                `form:"spot_instance,omitempty"`
+	SpotPrice                    string              `form:"spot_price,omitempty"`
+	DeleteSpot                   bool                `form:"delete_spot,omitempty"`
+	ApprovedLearnedCidrs         []string            `form:"approved_learned_cidrs"`
+	BgpLanVpcID                  string              `form:"bgp_lan_vpc"`
+	BgpLanSpecifySubnet          string              `form:"bgp_lan_subnet"`
+	Async                        bool                `form:"async,omitempty"`
+	BgpLanInterfacesCount        int                 `form:"bgp_lan_intf_count,omitempty"`
+	LbVpcID                      string              `form:"lb_vpc_id,omitempty"`
+	Transit                      bool                `form:"transit,omitempty"`
+	DeviceID                     string              `form:"device_id,omitempty"`
+	SiteID                       string              `form:"site_id,omitempty"`
+	Interfaces                   string              `json:"interfaces,omitempty"`
+	InterfaceMapping             string              `json:"interface_mapping,omitempty"`
+	EipMap                       string              `json:"eip_map,omitempty"`
+	LogicalEipMap                map[string][]EipMap `json:"logical_intf_eip_map,omitempty"`
+	ZtpFileDownloadPath          string              `json:"-"`
+	ManagementEgressIPPrefix     string              `json:"mgmt_egress_ip,omitempty"`
 }
 
 type TransitGatewayAdvancedConfig struct {
@@ -255,7 +257,7 @@ func (c *Client) AttachTransitGWForHybrid(gateway *TransitVpc) error {
 }
 
 func (c *Client) UpdateEdgeGateway(gateway *TransitVpc) error {
-	form := map[string]string{
+	form := map[string]interface{}{
 		"CID":          c.CID,
 		"action":       "update_edge_gateway",
 		"gateway_name": gateway.GwName,
@@ -269,14 +271,25 @@ func (c *Client) UpdateEdgeGateway(gateway *TransitVpc) error {
 		form["eip_map"] = gateway.EipMap
 	}
 
-	if gateway.LogicalEipMap != "" {
-		form["logical_intf_eip_map"] = gateway.LogicalEipMap
+	if len(gateway.LogicalEipMap) > 0 {
+		eipMapJSON, err := json.Marshal(gateway.LogicalEipMap)
+		if err != nil {
+			return fmt.Errorf("failed to marshal eip_map to JSON: %w", err)
+		}
+		eipMapJSONObj := bytes.NewBuffer(eipMapJSON)
+		form["logical_intf_eip_map"] = eipMapJSONObj
 	}
 
 	if gateway.ManagementEgressIPPrefix != "" {
 		form["mgmt_egress_ip"] = gateway.ManagementEgressIPPrefix
 	}
-	return c.PostAPI(form["action"], form, BasicCheck)
+
+	action, ok := form["action"].(string)
+	if !ok {
+		return fmt.Errorf("form[action] is not a string, got type %T", form["action"])
+	}
+	log.Printf("Formm details: %v", form)
+	return c.PostAPI(action, form, BasicCheck)
 }
 
 func (c *Client) DeleteEdgeGateway(gateway *Gateway) error {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -272,6 +272,10 @@ func (c *Client) UpdateEdgeGateway(gateway *TransitVpc) error {
 	if gateway.LogicalEipMap != "" {
 		form["logical_intf_eip_map"] = gateway.LogicalEipMap
 	}
+
+	if gateway.ManagementEgressIPPrefix != "" {
+		form["mgmt_egress_ip"] = gateway.ManagementEgressIPPrefix
+	}
 	return c.PostAPI(form["action"], form, BasicCheck)
 }
 


### PR DESCRIPTION
Backport for https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2144
Adding the Transit and HA gateway logic to support Megaport cloud type.
The following fields have been updated

- interfaces
- ha_interfaces
- eip_map
- backup_link_info
- mgmt_egress_ip_prefix