### PR TITLE
AVX-61222: Add support for smart groups with k8s nodes

### DIFF
--- a/aviatrix/resource_aviatrix_smart_group.go
+++ b/aviatrix/resource_aviatrix_smart_group.go
@@ -63,7 +63,7 @@ func resourceAviatrixSmartGroup() *schema.Resource {
 									"type": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"vm", "vpc", "subnet", "k8s"}, false),
+										ValidateFunc: validation.StringInSlice([]string{"vm", "vpc", "subnet", "k8s", "k8s_node"}, false),
 										Description:  "Type of resource this expression matches.",
 									},
 									goaviatrix.K8sClusterIdKey: {

--- a/docs/resources/aviatrix_smart_group.md
+++ b/docs/resources/aviatrix_smart_group.md
@@ -79,6 +79,12 @@ resource "aviatrix_smart_group" "test_smart_group_ip" {
       k8s_pod        = "testpod"
     }
 
+    # Match all nodes of a cluster
+    match_expressions {
+      type           = "k8s_node"
+      k8s_cluster_id = resource.aviatrix_kubernetes_cluster.test_cluster.cluster_id
+    }
+
     // Below are external group type examples
 
     // generic format


### PR DESCRIPTION
This PR adds support for selecting Kubernetes nodes with smart groups.

A smart group for this would look like this:
```hcl
resource "aviatrix_smart_group" "k8s-nodes" {
  name = "k8s-node"
  selector {
    match_expressions {
      type          = "k8s_node"
      k8s_cluster_id = data.aws_eks_cluster.cluster.arn
    }
  }
}
```

In combination with a web group like this:
```hcl
resource "aviatrix_web_group" "image_registries" {
  name = "web-group-image-registries"
  selector {
    match_expressions {
      snifilter = "ghcr.io"
    }
    match_expressions {
      snifilter = "*.docker.io"
    }
    match_expressions {
      snifilter = "*.docker.com"
    }
    match_expressions {
      snifilter = "*.githubusercontent.com"
    }
    match_expressions {
      snifilter = "*.cloudflarestorage.com"
    }
  }
}
```
it is possible to give the nodes permission to download images:
```hcl
resource "aviatrix_distributed_firewalling_policy_list" "test" {
  policies {
    name     = "k8s-nodes"
    priority = 3
    action   = "PERMIT"
    protocol = "ANY"
    src_smart_groups = [
      aviatrix_smart_group.k8s-nodes.uuid,
    ]
    dst_smart_groups         = ["def000ad-0000-0000-0000-000000000000"]
    web_groups = [
      aviatrix_web_group. image_registries.uuid,
    ]
  }
}
```