### PR TITLE
AVX-61942 fix the vendor name to cloud type mapping

### DIFF
--- a/goaviatrix/const.go
+++ b/goaviatrix/const.go
@@ -39,15 +39,15 @@ const (
 
 // The value is corresponding to cloudn repro definition of the same name
 const (
-	SHORTHAND_AWS_VENDOR_NAME             = "aws"
-	SHORTHAND_GOOGLE_VENDOR_NAME          = "gcp"
-	SHORTHAND_AZURE_ARM_VENDOR_NAME       = "arm"
-	SHORTHAND_ORACLE_VENDOR_NAME          = "oci"
-	SHORTHAND_ARM_GOV_VENDOR_NAME         = "arm_gov"
-	SHORTHAND_AWS_GOV_VENDOR_NAME         = "aws_gov"
-	SHORTHAND_AWS_CHINA_VENDOR_NAME       = "aws_cn"
-	SHORTHAND_AZURE_ARM_CHINA_VENDOR_NAME = "arm_cn"
-	SHORTHAND_ALIYUN_VENDOR_NAME          = "acs"
+	ShorthandAWSVendorName           = "aws"
+	ShorthandGOOGLEVendorName        = "gcp"
+	ShorthandAzureARMVendorName      = "arm"
+	ShorthandOracleVendorName        = "oci"
+	ShorthandARMGovVendorName        = "arm_gov"
+	ShorthandAWSGovVendorName        = "aws_gov"
+	ShorthandAWSChinaVendorName      = "aws_cn"
+	ShorthandAzureARMChinaVendorName = "arm_cn"
+	ShorthandAliYunVendorName        = "acs"
 )
 
 // GetSupportedClouds returns the list of currently supported cloud IDs

--- a/goaviatrix/const.go
+++ b/goaviatrix/const.go
@@ -4,6 +4,7 @@
 package goaviatrix
 
 // Cloud provider ids
+// The value is corresponding to cloudn repro definition for cloud type bit, e.g. AWS is AWS_CLOUD_TYPE_BIT
 const (
 	AWS          = 1
 	GCP          = 4
@@ -34,6 +35,19 @@ const (
 	OCIRelatedCloudTypes      = OCI
 	AliCloudRelatedCloudTypes = AliCloud
 	EdgeRelatedCloudTypes     = EDGEEQUINIX | EDGENEO | EDGEMEGAPORT
+)
+
+// The value is corresponding to cloudn repro definition of the same name
+const (
+	SHORTHAND_AWS_VENDOR_NAME             = "aws"
+	SHORTHAND_GOOGLE_VENDOR_NAME          = "gcp"
+	SHORTHAND_AZURE_ARM_VENDOR_NAME       = "arm"
+	SHORTHAND_ORACLE_VENDOR_NAME          = "oci"
+	SHORTHAND_ARM_GOV_VENDOR_NAME         = "arm_gov"
+	SHORTHAND_AWS_GOV_VENDOR_NAME         = "aws_gov"
+	SHORTHAND_AWS_CHINA_VENDOR_NAME       = "aws_cn"
+	SHORTHAND_AZURE_ARM_CHINA_VENDOR_NAME = "arm_cn"
+	SHORTHAND_ALIYUN_VENDOR_NAME          = "acs"
 )
 
 // GetSupportedClouds returns the list of currently supported cloud IDs

--- a/goaviatrix/vpc_tracker.go
+++ b/goaviatrix/vpc_tracker.go
@@ -89,15 +89,15 @@ func (c *Client) GetVpcTracker() ([]*VpcTracker, error) {
 
 func vendorNameToCloudType(v string) int {
 	vendorToCloud := map[string]int{
-		"aws":     AWS,
-		"gcp":     GCP,
-		"arm":     Azure,
-		"oci":     OCI,
-		"aws_gov": AWSGov,
-		"arm_gov": AzureGov,
-		"aws_cn":  AWSChina,
-		"arm_cn":  AzureChina,
-		"acs":     AliCloud,
+		SHORTHAND_AWS_VENDOR_NAME:             AWS,
+		SHORTHAND_GOOGLE_VENDOR_NAME:          GCP,
+		SHORTHAND_AZURE_ARM_VENDOR_NAME:       Azure,
+		SHORTHAND_ORACLE_VENDOR_NAME:          OCI,
+		SHORTHAND_ARM_GOV_VENDOR_NAME:         AzureGov,
+		SHORTHAND_AWS_GOV_VENDOR_NAME:         AWSGov,
+		SHORTHAND_AWS_CHINA_VENDOR_NAME:       AWSChina,
+		SHORTHAND_AZURE_ARM_CHINA_VENDOR_NAME: AzureChina,
+		SHORTHAND_ALIYUN_VENDOR_NAME:          AliCloud,
 	}
 	ct, ok := vendorToCloud[v]
 	if !ok {

--- a/goaviatrix/vpc_tracker.go
+++ b/goaviatrix/vpc_tracker.go
@@ -89,11 +89,15 @@ func (c *Client) GetVpcTracker() ([]*VpcTracker, error) {
 
 func vendorNameToCloudType(v string) int {
 	vendorToCloud := map[string]int{
-		"CLOUD_AWS":     AWS,
-		"CLOUD_GOOGLE":  GCP,
-		"CLOUD_AZURE":   Azure,
-		"CLOUD_ORACLE":  OCI,
-		"CLOUD_AWS_GOV": AWSGov,
+		"aws":     AWS,
+		"gcp":     GCP,
+		"arm":     Azure,
+		"oci":     OCI,
+		"aws_gov": AWSGov,
+		"arm_gov": AzureGov,
+		"aws_cn":  AWSChina,
+		"arm_cn":  AzureChina,
+		"acs":     AliCloud,
 	}
 	ct, ok := vendorToCloud[v]
 	if !ok {

--- a/goaviatrix/vpc_tracker.go
+++ b/goaviatrix/vpc_tracker.go
@@ -89,15 +89,15 @@ func (c *Client) GetVpcTracker() ([]*VpcTracker, error) {
 
 func vendorNameToCloudType(v string) int {
 	vendorToCloud := map[string]int{
-		SHORTHAND_AWS_VENDOR_NAME:             AWS,
-		SHORTHAND_GOOGLE_VENDOR_NAME:          GCP,
-		SHORTHAND_AZURE_ARM_VENDOR_NAME:       Azure,
-		SHORTHAND_ORACLE_VENDOR_NAME:          OCI,
-		SHORTHAND_ARM_GOV_VENDOR_NAME:         AzureGov,
-		SHORTHAND_AWS_GOV_VENDOR_NAME:         AWSGov,
-		SHORTHAND_AWS_CHINA_VENDOR_NAME:       AWSChina,
-		SHORTHAND_AZURE_ARM_CHINA_VENDOR_NAME: AzureChina,
-		SHORTHAND_ALIYUN_VENDOR_NAME:          AliCloud,
+		ShorthandAWSVendorName:           AWS,
+		ShorthandGOOGLEVendorName:        GCP,
+		ShorthandAzureARMVendorName:      Azure,
+		ShorthandOracleVendorName:        OCI,
+		ShorthandARMGovVendorName:        AzureGov,
+		ShorthandAWSGovVendorName:        AWSGov,
+		ShorthandAWSChinaVendorName:      AWSChina,
+		ShorthandAzureARMChinaVendorName: AzureChina,
+		ShorthandAliYunVendorName:        AliCloud,
 	}
 	ct, ok := vendorToCloud[v]
 	if !ok {


### PR DESCRIPTION
Issue:
when cloud_type=0 is provided, cloud_type=0 is returned. Expected for cidr "10.0.0.0/16" which exists in multiple CSPs, the return item should have the corresponding cloud_type.
RC:
incorrect vendor name to cloud_type mapping.

UT:
main.tf:
```
terraform {
  required_providers {
    aviatrix = {
      source  = "aviatrix.com/aviatrix/aviatrix"
      version = "99.0.0"
    }
  }
}

provider "aviatrix" {
  controller_ip = "52.202.7.7"
  username = "admin"
  password = "xviatrixxxxx" 
  skip_version_validation = true
}

data "aviatrix_vpc_tracker" "transit_gateway_1" {
    cloud_type = 1
    cidr = "10.14.0.0/16"
}

output name {
  value = data.aviatrix_vpc_tracker.transit_gateway_1
  sensitive = false
}

data "aviatrix_vpc_tracker" "vnet" {
    cidr = "10.0.0.0/16"
}

output vnet_name {
  value = data.aviatrix_vpc_tracker.vnet
  sensitive = false
}
```

output:
```name = {
  "account_name" = tostring(null)
  "cidr" = "10.14.0.0/16"
  "cloud_type" = tonumber(null)
  "id" = "vpc_tracker~0~10.14.0.0/16~~"
  "region" = tostring(null)
  "vpc_list" = tolist([
    {
      "account_name" = "lfu-aws"
      "cidr" = "10.14.0.0/16"
      "cloud_type" = 1
      "instance_count" = 1
      "name" = "aws-transit(vpc-032fc4e1d7bdcf39b)"
      "region" = "us-east-1"
      "subnets" = tolist([])
      "vpc_id" = "vpc-032fc4e1d7bdcf39b"
    },
  ])
}
vnet_name = {
  "account_name" = tostring(null)
  "cidr" = "10.0.0.0/16"
  "cloud_type" = tonumber(null)
  "id" = "vpc_tracker~0~10.0.0.0/16~~"
  "region" = tostring(null)
  "vpc_list" = tolist([
    {
      "account_name" = "lfu-aws"
      "cidr" = "10.0.0.0/16"
      "cloud_type" = 1
      "instance_count" = 0
      "name" = "vpc-useast2(vpc-0809a9b346395136f)"
      "region" = "us-east-2"
      "subnets" = tolist([])
      "vpc_id" = "vpc-0809a9b346395136f"
    },
    {
      "account_name" = "lfu-azure-csp"
      "cidr" = "10.0.0.0/16"
      "cloud_type" = 8
      "instance_count" = 0
      "name" = "test-subnet-prefix:test-subnet-prefix:295b9b3b-5e33-46c8-93b8-673b68e50725"
      "region" = "East US"
      "subnets" = tolist([])
      "vpc_id" = "test-subnet-prefix:test-subnet-prefix:295b9b3b-5e33-46c8-93b8-673b68e50725"
    },
    {
      "account_name" = "lfu-azure-csp"
      "cidr" = "10.0.0.0/16"
      "cloud_type" = 8
      "instance_count" = 0
      "name" = "myDualVnet:myDualRg:3c08fedf-d935-49ae-9ea7-bb4c503ae83c"
      "region" = "East US 2"
      "subnets" = tolist([])
      "vpc_id" = "myDualVnet:myDualRg:3c08fedf-d935-49ae-9ea7-bb4c503ae83c"
    },
    {
      "account_name" = "lfu-azure-csp"
      "cidr" = "10.0.0.0/16"
      "cloud_type" = 8
      "instance_count" = 0
      "name" = "vnet-1:test-rg:d157cf06-404b-4c8f-ab94-07a9a297d2ea"
      "region" = "East US 2"
      "subnets" = tolist([])
      "vpc_id" = "vnet-1:test-rg:d157cf06-404b-4c8f-ab94-07a9a297d2ea"
    },
    {
      "account_name" = "lfu-azure-csp"
      "cidr" = "10.0.0.0/16"
      "cloud_type" = 8
      "instance_count" = 1
      "name" = "vpc-west-10-0-0-0:rg-av-vpc-west-10-0-0-0-263454:3fe87d14-9e67-4a08-93a4-c711fa4b98bd"
      "region" = "West US 2"
      "subnets" = tolist([])
      "vpc_id" = "vpc-west-10-0-0-0:rg-av-vpc-west-10-0-0-0-263454:3fe87d14-9e67-4a08-93a4-c711fa4b98bd"
    },
    {
      "account_name" = "lfu-azure-csp"
      "cidr" = "10.0.0.0/16"
      "cloud_type" = 8
      "instance_count" = 0
      "name" = "vpc-mexico-10-0-0-0:rg-av-vpc-mexico-10-0-0-0-021576:0dc3e67d-2d26-4330-bce8-349867cc2c01"
      "region" = "Mexico Central"
      "subnets" = tolist([])
      "vpc_id" = "vpc-mexico-10-0-0-0:rg-av-vpc-mexico-10-0-0-0-021576:0dc3e67d-2d26-4330-bce8-349867cc2c01"
    },
    {
      "account_name" = "lfu-aws"
      "cidr" = "10.0.0.0/16"
      "cloud_type" = 1
      "instance_count" = 0
      "name" = "vpc-eucentral1(vpc-07c310a446d75755c)"
      "region" = "eu-central-1"
      "subnets" = tolist([])
      "vpc_id" = "vpc-07c310a446d75755c"
    },
    {
      "account_name" = "lfu-aws"
      "cidr" = "10.0.0.0/16"
      "cloud_type" = 1
      "instance_count" = 0
      "name" = "vpc-eusouth1(vpc-07ce384d1d432e691)"
      "region" = "eu-south-1"
      "subnets" = tolist([])
      "vpc_id" = "vpc-07ce384d1d432e691"
    },
  ])
}```