### PR TITLE
AVX-58676 Adding support for Megaport peerings and attachments

### DIFF
--- a/aviatrix/resource_aviatrix_account.go
+++ b/aviatrix/resource_aviatrix_account.go
@@ -711,10 +711,10 @@ func resourceAviatrixAccountCreate(ctx context.Context, d *schema.ResourceData, 
 			return diag.Errorf("edge_csp_username and edge_csp_password are required to create an Aviatrix account for Edge CSP, " +
 				"edge_zededa_username and edge_zededa_password are required to create an Aviatrix account for Edge Zededa")
 		}
-	} else if account.CloudType == goaviatrix.EDGEEQUINIX || account.CloudType == goaviatrix.EDGENEO || account.CloudType == goaviatrix.EDGEMEGAPORT {
-		log.Printf("no check is needed to create an Aviatrix account for Edge Equinix and Edge NEO")
+	} else if goaviatrix.IsCloudType(account.CloudType, goaviatrix.EdgeRelatedCloudTypes) {
+		log.Printf("no check is needed to create an Aviatrix account for Edge Equinix, Edge NEO and Edge Megaport")
 	} else {
-		return diag.Errorf("cloud type can only be either AWS (1), GCP (4), Azure (8), OCI (16), AzureGov (32), AWSGov (256), AWSChina (1024), AzureChina (2048), Alibaba Cloud (8192), AWS Top Secret (16384), AWS Secret (32768), Edge CSP/Zededa (65536), Edge Equinix (524288) or Edge NEO/Platform (262144)")
+		return diag.Errorf("cloud type can only be either AWS (1), GCP (4), Azure (8), OCI (16), AzureGov (32), AWSGov (256), AWSChina (1024), AzureChina (2048), Alibaba Cloud (8192), AWS Top Secret (16384), AWS Secret (32768), Edge CSP/Zededa (65536), Edge Equinix (524288), Edge Megaport(1048576) or Edge NEO/Platform (262144)")
 	}
 
 	var err error

--- a/aviatrix/resource_aviatrix_account.go
+++ b/aviatrix/resource_aviatrix_account.go
@@ -712,7 +712,7 @@ func resourceAviatrixAccountCreate(ctx context.Context, d *schema.ResourceData, 
 				"edge_zededa_username and edge_zededa_password are required to create an Aviatrix account for Edge Zededa")
 		}
 	} else if goaviatrix.IsCloudType(account.CloudType, goaviatrix.EdgeRelatedCloudTypes) {
-		log.Printf("no check is needed to create an Aviatrix account for Edge Equinix, Edge NEO and Edge Megaport")
+		log.Print("no check is needed to create an Aviatrix account for Edge Equinix, Edge NEO and Edge Megaport")
 	} else {
 		return diag.Errorf("cloud type can only be either AWS (1), GCP (4), Azure (8), OCI (16), AzureGov (32), AWSGov (256), AWSChina (1024), AzureChina (2048), Alibaba Cloud (8192), AWS Top Secret (16384), AWS Secret (32768), Edge CSP/Zededa (65536), Edge Equinix (524288), Edge Megaport(1048576) or Edge NEO/Platform (262144)")
 	}

--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
@@ -328,7 +328,11 @@ func resourceAviatrixEdgeSpokeTransitAttachmentRead(ctx context.Context, d *sche
 
 	if goaviatrix.IsCloudType(transitGateway.CloudType, goaviatrix.EdgeRelatedCloudTypes) {
 		if len(attachment.TransitGatewayLogicalIfNames) > 0 {
-			_ = d.Set("transit_gateway_logical_ifnames", attachment.TransitGatewayLogicalIfNames)
+			logicalIfNames, err := getLogicalIfNames(transitGateway, attachment.TransitGatewayLogicalIfNames)
+			if err != nil {
+				return diag.Errorf("could not get logical interface names for edge transit gateway %s: %v", transitGwName, err)
+			}
+			_ = d.Set("transit_gateway_logical_ifnames", logicalIfNames)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
@@ -184,7 +184,7 @@ func resourceAviatrixEdgeSpokeTransitAttachmentCreate(ctx context.Context, d *sc
 	retryInterval := d.Get("retry_interval").(int)
 
 	for i := 0; ; i++ {
-		err := client.CreateSpokeTransitAttachment(context.Background(), attachment)
+		err := client.CreateSpokeTransitAttachment(ctx, attachment)
 		if err != nil {
 			if !strings.Contains(err.Error(), "not ready") && !strings.Contains(err.Error(), "not up") &&
 				!strings.Contains(err.Error(), "try again") {

--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment_test.go
@@ -117,7 +117,7 @@ resource "aviatrix_transit_gateway" "test_edge_transit" {
 	interfaces {
         gateway_ip     = "192.168.20.1"
         ip_address     = "192.168.20.11/24"
-		public_ip      = "67.207.104.19"
+        public_ip      = "67.207.104.19"
         logical_ifname = "wan0"
         secondary_private_cidr_list = ["192.168.20.16/29"]
     }
@@ -125,7 +125,7 @@ resource "aviatrix_transit_gateway" "test_edge_transit" {
     interfaces {
         gateway_ip     = "192.168.21.1"
         ip_address     = "192.168.21.11/24"
-		public_ip      = "67.71.12.148"
+        public_ip      = "67.71.12.148"
         logical_ifname = "wan1"
         secondary_private_cidr_list = ["192.168.21.16/29"]
     }

--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment_test.go
@@ -16,6 +16,14 @@ func TestAccAviatrixEdgeSpokeTransitAttachment_basic(t *testing.T) {
 	rName := acctest.RandString(5)
 	resourceName := "aviatrix_edge_spoke_transit_attachment.test"
 
+	accountName := "megaport-" + rName
+	spokeGwName := "spoke-" + rName
+	spokeSiteID := "site-" + rName
+	path, _ := os.Getwd()
+	transitGwName := "transit-" + rName
+	transitSiteID := "site-" + rName
+	resourceNameEdge := "aviatrix_edge_spoke_transit_attachment.test_edge_spoke_transit_attachment"
+
 	skipAcc := os.Getenv("SKIP_EDGE_SPOKE_TRANSIT_ATTACHMENT")
 	if skipAcc == "yes" {
 		t.Skip("Skipping Edge as a Spoke transit attachment tests as 'SKIP_EDGE_SPOKE_TRANSIT_ATTACHMENT' is set")
@@ -41,6 +49,19 @@ func TestAccAviatrixEdgeSpokeTransitAttachment_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEdgeSpokeTransitAttachmentConfigEdge(accountName, spokeGwName, spokeSiteID, path, transitGwName, transitSiteID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeSpokeTransitAttachmentExists(resourceNameEdge),
+					resource.TestCheckResourceAttr(resourceNameEdge, "spoke_gw_name", spokeGwName),
+					resource.TestCheckResourceAttr(resourceNameEdge, "transit_gw_name", transitGwName),
+					resource.TestCheckResourceAttr(resourceNameEdge, "enable_over_private_network", "true"),
+					resource.TestCheckResourceAttr(resourceNameEdge, "enable_jumbo_frame", "false"),
+					resource.TestCheckResourceAttr(resourceNameEdge, "enable_insane_mode", "true"),
+					resource.TestCheckResourceAttr(resourceNameEdge, "spoke_gateway_logical_ifnames.0", "wan1"),
+					resource.TestCheckResourceAttr(resourceNameEdge, "transit_gateway_logical_ifnames.0", "wan1"),
+				),
 			},
 		},
 	})
@@ -78,6 +99,110 @@ resource "aviatrix_edge_spoke_transit_attachment" "test" {
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		rName, os.Getenv("AWS_VPC_ID"), os.Getenv("AWS_REGION"), os.Getenv("AWS_SUBNET"),
 		os.Getenv("EDGE_SPOKE_NAME"))
+}
+
+func testAccEdgeSpokeTransitAttachmentConfigEdge(accountName, spokeGwName, spokeSiteID, path, transitGwName, transitSiteID string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_edge_megaport" {
+	account_name       = "edge-%s"
+	cloud_type         = 1048576
+}
+resource "aviatrix_transit_gateway" "test_edge_transit" {
+	cloud_type   = 1048576
+	account_name = aviatrix_account.test_acc_edge_megaport.account_name
+	gw_name      = "%s"
+	vpc_id       = "%s"
+	gw_size      = "SMALL"
+	ztp_file_download_path = "%s"
+	interfaces {
+        gateway_ip     = "192.168.20.1"
+        ip_address     = "192.168.20.11/24"
+		public_ip      = "67.207.104.19"
+        logical_ifname = "wan0"
+        secondary_private_cidr_list = ["192.168.20.16/29"]
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.21.1"
+        ip_address     = "192.168.21.11/24"
+		public_ip      = "67.71.12.148"
+        logical_ifname = "wan1"
+        secondary_private_cidr_list = ["192.168.21.16/29"]
+    }
+
+    interfaces {
+        dhcp           = true
+        logical_ifname = "mgmt0"
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.22.1"
+        ip_address     = "192.168.22.11/24"
+        logical_ifname = "wan2"
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.23.1"
+        ip_address     = "192.168.23.11/24"
+        logical_ifname = "wan3"
+    }
+}
+
+resource "aviatrix_edge_megaport" "test_edge_spoke" {
+	account_name                       = aviatrix_account.test_acc_edge_megaport.account_name
+	gw_name                            = "%s"
+	site_id                            = "%s"
+	ztp_file_download_path             = "%s"
+
+	interfaces {
+		gateway_ip     = "10.220.14.1"
+		ip_address     = "10.220.14.10/24"
+		logical_ifname = "lan0"
+	}
+
+	interfaces {
+		gateway_ip     = "192.168.99.1"
+		ip_address     = "192.168.99.14/24"
+		logical_ifname = "wan0"
+		wan_public_ip  = "67.207.104.19"
+	}
+
+	interfaces {
+		gateway_ip     = "192.168.88.1"
+		ip_address     = "192.168.88.14/24"
+		logical_ifname = "wan1"
+		wan_public_ip  = "67.71.12.148"
+	}
+
+	interfaces {
+		gateway_ip     = "192.168.77.1"
+		ip_address     = "192.168.77.14/24"
+		logical_ifname = "wan2"
+		wan_public_ip  = "67.72.12.149"
+	}
+
+	interfaces {
+		enable_dhcp   = true
+		logical_ifname = "mgmt0"
+	}
+
+	vlan {
+		parent_logical_interface_name = "lan0"
+		vlan_id                        = 21
+		ip_address                     = "10.220.21.11/24"
+	}
+}
+
+resource "aviatrix_edge_spoke_transit_attachment" "test_edge_spoke_transit_attachment" {
+	spoke_gw_name   = "aviatrix_edge_megaport.test_edge_spoke.gw_name"
+	transit_gw_name = "aviatrix_transit_gateway.test_edge_transit.gw_name"
+	enable_over_private_network = true
+	enable_jumbo_frame = false
+	enable_insane_mode = true
+	spoke_gateway_logical_ifnames = ["wan1"]
+	transit_gateway_logical_ifnames = ["wan1"]
+  }
+	`, accountName, spokeGwName, spokeSiteID, path, transitGwName, transitSiteID, path)
 }
 
 func testAccCheckEdgeSpokeTransitAttachmentExists(resourceName string) resource.TestCheckFunc {

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -248,7 +248,11 @@ func resourceAviatrixSpokeTransitAttachmentRead(d *schema.ResourceData, meta int
 
 	if goaviatrix.IsCloudType(transitGateway.CloudType, goaviatrix.EdgeRelatedCloudTypes) {
 		if len(attachment.TransitGatewayLogicalIfNames) > 0 {
-			_ = d.Set("transit_gateway_logical_ifnames", attachment.TransitGatewayLogicalIfNames)
+			logicalIfNames, err := getLogicalIfNames(transitGateway, attachment.TransitGatewayLogicalIfNames)
+			if err != nil {
+				return fmt.Errorf("could not get logical interface names for edge transit gateway %s: %w", transitGwName, err)
+			}
+			_ = d.Set("transit_gateway_logical_ifnames", logicalIfNames)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -128,10 +128,13 @@ func resourceAviatrixSpokeTransitAttachmentCreate(d *schema.ResourceData, meta i
 	flag := false
 	defer resourceAviatrixSpokeTransitAttachmentReadIfRequired(d, meta, &flag)
 
+	timeout := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	try, maxTries, backoff := 0, 10, 1000*time.Millisecond
 	for {
 		try++
-		err := client.CreateSpokeTransitAttachment(context.Background(), attachment)
+		err := client.CreateSpokeTransitAttachment(ctx, attachment)
 		if err != nil {
 			if strings.Contains(err.Error(), "is not up") || strings.Contains(err.Error(), "is not ready") {
 				if try == maxTries {

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -1,6 +1,7 @@
 package aviatrix
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -117,7 +118,7 @@ func resourceAviatrixSpokeTransitAttachmentCreate(d *schema.ResourceData, meta i
 	try, maxTries, backoff := 0, 10, 1000*time.Millisecond
 	for {
 		try++
-		err := client.CreateSpokeTransitAttachment(attachment)
+		err := client.CreateSpokeTransitAttachment(context.Background(), attachment)
 		if err != nil {
 			if strings.Contains(err.Error(), "is not up") || strings.Contains(err.Error(), "is not ready") {
 				if try == maxTries {

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
@@ -161,7 +161,7 @@ resource "aviatrix_transit_gateway" "test_edge_transit" {
 	interfaces {
         gateway_ip     = "192.168.20.1"
         ip_address     = "192.168.20.11/24"
-		public_ip      = "67.207.104.19"
+        public_ip      = "67.207.104.19"
         logical_ifname = "wan0"
         secondary_private_cidr_list = ["192.168.20.16/29"]
     }
@@ -169,7 +169,7 @@ resource "aviatrix_transit_gateway" "test_edge_transit" {
     interfaces {
         gateway_ip     = "192.168.21.1"
         ip_address     = "192.168.21.11/24"
-		public_ip      = "67.71.12.148"
+        public_ip      = "67.71.12.148"
         logical_ifname = "wan1"
         secondary_private_cidr_list = ["192.168.21.16/29"]
     }

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
@@ -3,6 +3,7 @@ package aviatrix
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
@@ -115,91 +116,25 @@ resource "aviatrix_spoke_transit_attachment" "test" {
 }
 
 func testAccSpokeTransitAttachmentConfigEdge(accountName, spokeGwName, path, transitGwName, transitSiteID string) string {
-	return fmt.Sprintf(`
-resource "aviatrix_account" "test_aws" {
-	cloud_type         = 1
-	account_name       = "aws-%s"
-	aws_account_number = "%s"
-	aws_iam            = false
-	aws_access_key     = "%s"
-	aws_secret_key     = "%s"
-}
+	filePath := filepath.Join("testdata", "testAccEdgeSpokeTransitAttachmentConfigEdge.tf")
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return ""
+	}
 
-resource "aviatrix_account" "test_acc_edge_megaport" {
-	account_name       = "megaport-%s"
-	cloud_type         = 1048576
-}
-
-resource "aviatrix_vpc" "test_vpc" {
-	cloud_type           = 1
-	account_name         = aviatrix_account.test_aws.account_name
-	region               = "us-west-1"
-	name                 = "aws-vpc-test-1"
-	cidr                 = "16.0.0.0/20"
-	aviatrix_transit_vpc = true
-}
-
-resource "aviatrix_spoke_gateway" "test_spoke" {
-	cloud_type     = 1
-	account_name   = aviatrix_account.test.account_name
-	gw_name        = "tfs-%s"
-	vpc_id         = aviatrix_vpc.test_vpc.vpc_id
-	vpc_reg        = aviatrix_vpc.test_vpc.region
-	gw_size        = "c5.xlarge"
-	insane_mode    = true
-	subnet         = join(".", [join(".", slice(split(".", aviatrix_vpc.test1.public_subnets[1].cidr), 0, 2)), "12.0/26"]) #"173.31.12.0/26"
-	insane_mode_az = "us-east-1a"
-}
-
-resource "aviatrix_transit_gateway" "test_edge_transit" {
-	cloud_type   = 1048576
-	account_name = aviatrix_account.test_acc_edge_megaport.account_name
-	gw_name      = "%s"
-	vpc_id       = "%s"
-	gw_size      = "SMALL"
-	ztp_file_download_path = "%s"
-	interfaces {
-        gateway_ip     = "192.168.20.1"
-        ip_address     = "192.168.20.11/24"
-        public_ip      = "67.207.104.19"
-        logical_ifname = "wan0"
-        secondary_private_cidr_list = ["192.168.20.16/29"]
-    }
-
-    interfaces {
-        gateway_ip     = "192.168.21.1"
-        ip_address     = "192.168.21.11/24"
-        public_ip      = "67.71.12.148"
-        logical_ifname = "wan1"
-        secondary_private_cidr_list = ["192.168.21.16/29"]
-    }
-
-    interfaces {
-        dhcp           = true
-        logical_ifname = "mgmt0"
-    }
-
-    interfaces {
-        gateway_ip     = "192.168.22.1"
-        ip_address     = "192.168.22.11/24"
-        logical_ifname = "wan2"
-    }
-
-    interfaces {
-        gateway_ip     = "192.168.23.1"
-        ip_address     = "192.168.23.11/24"
-        logical_ifname = "wan3"
-    }
-}
-
-resource "aviatrix_spoke_transit_attachment" "test" {
-	spoke_gw_name   = aviatrix_spoke_gateway.test_spoke.gw_name
-	transit_gw_name = aviatrix_transit_gateway.test_edge_transit.gw_name
-	tunnel_count    = 4
-	transit_gateway_logical_ifnames = ["wan1"]
-
-}
-	`, accountName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"), accountName, spokeGwName, transitGwName, transitSiteID, path)
+	tfConfig := string(content)
+	// Replace placeholders with actual values
+	return fmt.Sprintf(tfConfig,
+		accountName,
+		os.Getenv("AWS_ACCOUNT_NUMBER"),
+		os.Getenv("AWS_ACCESS_KEY"),
+		os.Getenv("AWS_SECRET_KEY"),
+		accountName,
+		spokeGwName,
+		transitGwName,
+		transitSiteID,
+		path,
+	)
 }
 
 func testAccCheckSpokeTransitAttachmentExists(n string, spokeTransitAttachment *goaviatrix.SpokeTransitAttachment) resource.TestCheckFunc {

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
@@ -116,7 +116,7 @@ resource "aviatrix_spoke_transit_attachment" "test" {
 }
 
 func testAccSpokeTransitAttachmentConfigEdge(accountName, spokeGwName, path, transitGwName, transitSiteID string) string {
-	filePath := filepath.Join("testdata", "testAccEdgeSpokeTransitAttachmentConfigEdge.tf")
+	filePath := filepath.Join("test-data", "testAccEdgeSpokeTransitAttachmentConfigEdge.tf")
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return ""

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
@@ -44,6 +44,16 @@ func TestAccAviatrixSpokeTransitAttachment_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccSpokeTransitAttachmentConfigEdge("acc-"+rName, "spoke-"+rName, os.Getenv("PWD"), "transit-"+rName, "site-"+rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpokeTransitAttachmentExists(resourceName, &spokeTransitAttachment),
+					resource.TestCheckResourceAttr(resourceName, "spoke_gw_name", "spoke-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "transit_gw_name", "transit-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_count", "4"),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_logical_ifnames.0", "wan1"),
+				),
+			},
 		},
 	})
 }
@@ -102,6 +112,94 @@ resource "aviatrix_spoke_transit_attachment" "test" {
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		rName, rName)
+}
+
+func testAccSpokeTransitAttachmentConfigEdge(accountName, spokeGwName, path, transitGwName, transitSiteID string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_aws" {
+	cloud_type         = 1
+	account_name       = "aws-%s"
+	aws_account_number = "%s"
+	aws_iam            = false
+	aws_access_key     = "%s"
+	aws_secret_key     = "%s"
+}
+
+resource "aviatrix_account" "test_acc_edge_megaport" {
+	account_name       = "megaport-%s"
+	cloud_type         = 1048576
+}
+
+resource "aviatrix_vpc" "test_vpc" {
+	cloud_type           = 1
+	account_name         = aviatrix_account.test_aws.account_name
+	region               = "us-west-1"
+	name                 = "aws-vpc-test-1"
+	cidr                 = "16.0.0.0/20"
+	aviatrix_transit_vpc = true
+}
+
+resource "aviatrix_spoke_gateway" "test_spoke" {
+	cloud_type     = 1
+	account_name   = aviatrix_account.test.account_name
+	gw_name        = "tfs-%s"
+	vpc_id         = aviatrix_vpc.test_vpc.vpc_id
+	vpc_reg        = aviatrix_vpc.test_vpc.region
+	gw_size        = "c5.xlarge"
+	insane_mode    = true
+	subnet         = join(".", [join(".", slice(split(".", aviatrix_vpc.test1.public_subnets[1].cidr), 0, 2)), "12.0/26"]) #"173.31.12.0/26"
+	insane_mode_az = "us-east-1a"
+}
+
+resource "aviatrix_transit_gateway" "test_edge_transit" {
+	cloud_type   = 1048576
+	account_name = aviatrix_account.test_acc_edge_megaport.account_name
+	gw_name      = "%s"
+	vpc_id       = "%s"
+	gw_size      = "SMALL"
+	ztp_file_download_path = "%s"
+	interfaces {
+        gateway_ip     = "192.168.20.1"
+        ip_address     = "192.168.20.11/24"
+		public_ip      = "67.207.104.19"
+        logical_ifname = "wan0"
+        secondary_private_cidr_list = ["192.168.20.16/29"]
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.21.1"
+        ip_address     = "192.168.21.11/24"
+		public_ip      = "67.71.12.148"
+        logical_ifname = "wan1"
+        secondary_private_cidr_list = ["192.168.21.16/29"]
+    }
+
+    interfaces {
+        dhcp           = true
+        logical_ifname = "mgmt0"
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.22.1"
+        ip_address     = "192.168.22.11/24"
+        logical_ifname = "wan2"
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.23.1"
+        ip_address     = "192.168.23.11/24"
+        logical_ifname = "wan3"
+    }
+}
+
+resource "aviatrix_spoke_transit_attachment" "test" {
+	spoke_gw_name   = aviatrix_spoke_gateway.test_spoke.gw_name
+	transit_gw_name = aviatrix_transit_gateway.test_edge_transit.gw_name
+	tunnel_count    = 4
+	transit_gateway_logical_ifnames = ["wan1"]
+
+}
+	`, accountName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"), accountName, spokeGwName, transitGwName, transitSiteID, path)
 }
 
 func testAccCheckSpokeTransitAttachmentExists(n string, spokeTransitAttachment *goaviatrix.SpokeTransitAttachment) resource.TestCheckFunc {

--- a/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment_test.go
@@ -116,7 +116,8 @@ resource "aviatrix_spoke_transit_attachment" "test" {
 }
 
 func testAccSpokeTransitAttachmentConfigEdge(accountName, spokeGwName, path, transitGwName, transitSiteID string) string {
-	filePath := filepath.Join("test-data", "testAccEdgeSpokeTransitAttachmentConfigEdge.tf")
+	repoRootPath := filepath.Dir(path)
+	filePath := filepath.Join(repoRootPath, "test-data", "testAccEdgeSpokeTransitAttachmentConfigEdge.tf")
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return ""

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -3960,10 +3960,10 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 	// create the transit gateway
 	log.Printf("[INFO] Creating Aviatrix Transit Gateway: %#v", gateway)
 	d.SetId(gateway.GwName)
-	// err = client.LaunchTransitVpc(gateway)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to create Aviatrix Transit Gateway: %w", err)
-	// }
+	err = client.LaunchTransitVpc(gateway)
+	if err != nil {
+		return fmt.Errorf("failed to create Aviatrix Transit Gateway: %w", err)
+	}
 	// create ha transit gateway if ha_interfaces are provided
 	haInterfaces, ok := d.Get("ha_interfaces").([]interface{})
 	if ok && len(haInterfaces) > 0 {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1965,6 +1965,10 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		} else {
 			_ = d.Set("ha_management_egress_ip_prefix_list", strings.Split(gw.HaGw.ManagementEgressIPPrefix, ","))
 		}
+		if err := setGatewayResourceData(d, gw); err != nil {
+			log.Printf("[ERROR] %v", err)
+			return err
+		}
 	} else {
 		d.Set("enable_encrypt_volume", gw.EnableEncryptVolume)
 		d.Set("eip", gw.PublicIP)
@@ -3956,10 +3960,10 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 	// create the transit gateway
 	log.Printf("[INFO] Creating Aviatrix Transit Gateway: %#v", gateway)
 	d.SetId(gateway.GwName)
-	err = client.LaunchTransitVpc(gateway)
-	if err != nil {
-		return fmt.Errorf("failed to create Aviatrix Transit Gateway: %w", err)
-	}
+	// err = client.LaunchTransitVpc(gateway)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to create Aviatrix Transit Gateway: %w", err)
+	// }
 	// create ha transit gateway if ha_interfaces are provided
 	haInterfaces, ok := d.Get("ha_interfaces").([]interface{})
 	if ok && len(haInterfaces) > 0 {
@@ -4546,4 +4550,58 @@ func setEipMapDetails(eipMap map[string][]goaviatrix.EipMap, ifNameTranslation m
 		}
 	}
 	return eipMapList, nil
+}
+
+func setGatewayResourceData(d *schema.ResourceData, gw *goaviatrix.Gateway) error {
+	settings := map[string]interface{}{
+		"eip":                                  gw.PublicIP,
+		"cloud_instance_id":                    gw.CloudnGatewayInstID,
+		"security_group_id":                    gw.GwSecurityGroupID,
+		"single_ip_snat":                       gw.EnableNat == "yes" && gw.SnatMode == "primary",
+		"connected_transit":                    gw.ConnectedTransit == "yes",
+		"bgp_hold_time":                        gw.BgpHoldTime,
+		"bgp_polling_time":                     gw.BgpPollingTime,
+		"bgp_neighbor_status_polling_time":     gw.BgpBfdPollingTime,
+		"image_version":                        gw.ImageVersion,
+		"software_version":                     gw.SoftwareVersion,
+		"local_as_number":                      gw.LocalASNumber,
+		"bgp_ecmp":                             gw.BgpEcmp,
+		"enable_active_standby":                gw.EnableActiveStandby,
+		"enable_active_standby_preemptive":     gw.EnableActiveStandbyPreemptive,
+		"enable_s2c_rx_balancing":              gw.EnableS2CRxBalancing,
+		"enable_transit_summarize_cidr_to_tgw": gw.EnableTransitSummarizeCidrToTgw,
+		"enable_segmentation":                  gw.EnableSegmentation,
+		"learned_cidrs_approval_mode":          gw.LearnedCidrsApprovalMode,
+		"enable_jumbo_frame":                   gw.JumboFrame,
+		"enable_private_oob":                   gw.EnablePrivateOob,
+		"enable_firenet":                       gw.EnableFirenet,
+		"enable_gateway_load_balancer":         gw.EnableGatewayLoadBalancer,
+		"enable_egress_transit_firenet":        gw.EnableEgressTransitFirenet,
+		"enable_preserve_as_path":              gw.EnablePreserveAsPath,
+		"customized_transit_vpc_routes":        gw.CustomizedTransitVpcRoutes,
+		"enable_transit_firenet":               gw.EnableTransitFirenet,
+		"enable_advertise_transit_cidr":        gw.EnableAdvertiseTransitCidr,
+		"enable_learned_cidrs_approval":        gw.EnableLearnedCidrsApproval,
+		"enable_multi_tier_transit":            gw.EnableMultitierTransit,
+		"tunnel_detection_time":                gw.TunnelDetectionTime,
+	}
+
+	for key, value := range settings {
+		if err := d.Set(key, value); err != nil {
+			return fmt.Errorf("failed to set %s: %w", key, err)
+		}
+	}
+
+	var prependAsPath []string
+	for _, p := range strings.Split(gw.PrependASPath, " ") {
+		if p != "" {
+			prependAsPath = append(prependAsPath, p)
+		}
+	}
+
+	if err := d.Set("prepend_as_path", prependAsPath); err != nil {
+		return fmt.Errorf("failed to set prepend_as_path: %w", err)
+	}
+
+	return nil
 }

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -3979,6 +3979,11 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 		}
 	}
 
+	// for AEP EAT gateway, set the eip_map, bgp polling time, bgp neighbor status polling time, local_as_number and prepend_as_path after the transit is created. AEP gateways take ~15 mins to be up and running. Updates to the gateway while is in the process of being created will fail.
+	if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGENEO) {
+		return nil
+	}
+
 	// eip map is updated after the transit is created
 	eipMap, ok := d.Get("eip_map").([]interface{})
 	if !ok {
@@ -4009,6 +4014,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 	}
 
 	if val, ok := d.GetOk("bgp_polling_time"); ok {
+		log.Printf("[INFO] Setting BGP Polling Time: %d", val.(int))
 		err := client.SetBgpPollingTime(gateway, val.(int))
 		if err != nil {
 			return fmt.Errorf("could not set bgp polling time: %w", err)

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -4014,7 +4014,6 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 	}
 
 	if val, ok := d.GetOk("bgp_polling_time"); ok {
-		log.Printf("[INFO] Setting BGP Polling Time: %d", val.(int))
 		err := client.SetBgpPollingTime(gateway, val.(int))
 		if err != nil {
 			return fmt.Errorf("could not set bgp polling time: %w", err)

--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -154,15 +154,21 @@ func resourceAviatrixTransitGatewayPeering() *schema.Resource {
 				Default:     false,
 				Description: "Enable HPE mode for peering with Edge Transit",
 			},
-			"src_wan_interfaces": {
-				Type:        schema.TypeString,
+			"gateway1_logical_ifnames": {
+				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "Source WAN interface for edge gateways where the peering originates",
+				Description: "Gateway 1 logical interface names for edge gateways where the peering originates",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
-			"dst_wan_interfaces": {
+			"gateway2_logical_ifnames": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Destination WAN interface for edge gateways where the peering terminates",
+				Description: "Gateway 2 logical interface names for edge gateways where the peering terminates",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 		},
 	}
@@ -179,9 +185,10 @@ func resourceAviatrixTransitGatewayPeeringCreate(d *schema.ResourceData, meta in
 			EnableOverPrivateNetwork: d.Get("over_private_network").(bool),
 			EnableJumboFrame:         d.Get("jumbo_frame").(bool),
 			EnableInsaneMode:         d.Get("insane_mode").(bool),
-			SrcWanInterfaces:         d.Get("src_wan_interfaces").(string),
-			DstWanInterfaces:         d.Get("dst_wan_interfaces").(string),
+			SrcWanInterfaces:         d.Get("gateway1_logical_ifnames").(string),
+			DstWanInterfaces:         d.Get("gateway2_logical_ifnames").(string),
 		}
+		// get logical interfcae names
 		d.SetId(edgeTransitGatewayPeering.TransitGatewayName1 + "~" + edgeTransitGatewayPeering.TransitGatewayName2)
 		defer resourceAviatrixTransitGatewayPeeringReadIfRequired(d, meta, &flag)
 

--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -91,7 +91,6 @@ func resourceAviatrixTransitGatewayPeering() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
 				Description: "(Optional) Advanced option. Enable peering over private network. Only appears and applies to " +
 					"when the two Multi-cloud Transit Gateways are each launched in Insane Mode and in a different cloud type. " +
 					"Conflicts with `enable_insane_mode_encryption_over_internet` and `tunnel_count`. " +
@@ -277,11 +276,11 @@ func resourceAviatrixTransitGatewayPeeringCreate(d *schema.ResourceData, meta in
 		}
 		d.SetId(edgeTransitGatewayPeering.TransitGatewayName1 + "~" + edgeTransitGatewayPeering.TransitGatewayName2)
 		defer resourceAviatrixTransitGatewayPeeringReadIfRequired(d, meta, &flag)
-		log.Printf("[INFO] Creating Aviatrix Edge Transit Gateway peering: %#v", edgeTransitGatewayPeering)
-		err := client.CreateTransitGatewayPeering(context.Background(), edgeTransitGatewayPeering)
-		if err != nil {
-			return fmt.Errorf("failed to create Aviatrix Transit Gateway peering: %s", err)
-		}
+		// log.Printf("[INFO] Creating Aviatrix Edge Transit Gateway peering: %#v", edgeTransitGatewayPeering)
+		// err := client.CreateTransitGatewayPeering(context.Background(), edgeTransitGatewayPeering)
+		// if err != nil {
+		// 	return fmt.Errorf("failed to create Aviatrix Transit Gateway peering: %s", err)
+		// }
 	} else {
 		var gw1Cidrs []string
 		for _, cidr := range d.Get("gateway1_excluded_network_cidrs").([]interface{}) {
@@ -311,6 +310,7 @@ func resourceAviatrixTransitGatewayPeeringCreate(d *schema.ResourceData, meta in
 			InsaneModeOverInternet:         d.Get("enable_insane_mode_encryption_over_internet").(bool),
 			NoMaxPerformance:               !d.Get("enable_max_performance").(bool),
 		}
+
 		if d.Get("enable_peering_over_private_network").(bool) {
 			transitGatewayPeering.PrivateIPPeering = "yes"
 		} else {

--- a/aviatrix/resource_aviatrix_transit_gateway_peering_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering_test.go
@@ -159,7 +159,7 @@ func testAccTransitGatewayPeeringConfigEdge(accountName, transit1GwName, transit
 		account_name       = "edge-%s"
 		cloud_type         = 1048576
 	}
-	
+
 	resource "aviatrix_transit_gateway" "test_edge_transit_1" {
 		cloud_type   = 1048576
 		account_name = aviatrix_account.test_acc_edge_megaport.account_name
@@ -196,7 +196,7 @@ func testAccTransitGatewayPeeringConfigEdge(accountName, transit1GwName, transit
 			logical_ifname = "wan3"
 		}
 	}
-	
+
 	resource "aviatrix_transit_gateway" "test_edge_transit_2" {
 		cloud_type   = 1048576
 		account_name = aviatrix_account.test_acc_edge_megaport.account_name
@@ -233,7 +233,7 @@ func testAccTransitGatewayPeeringConfigEdge(accountName, transit1GwName, transit
 			logical_ifname = "wan3"
 		}
 	}
-	
+
 	resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering" {
 		transit_gateway_name1 = aviatrix_transit_gateway.test_edge_transit_1.gw_name
 		transit_gateway_name2 = aviatrix_transit_gateway.test_edge_transit_2.gw_name

--- a/aviatrix/resource_aviatrix_transit_gateway_peering_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering_test.go
@@ -414,3 +414,71 @@ func TestSetWanInterfaceNames(t *testing.T) {
 		})
 	}
 }
+
+func TestGetLogicalIfNames(t *testing.T) {
+	gateway := &goaviatrix.Gateway{
+		IfNamesTranslation: map[string]string{
+			"eth0": "wan.0",
+			"eth1": "wan.1",
+			"eth2": "mgmt.0",
+			"eth3": "wan.2",
+			"eth4": "wan.3",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		interfaceList []string
+		expected      []string
+		expectErr     bool
+	}{
+		{
+			name:          "Valid interface list",
+			interfaceList: []string{"eth0", "eth1", "eth2", "eth3", "eth4"},
+			expected:      []string{"wan0", "wan1", "mgmt0", "wan2", "wan3"},
+			expectErr:     false,
+		},
+		{
+			name:          "Single valid interface",
+			interfaceList: []string{"eth0"},
+			expected:      []string{"wan0"},
+			expectErr:     false,
+		},
+		{
+			name:          "Interface not found",
+			interfaceList: []string{"eth5"},
+			expected:      nil,
+			expectErr:     true,
+		},
+		{
+			name:          "Mixed valid and invalid interfaces",
+			interfaceList: []string{"eth0", "eth5"},
+			expected:      nil,
+			expectErr:     true,
+		},
+		{
+			name:          "Empty interface list",
+			interfaceList: []string{},
+			expected:      []string{},
+			expectErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getLogicalIfNames(gateway, tt.interfaceList)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectErr, err)
+			}
+			if result == nil {
+				result = []string{}
+			}
+			if tt.expected == nil {
+				tt.expected = []string{}
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected: %v, got: %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -292,6 +292,13 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceNameAEP, "ha_interfaces.0.logical_ifname", "wan0"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "peer_backup_logical_ifname", "wan1"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "peer_connection_type", "private"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "eip_map.0.logical_ifname", "wan0"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "eip_map.0.private_ip", "192.168.19.18"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "eip_map.0.public_ip", "35.0.16.1"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "bgp_polling_time", "55"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "local_as_number", "65000"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "enable_jumbo_frame", "true"),
+						resource.TestCheckResourceAttr(resourceNameAEP, "tunnel_detection_time", "10"),
 					),
 				},
 				{
@@ -541,6 +548,16 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_aep" {
         ip_address     = "192.168.23.12/24"
         logical_ifname = "wan3"
     }
+
+	eip_map {
+        logical_ifname = "wan0"
+        private_ip     = "192.168.19.18"
+        public_ip      = "35.0.16.1"
+    }
+	bgp_polling_time   = 55
+	local_as_number    = 65000
+	enable_jumbo_frame = true
+	tunnel_detection_time = 10
 }
 	`, rName, os.Getenv("AEP_VPC_ID"), os.Getenv("AEP_DEVICE_ID"))
 }

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -380,8 +380,8 @@ func createOrderMap(order []string) map[string]int {
 func sortInterfacesByCustomOrder(interfaces []goaviatrix.EdgeTransitInterface) []goaviatrix.EdgeTransitInterface {
 	orderMap := createOrderMap(interfaceOrder)
 	sort.SliceStable(interfaces, func(i, j int) bool {
-		iIndex, iExists := orderMap[interfaces[i].LogicalIfName]
-		jIndex, jExists := orderMap[interfaces[j].LogicalIfName]
+		iIndex, iExists := orderMap[interfaces[i].Name]
+		jIndex, jExists := orderMap[interfaces[j].Name]
 		if !iExists {
 			iIndex = len(orderMap)
 		}

--- a/docs/resources/aviatrix_account.md
+++ b/docs/resources/aviatrix_account.md
@@ -152,7 +152,7 @@ The following arguments are supported:
 
 ### Required
 * `account_name` - (Required) Account name. This can be used for logging in to CloudN console or UserConnect controller.
-* `cloud_type` - (Required) Type of cloud service provider. Only AWS, GCP, Azure, OCI, AzureGov, AWSGov, AWSChina, AzureChina, Alibaba Cloud, Edge CSP/Zededa, Edge Equinix and Edge NEO/Platform are supported currently. Enter 1 for AWS, 4 for GCP, 8 for Azure, 16 for OCI, 32 for AzureGov, 256 for AWSGov, 1024 for AWSChina or 2048 for AzureChina, 8192 for Alibaba Cloud, 65536 for Edge CSP/Zededa, 524288 for Edge Equinix, 262144 for Edge NEO/Platform.
+* `cloud_type` - (Required) Type of cloud service provider. Only AWS, GCP, Azure, OCI, AzureGov, AWSGov, AWSChina, AzureChina, Alibaba Cloud, Edge CSP/Zededa, Edge Equinix and Edge NEO/Platform are supported currently. Enter 1 for AWS, 4 for GCP, 8 for Azure, 16 for OCI, 32 for AzureGov, 256 for AWSGov, 1024 for AWSChina or 2048 for AzureChina, 8192 for Alibaba Cloud, 65536 for Edge CSP/Zededa, 524288 for Edge Equinix, 262144 for Edge NEO/Platform, 1048576 for Edge Megaport.
 
 ### AWS
 ~> **NOTE:** As of Aviatrix provider version R2.19+, the Aviatrix Controller supports the use of custom IAM roles through the `aws_role_app` and `aws_role_ec2` attributes. If the Controller's IAM role is changed through the AWS console, please run `terraform apply -refresh=false` in order to update `aws_role_app` and `aws_role_ec2`. `audit_account` must be set to "false" when using custom IAM roles.

--- a/docs/resources/aviatrix_edge_spoke_transit_attachment.md
+++ b/docs/resources/aviatrix_edge_spoke_transit_attachment.md
@@ -27,8 +27,20 @@ resource "aviatrix_edge_spoke_transit_attachment" "test_attachment_2" {
   enable_over_private_network = true
   enable_jumbo_frame          = false
   enable_insane_mode          = true
-  dst_wan_interfaces          = "eth1"
   edge_wan_interfaces         = ["eth0"]
+  transit_gateway_logical_ifnames = ["wan1"]
+}
+```
+```hcl
+# Create an Aviatrix Edge as a Spoke to Edge as a Transit Attachment for Megaport
+resource "aviatrix_edge_spoke_transit_attachment" "test_attachment_2" {
+  spoke_gw_name                   = "test-edge-spoke-1"
+  transit_gw_name                 = "test-edge-transit-1"
+  enable_over_private_network     = true
+  enable_jumbo_frame              = false
+  enable_insane_mode              = true
+  spoke_gateway_logical_ifnames   = ["wan1"]
+  transit_gateway_logical_ifnames = ["wan1"]
 }
 ```
 
@@ -52,7 +64,8 @@ The following arguments are supported:
 * `number_of_retries` - (Optional) Number of retries. Default value: 0.
 * `retry_interval` - (Optional) Retry interval in seconds. Default value: 300.
 * `edge_wan_interfaces` - (Optional) Set of Edge WAN interfaces.
-* `dst_wan_interfaces` - (Optional) Destination WAN interface for edge gateways where the peering terminates. Required only for edge as a transit attachment.
+* `spoke_gateway_logical_ifnames` - (Optional) Spoke gateway logical interface names for edge gateways where the peering originates. Required only for Megaport edge as a transit attachment.
+* `transit_gateway_logical_ifnames` - (Optional) Transit gateway logical interface names for edge gateways where the peering terminates. Required only for edge as a transit attachment.
 
 ## Import
 

--- a/docs/resources/aviatrix_spoke_transit_attachment.md
+++ b/docs/resources/aviatrix_spoke_transit_attachment.md
@@ -25,6 +25,14 @@ resource "aviatrix_spoke_transit_attachment" "test_attachment" {
   ]
 }
 ```
+```hcl
+# Create an Aviatrix Spoke Transit Attachment for EAT
+resource "aviatrix_spoke_transit_attachment" "test_attachment" {
+  spoke_gw_name   = "spoke-gw"
+  transit_gw_name = "transit-gw"
+  transit_gateway_logical_ifnames = ["wan1"]
+}
+```
 
 ## Argument Reference
 
@@ -40,6 +48,7 @@ The following arguments are supported:
 * `enable_max_performance` - (Optional) Indicates whether the maximum amount of HPE tunnels will be created. Only valid when transit and spoke gateways are each launched in Insane Mode and in the same cloud type. Default value: true. Available as of provider version R2.22.2+.
 * `spoke_prepend_as_path` - (Optional) Connection based AS Path Prepend. Valid only for BGP connection. Can only use the gateway's own local AS number, repeated up to 25 times. Applies on spoke_gateway_name. Available as of provider version R2.23+.
 * `transit_prepend_as_path` - (Optional) Connection based AS Path Prepend. Valid only for BGP connection. Can only use the gateway's own local AS number, repeated up to 25 times. Applies on transit_gateway_name. Available as of provider version R2.23+.
+* `transit_gateway_logical_ifnames` - (Optional) Transit gateway logical interface names for edge gateways where the peering terminates. Required only for edge as a transit attachment.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_transit_gateway_peering.md
+++ b/docs/resources/aviatrix_transit_gateway_peering.md
@@ -38,11 +38,11 @@ resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering" {
 resource "aviatrix_transit_gateway_peering" "test_edge_transit_gateway_peering" {
   transit_gateway_name1   = "test-edge-transit-1"
   transit_gateway_name2   = "test-edge-transit-2"
-  over_private_network    = true
+  enable_peering_over_private_network  = true
   jumbo_frame             = false
   insane_mode             = true
-  src_wan_interfaces      = "eth1"
-  dst_wan_interfaces      = "eth1"
+  gateway1_logical_ifnames      = ["wan1"]
+  gateway2_logical_ifnames      = ["wan1"]
 }
 ```
 
@@ -66,11 +66,10 @@ The following arguments are supported:
 * `enable_insane_mode_encryption_over_internet` - (Optional) Advanced option. Enable Insane Mode Encryption over Internet. Transit gateways must be in Insane Mode. Currently, only inter-cloud connections between AWS and Azure are supported. Required with valid `tunnel_count`. Conflicts with `enable_peering_over_private_network` and `enable_single_tunnel_mode`. Type: Boolean. Default: false. Available as of provider version R2.19+.
 * `tunnel_count` - (Optional) Advanced option. Number of public tunnels. Required with `enable_insane_mode_encryption_over_internet`. Conflicts with `enable_peering_over_private_network` and `enable_single_tunnel_mode`. Type: Integer. Valid Range: 2-20. Available as of provider version R2.19+.
 * `enable_max_performance` - (Optional) Indicates whether the maximum amount of HPE tunnels will be created. Only valid when the two transit gateways are each launched in Insane Mode and in the same cloud type. Default value: true. Available as of provider version R2.22.2+.
-* `over_private_network` - (Optional) This underlay connects over the private network for peering with Edge Transit. Required only for edge transit attachments.
-* `jumbo_frame` - (Optional) Enable jumbo frame for over private peering with Edge Transit. Required only for edge transit attachments.
-* `insane_mode` - (Optional) Enable HPE mode for peering with Edge Transit. Required only for edge transit attachments.
-* `src_wan_interfaces` - (Optional) Source WAN interface for edge gateways where the peering originates. Required only for edge transit attachments.
-* `dst_wan_interfaces` - (Optional) Destination WAN interface for edge gateways where the peering terminates. Required only for edge transit attachments.
+* `jumbo_frame` - (Optional) Enable jumbo frame for over private peering with Edge Transit. Required only for edge transit peerings.
+* `insane_mode` - (Optional) Enable HPE mode for peering with Edge Transit. Required only for edge transit peerings.
+* `gateway1_logical_ifnames` - (Optional) Logical source WAN interfaces for edge gateways where the peering originates. Required only for edge transit attachments.
+* `gateway2_logical_ifnames` - (Optional) Logical destination WAN interface for edge gateways where the peering terminates. Required only for edge transit attachments.
 
 
 ~> **NOTE:** `enable_single_tunnel_mode` is only valid when `enable_peering_over_private_network` is set to `true`. Private Transit Gateway Peering with Single-Tunnel Mode expands the existing Insane Mode Transit Gateway Peering Over Private Network to apply it to single IPSec tunnel. One use case is for low speed encryption between cloud networks.

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -84,6 +84,7 @@ type EdgeSpokeVlan struct {
 type EdgeSpokeResp struct {
 	GwName                             string `json:"gw_name"`
 	SiteId                             string `json:"vpc_id"`
+	CloudType                          int    `json:"cloud_type"`
 	ManagementEgressIpPrefix           string `json:"mgmt_egress_ip"`
 	EnableManagementOverPrivateNetwork bool   `json:"mgmt_over_private_network"`
 	DnsServerIp                        string `json:"dns_server_ip"`

--- a/goaviatrix/spoke_transit_attachment.go
+++ b/goaviatrix/spoke_transit_attachment.go
@@ -11,22 +11,24 @@ import (
 )
 
 type SpokeTransitAttachment struct {
-	Action                   string `form:"action,omitempty"`
-	CID                      string `form:"CID,omitempty"`
-	SpokeGwName              string `form:"spoke_gw,omitempty"`
-	TransitGwName            string `form:"transit_gw,omitempty"`
-	RouteTables              string `form:"route_table_list,omitempty"`
-	SpokeBgpEnabled          bool
-	SpokePrependAsPath       []string
-	TransitPrependAsPath     []string
-	EnableOverPrivateNetwork bool   `form:"over_private_network,omitempty"`
-	EnableJumboFrame         bool   `form:"jumbo_frame,omitempty"`
-	EnableInsaneMode         bool   `form:"insane_mode,omitempty"`
-	InsaneModeTunnelNumber   int    `form:"tunnel_count,omitempty"`
-	NoMaxPerformance         bool   `form:"no_max_performance,omitempty"`
-	EdgeWanInterfaces        string `form:"edge_wan_interfaces,omitempty"`
-	EdgeWanInterfacesResp    []string
-	DstWanInterfaces         string `form:"dst_wan_interfaces,omitempty"`
+	Action                       string `form:"action,omitempty" json:"action,omitempty"`
+	CID                          string `form:"CID,omitempty" json:"CID,omitempty"`
+	SpokeGwName                  string `form:"spoke_gw,omitempty" json:"spoke_gw,omitempty"`
+	TransitGwName                string `form:"transit_gw,omitempty" json:"transit_gw,omitempty"`
+	RouteTables                  string `form:"route_table_list,omitempty" json:"route_table_list,omitempty"`
+	SpokeBgpEnabled              bool
+	SpokePrependAsPath           []string
+	TransitPrependAsPath         []string
+	EnableOverPrivateNetwork     bool   `form:"over_private_network,omitempty" json:"over_private_network,omitempty"`
+	EnableJumboFrame             bool   `form:"jumbo_frame,omitempty" json:"jumbo_frame,omitempty"`
+	EnableInsaneMode             bool   `form:"insane_mode,omitempty" json:"insane_mode,omitempty"`
+	InsaneModeTunnelNumber       int    `form:"tunnel_count,omitempty" json:"tunnel_count,omitempty"`
+	NoMaxPerformance             bool   `form:"no_max_performance,omitempty" json:"no_max_performance,omitempty"`
+	EdgeWanInterfaces            string `form:"edge_wan_interfaces,omitempty" json:"edge_wan_interfaces,omitempty"`
+	EdgeWanInterfacesResp        []string
+	DstWanInterfaces             string   `form:"dst_wan_interfaces,omitempty" json:"dst_wan_interfaces,omitempty"`
+	SpokeGatewayLogicalIfNames   []string `form:"spoke_gw_logical_ifnames,omitempty" json:"spoke_gw_logical_ifnames,omitempty"`
+	TransitGatewayLogicalIfNames []string `form:"transit_gw_logical_ifnames,omitempty" json:"transit_gw_logical_ifnames,omitempty"`
 }
 
 type EdgeSpokeTransitAttachmentResp struct {
@@ -36,24 +38,26 @@ type EdgeSpokeTransitAttachmentResp struct {
 }
 
 type EdgeSpokeTransitAttachmentResults struct {
-	Site1                    SiteDetail `json:"site_1"`
-	Site2                    SiteDetail `json:"site_2"`
-	EnableOverPrivateNetwork bool       `json:"private_network_peering"`
-	EnableJumboFrame         bool       `json:"jumbo_frame"`
-	EnableInsaneMode         bool       `json:"insane_mode"`
-	InsaneModeTunnelNumber   int        `json:"insane_mode_tunnel_count"`
-	EdgeWanInterfaces        []string   `json:"src_wan_interfaces"`
+	Site1                        SiteDetail `json:"site_1"`
+	Site2                        SiteDetail `json:"site_2"`
+	EnableOverPrivateNetwork     bool       `json:"private_network_peering"`
+	EnableJumboFrame             bool       `json:"jumbo_frame"`
+	EnableInsaneMode             bool       `json:"insane_mode"`
+	InsaneModeTunnelNumber       int        `json:"insane_mode_tunnel_count"`
+	EdgeWanInterfaces            []string   `json:"src_wan_interfaces"`
+	SpokeGatewayLogicalIfNames   []string   `json:"src_gw_logical_ifnames"`
+	TransitGatewayLogicalIfNames []string   `json:"dst_gw_logical_ifnames"`
 }
 
 type SiteDetail struct {
 	ConnBgpPrependAsPath string `json:"conn_bgp_prepend_as_path"`
 }
 
-func (c *Client) CreateSpokeTransitAttachment(spokeTransitAttachment *SpokeTransitAttachment) error {
+func (c *Client) CreateSpokeTransitAttachment(ctx context.Context, spokeTransitAttachment *SpokeTransitAttachment) error {
 	action := "attach_spoke_to_transit_gw"
 	spokeTransitAttachment.CID = c.CID
 	spokeTransitAttachment.Action = action
-	return c.PostAPI(action, spokeTransitAttachment, BasicCheck)
+	return c.PostAPIContext2(ctx, nil, action, spokeTransitAttachment, BasicCheck)
 }
 
 func (c *Client) GetSpokeTransitAttachment(spokeTransitAttachment *SpokeTransitAttachment) (*SpokeTransitAttachment, error) {
@@ -145,6 +149,16 @@ func (c *Client) GetEdgeSpokeTransitAttachment(ctx context.Context, spokeTransit
 			prependAsPath = append(prependAsPath, strings.TrimSpace(str))
 		}
 		spokeTransitAttachment.TransitPrependAsPath = prependAsPath
+	}
+
+	// set the spoke gateway logical interface names
+	if data.Results.SpokeGatewayLogicalIfNames != nil {
+		spokeTransitAttachment.SpokeGatewayLogicalIfNames = data.Results.SpokeGatewayLogicalIfNames
+	}
+
+	// set the transit gateway logical interface names
+	if data.Results.TransitGatewayLogicalIfNames != nil {
+		spokeTransitAttachment.TransitGatewayLogicalIfNames = data.Results.TransitGatewayLogicalIfNames
 	}
 
 	return spokeTransitAttachment, nil

--- a/goaviatrix/spoke_transit_attachment.go
+++ b/goaviatrix/spoke_transit_attachment.go
@@ -46,7 +46,7 @@ type EdgeSpokeTransitAttachmentResults struct {
 	InsaneModeTunnelNumber       int        `json:"insane_mode_tunnel_count"`
 	EdgeWanInterfaces            []string   `json:"src_wan_interfaces"`
 	SpokeGatewayLogicalIfNames   []string   `json:"src_gw_logical_ifnames"`
-	TransitGatewayLogicalIfNames []string   `json:"dst_gw_logical_ifnames"`
+	TransitGatewayLogicalIfNames []string   `json:"dst_wan_interfaces"`
 }
 
 type SiteDetail struct {

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -97,7 +97,6 @@ func (c *Client) CreateTransitGatewayPeering(ctx context.Context, transitGateway
 	transitGatewayPeering.CID = c.CID
 	transitGatewayPeering.Action = "create_inter_transit_gateway_peering"
 	return c.PostAPIContext2(ctx, nil, transitGatewayPeering.Action, transitGatewayPeering, BasicCheck)
-	// return c.PostAPI(transitGatewayPeering.Action, transitGatewayPeering, BasicCheck)
 }
 
 func (c *Client) GetTransitGatewayPeering(transitGatewayPeering *TransitGatewayPeering) error {

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -77,8 +77,8 @@ type TransitGatewayPeeringDetailsResults struct {
 	TunnelCount            int                         `json:"tunnel_count"`
 	EnableJumboFrame       bool                        `json:"jumbo_frame"` // jumbo frame
 	NoMaxPerformance       bool                        `json:"no_max_performance"`
-	Gateway1LogicalIfNames []string                    `json:"src_gw_logical_ifnames"`
-	Gateway2LogicalIfNames []string                    `json:"dst_gw_logical_ifnames"`
+	Gateway1LogicalIfNames []string                    `json:"src_wan_interfaces"`
+	Gateway2LogicalIfNames []string                    `json:"dst_wan_interfaces"`
 	InsaneMode             bool                        `json:"insane_mode"`
 }
 

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -1,6 +1,7 @@
 package goaviatrix
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,33 +9,33 @@ import (
 )
 
 type TransitGatewayPeering struct {
-	TransitGatewayName1                 string `form:"gateway1,omitempty" json:"gateway_1,omitempty"`
-	TransitGatewayName2                 string `form:"gateway2,omitempty" json:"gateway_2,omitempty"`
-	Gateway1ExcludedCIDRs               string `form:"src_filter_list,omitempty"`
-	Gateway2ExcludedCIDRs               string `form:"dst_filter_list,omitempty"`
-	Gateway1ExcludedTGWConnections      string `form:"source_exclude_connections,omitempty"`
-	Gateway2ExcludedTGWConnections      string `form:"destination_exclude_connections,omitempty"`
-	PrivateIPPeering                    string `form:"private_ip_peering,omitempty"`
-	InsaneModeOverInternet              bool   `form:"insane_mode_over_internet,omitempty"`
+	TransitGatewayName1                 string `form:"gateway1,omitempty" json:"gateway1,omitempty"`
+	TransitGatewayName2                 string `form:"gateway2,omitempty" json:"gateway2,omitempty"`
+	Gateway1ExcludedCIDRs               string `form:"src_filter_list,omitempty" json:"src_filter_list,omitempty"`
+	Gateway2ExcludedCIDRs               string `form:"dst_filter_list,omitempty" json:"dst_filter_list,omitempty"`
+	Gateway1ExcludedTGWConnections      string `form:"source_exclude_connections,omitempty" json:"source_exclude_connections,omitempty"`
+	Gateway2ExcludedTGWConnections      string `form:"destination_exclude_connections,omitempty" json:"destination_exclude_connections,omitempty"`
+	PrivateIPPeering                    string `form:"private_ip_peering,omitempty" json:"private_ip_peering,omitempty"`
+	InsaneModeOverInternet              bool   `form:"insane_mode_over_internet,omitempty" json:"insane_mode_over_internet,omitempty"`
 	InsaneModeTunnelCount               int    `json:"insane_mode_tunnel_count"`
-	TunnelCount                         int    `form:"tunnel_count,omitempty"`
+	TunnelCount                         int    `form:"tunnel_count,omitempty" json:"tunnel_count,omitempty"`
 	Gateway1ExcludedCIDRsSlice          []string
 	Gateway2ExcludedCIDRsSlice          []string
 	Gateway1ExcludedTGWConnectionsSlice []string
 	Gateway2ExcludedTGWConnectionsSlice []string
 	PrependAsPath1                      string
 	PrependAsPath2                      string
-	CID                                 string   `form:"CID,omitempty"`
-	Action                              string   `form:"action,omitempty"`
-	SingleTunnel                        string   `form:"single_tunnel,omitempty"`
-	NoMaxPerformance                    bool     `form:"no_max_performance,omitempty"`
-	EnableOverPrivateNetwork            bool     `form:"over_private_network,omitempty"`
-	EnableJumboFrame                    bool     `form:"jumbo_frame,omitempty"`
-	EnableInsaneMode                    bool     `form:"insane_mode,omitempty"`
-	SrcWanInterfaces                    string   `form:"src_wan_interfaces,omitempty"`
-	DstWanInterfaces                    string   `form:"dst_wan_interfaces,omitempty"`
-	Gateway1LogicalIfNames              []string `form:"gateway1_logical_ifnames,omitempty"`
-	Gateway2LogicalIfNames              []string `form:"gateway2_logical_ifnames,omitempty"`
+	CID                                 string   `form:"CID,omitempty" json:"CID,omitempty"`
+	Action                              string   `form:"action,omitempty" json:"action,omitempty"`
+	SingleTunnel                        string   `form:"single_tunnel,omitempty" json:"single_tunnel,omitempty"`
+	NoMaxPerformance                    bool     `form:"no_max_performance,omitempty" json:"no_max_performance,omitempty"`
+	EnableOverPrivateNetwork            bool     `form:"over_private_network,omitempty" json:"over_private_network,omitempty"`
+	EnableJumboFrame                    bool     `form:"jumbo_frame,omitempty" json:"jumbo_frame,omitempty"`
+	EnableInsaneMode                    bool     `form:"insane_mode,omitempty" json:"insane_mode,omitempty"`
+	SrcWanInterfaces                    string   `form:"src_wan_interfaces,omitempty" json:"src_wan_interfaces,omitempty"`
+	DstWanInterfaces                    string   `form:"dst_wan_interfaces,omitempty" json:"dst_wan_interfaces,omitempty"`
+	Gateway1LogicalIfNames              []string `form:"gateway1_logical_ifnames,omitempty" json:"gateway1_logical_ifnames,omitempty"`
+	Gateway2LogicalIfNames              []string `form:"gateway2_logical_ifnames,omitempty" json:"gateway2_logical_ifnames,omitempty"`
 }
 
 type TransitGatewayPeeringEdit struct {
@@ -89,10 +90,11 @@ type TunnelsDetail struct {
 	SubTunnelCount int        `json:"sub_tunnel_count"`
 }
 
-func (c *Client) CreateTransitGatewayPeering(transitGatewayPeering *TransitGatewayPeering) error {
+func (c *Client) CreateTransitGatewayPeering(ctx context.Context, transitGatewayPeering *TransitGatewayPeering) error {
 	transitGatewayPeering.CID = c.CID
 	transitGatewayPeering.Action = "create_inter_transit_gateway_peering"
-	return c.PostAPI(transitGatewayPeering.Action, transitGatewayPeering, BasicCheck)
+	return c.PostAPIContext2(ctx, nil, transitGatewayPeering.Action, transitGatewayPeering, BasicCheck)
+	// return c.PostAPI(transitGatewayPeering.Action, transitGatewayPeering, BasicCheck)
 }
 
 func (c *Client) GetTransitGatewayPeering(transitGatewayPeering *TransitGatewayPeering) error {

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -77,8 +77,9 @@ type TransitGatewayPeeringDetailsResults struct {
 	TunnelCount            int                         `json:"tunnel_count"`
 	EnableJumboFrame       bool                        `json:"jumbo_frame"` // jumbo frame
 	NoMaxPerformance       bool                        `json:"no_max_performance"`
-	Gateway1LogicalIfNames []string                    `json:"gateway1_logical_ifnames"`
-	Gateway2LogicalIfNames []string                    `json:"gateway2_logical_ifnames"`
+	Gateway1LogicalIfNames []string                    `json:"src_gw_logical_ifnames"`
+	Gateway2LogicalIfNames []string                    `json:"dst_gw_logical_ifnames"`
+	InsaneMode             bool                        `json:"insane_mode"`
 }
 
 type TransitGatewayPeeringDetail struct {
@@ -168,6 +169,22 @@ func (c *Client) GetTransitGatewayPeeringDetails(transitGatewayPeering *TransitG
 	if data.Results.Site2.ExcludedTGWConnections != nil {
 		transitGatewayPeering.Gateway2ExcludedTGWConnectionsSlice = data.Results.Site2.ExcludedTGWConnections
 	}
+
+	// set the gateway1 logical interface names
+	if data.Results.Gateway1LogicalIfNames != nil {
+		transitGatewayPeering.Gateway1LogicalIfNames = data.Results.Gateway1LogicalIfNames
+	}
+
+	// set the gateway2 logical interface names
+	if data.Results.Gateway2LogicalIfNames != nil {
+		transitGatewayPeering.Gateway2LogicalIfNames = data.Results.Gateway2LogicalIfNames
+	}
+
+	// set insane mode
+	transitGatewayPeering.EnableInsaneMode = data.Results.InsaneMode
+
+	// set over private network
+	transitGatewayPeering.EnableOverPrivateNetwork = data.Results.PrivateNetworkPeering
 
 	if data.Results.PrivateNetworkPeering {
 		transitGatewayPeering.PrivateIPPeering = "yes"

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -70,13 +70,15 @@ type TransitGatewayPeeringDetailsAPIResp struct {
 type TransitGatewayPeeringDetailsResults struct {
 	Site1                  TransitGatewayPeeringDetail `json:"site_1"`
 	Site2                  TransitGatewayPeeringDetail `json:"site_2"`
-	PrivateNetworkPeering  bool                        `json:"private_network_peering"`
+	PrivateNetworkPeering  bool                        `json:"private_network_peering"` // over private network
 	Tunnels                []TunnelsDetail             `json:"tunnels"`
 	InsaneModeOverInternet bool                        `json:"insane_mode_over_internet"`
 	InsaneModeTunnelCount  int                         `json:"insane_mode_tunnel_count"`
 	TunnelCount            int                         `json:"tunnel_count"`
-	EnableJumboFrame       bool                        `json:"jumbo_frame"`
+	EnableJumboFrame       bool                        `json:"jumbo_frame"` // jumbo frame
 	NoMaxPerformance       bool                        `json:"no_max_performance"`
+	Gateway1LogicalIfNames []string                    `json:"gateway1_logical_ifnames"`
+	Gateway2LogicalIfNames []string                    `json:"gateway2_logical_ifnames"`
 }
 
 type TransitGatewayPeeringDetail struct {
@@ -154,10 +156,19 @@ func (c *Client) GetTransitGatewayPeeringDetails(transitGatewayPeering *TransitG
 		return nil, err
 	}
 
-	transitGatewayPeering.Gateway1ExcludedCIDRsSlice = data.Results.Site1.ExcludedCIDRs
-	transitGatewayPeering.Gateway1ExcludedTGWConnectionsSlice = data.Results.Site1.ExcludedTGWConnections
-	transitGatewayPeering.Gateway2ExcludedCIDRsSlice = data.Results.Site2.ExcludedCIDRs
-	transitGatewayPeering.Gateway2ExcludedTGWConnectionsSlice = data.Results.Site2.ExcludedTGWConnections
+	if data.Results.Site1.ExcludedCIDRs != nil {
+		transitGatewayPeering.Gateway1ExcludedCIDRsSlice = data.Results.Site1.ExcludedCIDRs
+	}
+	if data.Results.Site1.ExcludedTGWConnections != nil {
+		transitGatewayPeering.Gateway1ExcludedTGWConnectionsSlice = data.Results.Site1.ExcludedTGWConnections
+	}
+	if data.Results.Site2.ExcludedCIDRs != nil {
+		transitGatewayPeering.Gateway2ExcludedCIDRsSlice = data.Results.Site2.ExcludedCIDRs
+	}
+	if data.Results.Site2.ExcludedTGWConnections != nil {
+		transitGatewayPeering.Gateway2ExcludedTGWConnectionsSlice = data.Results.Site2.ExcludedTGWConnections
+	}
+
 	if data.Results.PrivateNetworkPeering {
 		transitGatewayPeering.PrivateIPPeering = "yes"
 	} else {

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -24,15 +24,17 @@ type TransitGatewayPeering struct {
 	Gateway2ExcludedTGWConnectionsSlice []string
 	PrependAsPath1                      string
 	PrependAsPath2                      string
-	CID                                 string `form:"CID,omitempty"`
-	Action                              string `form:"action,omitempty"`
-	SingleTunnel                        string `form:"single_tunnel,omitempty"`
-	NoMaxPerformance                    bool   `form:"no_max_performance,omitempty"`
-	EnableOverPrivateNetwork            bool   `form:"over_private_network,omitempty"`
-	EnableJumboFrame                    bool   `form:"jumbo_frame,omitempty"`
-	EnableInsaneMode                    bool   `form:"insane_mode,omitempty"`
-	SrcWanInterfaces                    string `form:"src_wan_interfaces,omitempty"`
-	DstWanInterfaces                    string `form:"dst_wan_interfaces,omitempty"`
+	CID                                 string   `form:"CID,omitempty"`
+	Action                              string   `form:"action,omitempty"`
+	SingleTunnel                        string   `form:"single_tunnel,omitempty"`
+	NoMaxPerformance                    bool     `form:"no_max_performance,omitempty"`
+	EnableOverPrivateNetwork            bool     `form:"over_private_network,omitempty"`
+	EnableJumboFrame                    bool     `form:"jumbo_frame,omitempty"`
+	EnableInsaneMode                    bool     `form:"insane_mode,omitempty"`
+	SrcWanInterfaces                    string   `form:"src_wan_interfaces,omitempty"`
+	DstWanInterfaces                    string   `form:"dst_wan_interfaces,omitempty"`
+	Gateway1LogicalIfNames              []string `form:"gateway1_logical_ifnames,omitempty"`
+	Gateway2LogicalIfNames              []string `form:"gateway2_logical_ifnames,omitempty"`
 }
 
 type TransitGatewayPeeringEdit struct {

--- a/test-data/testAccEdgeSpokeTransitAttachmentConfigEdge.tf
+++ b/test-data/testAccEdgeSpokeTransitAttachmentConfigEdge.tf
@@ -1,83 +1,83 @@
 resource "aviatrix_account" "test_aws" {
-	cloud_type         = 1
-	account_name       = "aws-%s"
-	aws_account_number = "%s"
-	aws_iam            = false
-	aws_access_key     = "%s"
-	aws_secret_key     = "%s"
+  cloud_type         = 1
+  account_name       = "aws-%s"
+  aws_account_number = "%s"
+  aws_iam            = false
+  aws_access_key     = "%s"
+  aws_secret_key     = "%s"
 }
 
 resource "aviatrix_account" "test_acc_edge_megaport" {
-	account_name       = "megaport-%s"
-	cloud_type         = 1048576
+  account_name = "megaport-%s"
+  cloud_type   = 1048576
 }
 
 resource "aviatrix_vpc" "test_vpc" {
-	cloud_type           = 1
-	account_name         = aviatrix_account.test_aws.account_name
-	region               = "us-west-1"
-	name                 = "aws-vpc-test-1"
-	cidr                 = "16.0.0.0/20"
-	aviatrix_transit_vpc = true
+  cloud_type           = 1
+  account_name         = aviatrix_account.test_aws.account_name
+  region               = "us-west-1"
+  name                 = "aws-vpc-test-1"
+  cidr                 = "16.0.0.0/20"
+  aviatrix_transit_vpc = true
 }
 
 resource "aviatrix_spoke_gateway" "test_spoke" {
-	cloud_type     = 1
-	account_name   = aviatrix_account.test.account_name
-	gw_name        = "tfs-%s"
-	vpc_id         = aviatrix_vpc.test_vpc.vpc_id
-	vpc_reg        = aviatrix_vpc.test_vpc.region
-	gw_size        = "c5.xlarge"
-	insane_mode    = true
-	subnet         = join(".", [join(".", slice(split(".", aviatrix_vpc.test1.public_subnets[1].cidr), 0, 2)), "12.0/26"]) #"173.31.12.0/26"
-	insane_mode_az = "us-east-1a"
+  cloud_type     = 1
+  account_name   = aviatrix_account.test.account_name
+  gw_name        = "tfs-%s"
+  vpc_id         = aviatrix_vpc.test_vpc.vpc_id
+  vpc_reg        = aviatrix_vpc.test_vpc.region
+  gw_size        = "c5.xlarge"
+  insane_mode    = true
+  subnet         = join(".", [join(".", slice(split(".", aviatrix_vpc.test1.public_subnets[1].cidr), 0, 2)), "12.0/26"]) #"173.31.12.0/26"
+  insane_mode_az = "us-east-1a"
 }
 
 resource "aviatrix_transit_gateway" "test_edge_transit" {
-	cloud_type   = 1048576
-	account_name = aviatrix_account.test_acc_edge_megaport.account_name
-	gw_name      = "%s"
-	vpc_id       = "%s"
-	gw_size      = "SMALL"
-	ztp_file_download_path = "%s"
-	interfaces {
-        gateway_ip     = "192.168.20.1"
-        ip_address     = "192.168.20.11/24"
-        public_ip      = "67.207.104.19"
-        logical_ifname = "wan0"
-        secondary_private_cidr_list = ["192.168.20.16/29"]
-    }
+  cloud_type             = 1048576
+  account_name           = aviatrix_account.test_acc_edge_megaport.account_name
+  gw_name                = "%s"
+  vpc_id                 = "%s"
+  gw_size                = "SMALL"
+  ztp_file_download_path = "%s"
+  interfaces {
+    gateway_ip                  = "192.168.20.1"
+    ip_address                  = "192.168.20.11/24"
+    public_ip                   = "67.207.104.19"
+    logical_ifname              = "wan0"
+    secondary_private_cidr_list = ["192.168.20.16/29"]
+  }
 
-    interfaces {
-        gateway_ip     = "192.168.21.1"
-        ip_address     = "192.168.21.11/24"
-        public_ip      = "67.71.12.148"
-        logical_ifname = "wan1"
-        secondary_private_cidr_list = ["192.168.21.16/29"]
-    }
+  interfaces {
+    gateway_ip                  = "192.168.21.1"
+    ip_address                  = "192.168.21.11/24"
+    public_ip                   = "67.71.12.148"
+    logical_ifname              = "wan1"
+    secondary_private_cidr_list = ["192.168.21.16/29"]
+  }
 
-    interfaces {
-        dhcp           = true
-        logical_ifname = "mgmt0"
-    }
+  interfaces {
+    dhcp           = true
+    logical_ifname = "mgmt0"
+  }
 
-    interfaces {
-        gateway_ip     = "192.168.22.1"
-        ip_address     = "192.168.22.11/24"
-        logical_ifname = "wan2"
-    }
+  interfaces {
+    gateway_ip     = "192.168.22.1"
+    ip_address     = "192.168.22.11/24"
+    logical_ifname = "wan2"
+  }
 
-    interfaces {
-        gateway_ip     = "192.168.23.1"
-        ip_address     = "192.168.23.11/24"
-        logical_ifname = "wan3"
-    }
+  interfaces {
+    gateway_ip     = "192.168.23.1"
+    ip_address     = "192.168.23.11/24"
+    logical_ifname = "wan3"
+  }
 }
 
 resource "aviatrix_spoke_transit_attachment" "test" {
-	spoke_gw_name   = aviatrix_spoke_gateway.test_spoke.gw_name
-	transit_gw_name = aviatrix_transit_gateway.test_edge_transit.gw_name
-	tunnel_count    = 4
-	transit_gateway_logical_ifnames = ["wan1"]
+  spoke_gw_name                   = aviatrix_spoke_gateway.test_spoke.gw_name
+  transit_gw_name                 = aviatrix_transit_gateway.test_edge_transit.gw_name
+  tunnel_count                    = 4
+  transit_gateway_logical_ifnames = ["wan1"]
 
 }

--- a/test-data/testAccEdgeSpokeTransitAttachmentConfigEdge.tf
+++ b/test-data/testAccEdgeSpokeTransitAttachmentConfigEdge.tf
@@ -1,0 +1,83 @@
+resource "aviatrix_account" "test_aws" {
+	cloud_type         = 1
+	account_name       = "aws-%s"
+	aws_account_number = "%s"
+	aws_iam            = false
+	aws_access_key     = "%s"
+	aws_secret_key     = "%s"
+}
+
+resource "aviatrix_account" "test_acc_edge_megaport" {
+	account_name       = "megaport-%s"
+	cloud_type         = 1048576
+}
+
+resource "aviatrix_vpc" "test_vpc" {
+	cloud_type           = 1
+	account_name         = aviatrix_account.test_aws.account_name
+	region               = "us-west-1"
+	name                 = "aws-vpc-test-1"
+	cidr                 = "16.0.0.0/20"
+	aviatrix_transit_vpc = true
+}
+
+resource "aviatrix_spoke_gateway" "test_spoke" {
+	cloud_type     = 1
+	account_name   = aviatrix_account.test.account_name
+	gw_name        = "tfs-%s"
+	vpc_id         = aviatrix_vpc.test_vpc.vpc_id
+	vpc_reg        = aviatrix_vpc.test_vpc.region
+	gw_size        = "c5.xlarge"
+	insane_mode    = true
+	subnet         = join(".", [join(".", slice(split(".", aviatrix_vpc.test1.public_subnets[1].cidr), 0, 2)), "12.0/26"]) #"173.31.12.0/26"
+	insane_mode_az = "us-east-1a"
+}
+
+resource "aviatrix_transit_gateway" "test_edge_transit" {
+	cloud_type   = 1048576
+	account_name = aviatrix_account.test_acc_edge_megaport.account_name
+	gw_name      = "%s"
+	vpc_id       = "%s"
+	gw_size      = "SMALL"
+	ztp_file_download_path = "%s"
+	interfaces {
+        gateway_ip     = "192.168.20.1"
+        ip_address     = "192.168.20.11/24"
+        public_ip      = "67.207.104.19"
+        logical_ifname = "wan0"
+        secondary_private_cidr_list = ["192.168.20.16/29"]
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.21.1"
+        ip_address     = "192.168.21.11/24"
+        public_ip      = "67.71.12.148"
+        logical_ifname = "wan1"
+        secondary_private_cidr_list = ["192.168.21.16/29"]
+    }
+
+    interfaces {
+        dhcp           = true
+        logical_ifname = "mgmt0"
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.22.1"
+        ip_address     = "192.168.22.11/24"
+        logical_ifname = "wan2"
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.23.1"
+        ip_address     = "192.168.23.11/24"
+        logical_ifname = "wan3"
+    }
+}
+
+resource "aviatrix_spoke_transit_attachment" "test" {
+	spoke_gw_name   = aviatrix_spoke_gateway.test_spoke.gw_name
+	transit_gw_name = aviatrix_transit_gateway.test_edge_transit.gw_name
+	tunnel_count    = 4
+	transit_gateway_logical_ifnames = ["wan1"]
+
+}


### PR DESCRIPTION
Adding the following changes for Megaport peerings and attachment

**Transit to transit peerings**
- gateway1_logical_ifnames
- gateway2_logical_ifnames

**Edge spoke to transit attachements**
- spoke_gateway_logical_ifnames
- transit_gateway_logical_ifnames

**Spoke to transit attachments**
- transit_gateway_logical_ifnames

Also adding support for megaport cloud type account.

```
resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering" {
  transit_gateway_name1                       = "edge-transit-megaport-2"
  transit_gateway_name2                       = "edge-transit-megaport-3"
  enable_peering_over_private_network = true
  jumbo_frame = false
  insane_mode = true
  gateway1_logical_ifnames = ["wan1"]
  gateway2_logical_ifnames = ["wan1"]
}

resource "aviatrix_transit_gateway_peering" "test_transit_gateway_peering_2" {
  transit_gateway_name1                       = "edge-transit-megaport-2"
  transit_gateway_name2                       = "aws-transit"
  enable_peering_over_private_network = true
  jumbo_frame = false
  insane_mode = true
  gateway1_logical_ifnames = ["wan1"]
}

resource "aviatrix_edge_spoke_transit_attachment" "test_edge_spoke_transit_attachment" {
  spoke_gw_name   = "saileeMegaport32"
  transit_gw_name = "edge-transit-megaport-2"
  enable_over_private_network = true
  enable_jumbo_frame = false
  enable_insane_mode = true
  spoke_gateway_logical_ifnames = ["wan1"]
  transit_gateway_logical_ifnames = ["wan1"]
}

resource "aviatrix_spoke_transit_attachment" "test_spoke_transit_attachment" {
  spoke_gw_name   = "saileeMegaport3"
  transit_gw_name = "edge-transit-megaport-2"
  enable_over_private_network = true
  enable_jumbo_frame = false
  enable_insane_mode = true
  transit_gateway_logical_ifnames = ["wan1"]
}
```