### PR TITLE
AVX-61120: Fix ExternalDeviceConnBgpBfdDiffSuppressFunc. [Backport 8.0]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ terraform.tfstate.backup
 RELEASE_NOTES.md
 .devenv
 .direnv
+*.swp

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -2,6 +2,7 @@ package goaviatrix
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -344,59 +345,29 @@ func (c *Client) DeleteExternalDeviceConn(externalDeviceConn *ExternalDeviceConn
 }
 
 func ExternalDeviceConnBgpBfdDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	// if enable_bfd is changed, then the BFD configuration needs to be updated
-	if d.HasChange("enable_bfd") {
+	// In the case where BFD is disabled, we need to *not* suppress any
+	// diffs to "bgp_bfd", otherwise BFD config can be left in the state.
+	// That can break things, as BFD config is not allowed when BFD is
+	// disabled.
+	enabled, ok := d.Get("enable_bfd").(bool)
+	if !enabled || !ok {
 		return false
 	}
-	defaultBfd := map[string]interface{}{
-		"transmit_interval": defaultBfdTransmitInterval,
-		"receive_interval":  defaultBfdReceiveInterval,
-		"multiplier":        defaultBfdMultiplier,
-	}
-	// Retrieve necessary attributes from the schema
-	o, n := d.GetChange("bgp_bfd")
-	bfdEnabled := d.Get("enable_bfd").(bool)
-	// Expand old and new BGP BFD configurations
-	var oldConfig []map[string]interface{}
-	var newConfig []map[string]interface{}
-	if o != nil {
-		oldConfig = ExpandBfdConfig(o.([]interface{}))
-	}
-	if n != nil {
-		newConfig = ExpandBfdConfig(n.([]interface{}))
-	}
-	if bfdEnabled {
-		// If BFD is enabled, then compare the old and new BFD configurations
-		if len(oldConfig) != len(newConfig) {
-			return false
-		}
-		for i := range oldConfig {
-			// If the BFD configuration is different, then update the BFD configuration
-			if oldConfig[i]["transmit_interval"] != newConfig[i]["transmit_interval"] ||
-				oldConfig[i]["receive_interval"] != newConfig[i]["receive_interval"] ||
-				oldConfig[i]["multiplier"] != newConfig[i]["multiplier"] {
-				return false
-			}
-			// If the BFD configuration is the same as the default, then do not update the BFD configuration
-			if newConfig[i]["transmit_interval"] == defaultBfd["transmit_interval"] ||
-				oldConfig[i]["receive_interval"] == defaultBfd["receive_interval"] ||
-				oldConfig[i]["multiplier"] == defaultBfd["multiplier"] {
-				return true
-			}
-		}
-	}
-	return false
-}
 
-// ExpandBfdConfig expands a BGP BFD configuration from an interface slice
-func ExpandBfdConfig(config []interface{}) []map[string]interface{} {
-	expanded := make([]map[string]interface{}, 0, len(config))
-	for _, item := range config {
-		if itemMap, ok := item.(map[string]interface{}); ok {
-			expanded = append(expanded, itemMap)
-		}
-	}
-	return expanded
+	// You might expect that GetChange("bgp_bfd") would return old and
+	// new lists that could be compared. Unfortunately, it doesn't seem to
+	// work that way. The API can report identical values for "bgp_bfd",
+	// (along with HasChange() == false), while at the same time reporting
+	// a change for the first element ("bgp_bfd.0"). Fortunately for us, we
+	// enforce only a single element in bgp_bfd, so we can just check that.
+	// terraform will auto-populate all defaults - including for an empty
+	// list - so all we need to do is compare the two elements.
+	// The strong consensus on the internet is that SDKv2 was simply not
+	// designed for for this sort of thing and the recommended solution
+	// is to migrate to the plugin framework. Unfortunately that's not
+	// a small undertaking.
+	o, n := d.GetChange("bgp_bfd.0")
+	return reflect.DeepEqual(o, n)
 }
 
 func TransitExternalDeviceConnPh1RemoteIdDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
* AVX-61120: Fix ExternalDeviceConnBgpBfdDiffSuppressFunc.

The old implementation of ExternalDeviceConnBgpBfdDiffSuppressFunc could suppress a diff if any of the fields were set to the default value. This broke various cases, including trying to reconcile drift when the desired value matched the default value.

Fixing this was way more complicated than expected, because `GetDiff("bgp_bfd")` did not work as expected (see code comment). This PR changes the diff suppression to rely on terraform to populate list defaults. The net result is that we now only suppress if there is no change between the user config and the state, while accounting for defaults.

* golint

(cherry picked from commit 4e231e762bd68061c08021eec5daa69e6d46778d)