### PR TITLE
Fixing golangci-lint

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -8,11 +8,10 @@
     "netnstest",
     "manual",
   ]
-  skip-files = [ ".*goaviatrix/client_mock\\.go" ]
-
 
 [issues]
   fix = true
+  exclude-files = [ ".*goaviatrix/client_mock\\.go" ]
 
 [linters]
   disable-all = true

--- a/.golangci_strict.toml
+++ b/.golangci_strict.toml
@@ -8,10 +8,10 @@
     "netnstest",
     "manual",
   ]
-  skip-files = [ ".*goaviatrix/client_mock\\.go" ]
 
 [issues]
   fix = false
+  exclude-files = [ ".*goaviatrix/client_mock\\.go" ]
 
 [linters]
   disable-all = false


### PR DESCRIPTION
The previous config used a deprecated field. 