### PR TITLE
AVX-56050: fix HA eip resuse on azure when calling transit resource update

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2530,25 +2530,6 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			transitHaGw.Eip = haEip
 		}
 
-		haAzureEipName, haAzureEipNameOk := d.GetOk("ha_azure_eip_name_resource_group")
-		if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes) {
-			if haEip != "" && transitHaGw.GwSize != "" {
-				// No change will be detected when ha_eip is set to the empty string because it is computed.
-				// Instead, check ha_gw_size to detect when HA gateway is being deleted.
-				if !haAzureEipNameOk {
-					return fmt.Errorf("failed to create HA Transit Gateway: 'ha_azure_eip_name_resource_group' must be set when a custom EIP is provided and cloud_type is Azure (8), AzureGov (32) or AzureChina (2048)")
-				}
-				// AVX-9874 Azure EIP has a different format e.g. 'test_ip:rg:104.45.186.20'
-				transitHaGw.Eip = fmt.Sprintf("%s:%s", haAzureEipName.(string), haEip)
-			}
-		} else if haAzureEipNameOk {
-			return fmt.Errorf("failed to create HA Spoke Gateway: 'azure_eip_name_resource_group' must be empty when cloud_type is not one of Azure (8), AzureGov (32) or AzureChina (2048)")
-		}
-
-		if !d.HasChange("ha_subnet") && d.HasChange("ha_insane_mode_az") {
-			return fmt.Errorf("ha_subnet must change if ha_insane_mode_az changes")
-		}
-
 		oldSubnet, newSubnet := d.GetChange("ha_subnet")
 		oldZone, newZone := d.GetChange("ha_zone")
 		haGwSize := d.Get("ha_gw_size").(string)
@@ -2597,6 +2578,24 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			} else if oldZone != "" && newZone != "" {
 				changeHaGw = true
 			}
+		}
+
+		haAzureEipName, haAzureEipNameOk := d.GetOk("ha_azure_eip_name_resource_group")
+		if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes) {
+			if haEip != "" && (newHaGwEnabled || changeHaGw) {
+				// No change will be detected when ha_eip is set to the empty string because it is computed.
+				if !haAzureEipNameOk {
+					return fmt.Errorf("failed to create HA Transit Gateway: 'ha_azure_eip_name_resource_group' must be set when a custom EIP is provided and cloud_type is Azure (8), AzureGov (32) or AzureChina (2048)")
+				}
+				// AVX-9874 Azure EIP has a different format e.g. 'test_ip:rg:104.45.186.20'
+				transitHaGw.Eip = fmt.Sprintf("%s:%s", haAzureEipName.(string), haEip)
+			}
+		} else if haAzureEipNameOk {
+			return fmt.Errorf("failed to create HA Spoke Gateway: 'azure_eip_name_resource_group' must be empty when cloud_type is not one of Azure (8), AzureGov (32) or AzureChina (2048)")
+		}
+
+		if !d.HasChange("ha_subnet") && d.HasChange("ha_insane_mode_az") {
+			return fmt.Errorf("ha_subnet must change if ha_insane_mode_az changes")
 		}
 
 		if d.Get("insane_mode").(bool) {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2588,7 +2588,11 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					return fmt.Errorf("failed to create HA Transit Gateway: 'ha_azure_eip_name_resource_group' must be set when a custom EIP is provided and cloud_type is Azure (8), AzureGov (32) or AzureChina (2048)")
 				}
 				// AVX-9874 Azure EIP has a different format e.g. 'test_ip:rg:104.45.186.20'
-				transitHaGw.Eip = fmt.Sprintf("%s:%s", haAzureEipName.(string), haEip)
+				haAzureEipNameString, assertOk := haAzureEipName.(string)
+				if !assertOk {
+					return fmt.Errorf("failed to create HA Transit Gateway: 'ha_azure_eip_name_resource_group' must be a string")
+				}
+				transitHaGw.Eip = fmt.Sprintf("%s:%s", haAzureEipNameString, haEip)
 			}
 		} else if haAzureEipNameOk {
 			return fmt.Errorf("failed to create HA Spoke Gateway: 'azure_eip_name_resource_group' must be empty when cloud_type is not one of Azure (8), AzureGov (32) or AzureChina (2048)")

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2530,6 +2530,10 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			transitHaGw.Eip = haEip
 		}
 
+		if !d.HasChange("ha_subnet") && d.HasChange("ha_insane_mode_az") {
+			return fmt.Errorf("ha_subnet must change if ha_insane_mode_az changes")
+		}
+
 		oldSubnet, newSubnet := d.GetChange("ha_subnet")
 		oldZone, newZone := d.GetChange("ha_zone")
 		haGwSize := d.Get("ha_gw_size").(string)
@@ -2596,10 +2600,6 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 		} else if haAzureEipNameOk {
 			return fmt.Errorf("failed to create HA Spoke Gateway: 'azure_eip_name_resource_group' must be empty when cloud_type is not one of Azure (8), AzureGov (32) or AzureChina (2048)")
-		}
-
-		if !d.HasChange("ha_subnet") && d.HasChange("ha_insane_mode_az") {
-			return fmt.Errorf("ha_subnet must change if ha_insane_mode_az changes")
 		}
 
 		if d.Get("insane_mode").(bool) {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2584,6 +2584,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			}
 		}
 
+		// TODO. Re-using EIP for HA GW on update needs test coverage
 		haAzureEipName, haAzureEipNameOk := d.GetOk("ha_azure_eip_name_resource_group")
 		if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes) {
 			if haEip != "" && (newHaGwEnabled || changeHaGw) {


### PR DESCRIPTION
The Update function for transit gateway resource was incorrectly deciding on how to set the re-use EIP field for Azure HA GW. It was looking at GwSize on the local var transitHaGw before it was ever set so it was impossible for the EIP field to ever be set in an update call where the HA GW would be created.

To fix this I moved the block down slightly so I could leverage `newHaGwEnabled` and `changeHaGw` which already exist.

Validated on my setup.