### PR TITLE
AVX-59452 Adding Support to enable BGPoLan activemesh on edge spoke [Backport 8.0.0]

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -271,7 +271,8 @@ func marshalEdgeSpokeExternalDeviceConnInput(d *schema.ResourceData) (*goaviatri
 	if !ok {
 		return nil, fmt.Errorf("expected enable_bgp_lan_activemesh to be a boolean, but got %T", d.Get("enable_bgp_lan_activemesh"))
 	}
-	if enableBgpLanActiveMesh && (externalDeviceConn.ConnectionType != "bgp" || externalDeviceConn.TunnelProtocol != "LAN") {
+	if enableBgpLanActiveMesh &&
+		(externalDeviceConn.ConnectionType != "bgp" || externalDeviceConn.TunnelProtocol != "LAN") {
 		return nil, fmt.Errorf("'enable_bgp_lan_activemesh' only supports 'bgp' connection " +
 			"with 'LAN' tunnel protocol")
 	}

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -271,11 +271,9 @@ func marshalEdgeSpokeExternalDeviceConnInput(d *schema.ResourceData) (*goaviatri
 	if !ok {
 		return nil, fmt.Errorf("expected enable_bgp_lan_activemesh to be a boolean, but got %T", d.Get("enable_bgp_lan_activemesh"))
 	}
-	if externalDeviceConn.ConnectionType != "bgp" || externalDeviceConn.TunnelProtocol != "LAN" {
-		return nil, fmt.Errorf("'enable_bgp_lan_activemesh' only supports 'bgp' connection with 'LAN' tunnel protocol")
-	}
-	if externalDeviceConn.HAEnabled != "true" {
-		return nil, fmt.Errorf("'enable_bgp_lan_activemesh' can only be enabled with Remote Gateway HA enabled")
+	if enableBgpLanActiveMesh && (externalDeviceConn.ConnectionType != "bgp" || externalDeviceConn.TunnelProtocol != "LAN") {
+		return nil, fmt.Errorf("'enable_bgp_lan_activemesh' only supports 'bgp' connection " +
+			"with 'LAN' tunnel protocol")
 	}
 	externalDeviceConn.EnableBgpLanActiveMesh = enableBgpLanActiveMesh
 

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -92,12 +92,11 @@ func resourceAviatrixEdgeSpokeExternalDeviceConn() *schema.Resource {
 				},
 			},
 			"enable_bgp_lan_activemesh": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-				Description: "Switch to enable BGP LAN ActiveMesh. Only valid for GCP and Azure with Remote Gateway HA enabled. " +
-					"Requires Azure Remote Gateway insane mode enabled. Valid values: true, false. Default: false.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Switch to enable BGP LAN ActiveMesh. Valid values: true, false. Default: false.",
 			},
 			"number_of_retries": {
 				Type:        schema.TypeInt,

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -2,6 +2,7 @@ package aviatrix
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -89,6 +90,14 @@ func resourceAviatrixEdgeSpokeExternalDeviceConn() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return strings.ToUpper(old) == strings.ToUpper(new)
 				},
+			},
+			"enable_bgp_lan_activemesh": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+				Description: "Switch to enable BGP LAN ActiveMesh. Only valid for GCP and Azure with Remote Gateway HA enabled. " +
+					"Requires Azure Remote Gateway insane mode enabled. Valid values: true, false. Default: false.",
 			},
 			"number_of_retries": {
 				Type:        schema.TypeInt,
@@ -221,7 +230,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConn() *schema.Resource {
 	}
 }
 
-func marshalEdgeSpokeExternalDeviceConnInput(d *schema.ResourceData) *goaviatrix.ExternalDeviceConn {
+func marshalEdgeSpokeExternalDeviceConnInput(d *schema.ResourceData) (*goaviatrix.ExternalDeviceConn, error) {
 	externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 		VpcID:              d.Get("site_id").(string),
 		ConnectionName:     d.Get("connection_name").(string),
@@ -259,13 +268,28 @@ func marshalEdgeSpokeExternalDeviceConnInput(d *schema.ResourceData) *goaviatrix
 		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpLocalAsNum
 	}
 
-	return externalDeviceConn
+	enableBgpLanActiveMesh, ok := d.Get("enable_bgp_lan_activemesh").(bool)
+	if !ok {
+		return nil, fmt.Errorf("expected enable_bgp_lan_activemesh to be a boolean, but got %T", d.Get("enable_bgp_lan_activemesh"))
+	}
+	if externalDeviceConn.ConnectionType != "bgp" || externalDeviceConn.TunnelProtocol != "LAN" {
+		return nil, fmt.Errorf("'enable_bgp_lan_activemesh' only supports 'bgp' connection with 'LAN' tunnel protocol")
+	}
+	if externalDeviceConn.HAEnabled != "true" {
+		return nil, fmt.Errorf("'enable_bgp_lan_activemesh' can only be enabled with Remote Gateway HA enabled")
+	}
+	externalDeviceConn.EnableBgpLanActiveMesh = enableBgpLanActiveMesh
+
+	return externalDeviceConn, nil
 }
 
 func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*goaviatrix.Client)
 
-	externalDeviceConn := marshalEdgeSpokeExternalDeviceConnInput(d)
+	externalDeviceConn, err := marshalEdgeSpokeExternalDeviceConnInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if !externalDeviceConn.EnableEdgeUnderlay && externalDeviceConn.ConnectionName == "" {
 		return diag.Errorf("'connection_name' is required when 'enable_edge_underlay' is false")
@@ -303,7 +327,6 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnCreate(ctx context.Context, d *s
 		edgeExternalDeviceConn = goaviatrix.EdgeExternalDeviceConn(*externalDeviceConn)
 	}
 
-	var err error
 	var connName string
 	for i := 0; ; i++ {
 		if externalDeviceConn.EnableEdgeUnderlay {
@@ -453,6 +476,7 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 	d.Set("remote_lan_ip", conn.RemoteLanIP)
 	d.Set("enable_edge_underlay", conn.EnableEdgeUnderlay)
 	d.Set("remote_cloud_type", conn.RemoteCloudType)
+	_ = d.Set("enable_bgp_lan_activemesh", conn.EnableBgpLanActiveMesh)
 	if conn.BgpLocalAsNum != 0 {
 		d.Set("bgp_local_as_num", strconv.Itoa(conn.BgpLocalAsNum))
 	}
@@ -519,7 +543,10 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 	client := meta.(*goaviatrix.Client)
 	d.Partial(true)
 
-	externalDeviceConn := marshalEdgeSpokeExternalDeviceConnInput(d)
+	externalDeviceConn, err := marshalEdgeSpokeExternalDeviceConnInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if d.HasChange("prepend_as_path") {
 		var prependASPath []string
@@ -604,7 +631,10 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 func resourceAviatrixEdgeSpokeExternalDeviceConnDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*goaviatrix.Client)
 
-	externalDeviceConn := marshalEdgeSpokeExternalDeviceConnInput(d)
+	externalDeviceConn, err := marshalEdgeSpokeExternalDeviceConnInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if externalDeviceConn.EnableEdgeUnderlay {
 		edgeExternalDeviceConn := goaviatrix.EdgeExternalDeviceConn(*externalDeviceConn)

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -39,6 +39,9 @@ func TestAccAviatrixEdgeSpokeExternalDeviceConn_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bgp_remote_as_num", "65002"),
 					resource.TestCheckResourceAttr(resourceName, "local_lan_ip", "1.2.3.4"),
 					resource.TestCheckResourceAttr(resourceName, "remote_lan_ip", "5.6.7.8"),
+					resource.TestCheckResourceAttr(resourceName, "connection_type", "bgp"),
+					resource.TestCheckResourceAttr(resourceName, "ha_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_bgp_lan_activemesh", "true"),
 				),
 			},
 			{
@@ -109,6 +112,9 @@ resource "aviatrix_edge_spoke_external_device_conn" "test" {
 	bgp_remote_as_num = "65002"
 	local_lan_ip      = "1.2.3.4"
 	remote_lan_ip     = "5.6.7.8"
+	connection_type   = "bgp"
+	ha_enabled        = true
+	enable_bgp_lan_activemesh = true
 }
 	`, os.Getenv("EDGE_SPOKE_SITE_ID"), rName, os.Getenv("EDGE_SPOKE_NAME"))
 }

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -40,7 +40,6 @@ func TestAccAviatrixEdgeSpokeExternalDeviceConn_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "local_lan_ip", "1.2.3.4"),
 					resource.TestCheckResourceAttr(resourceName, "remote_lan_ip", "5.6.7.8"),
 					resource.TestCheckResourceAttr(resourceName, "connection_type", "bgp"),
-					resource.TestCheckResourceAttr(resourceName, "ha_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enable_bgp_lan_activemesh", "true"),
 				),
 			},
@@ -113,7 +112,6 @@ resource "aviatrix_edge_spoke_external_device_conn" "test" {
 	local_lan_ip      = "1.2.3.4"
 	remote_lan_ip     = "5.6.7.8"
 	connection_type   = "bgp"
-	ha_enabled        = true
 	enable_bgp_lan_activemesh = true
 }
 	`, os.Getenv("EDGE_SPOKE_SITE_ID"), rName, os.Getenv("EDGE_SPOKE_NAME"))

--- a/docs/resources/aviatrix_edge_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_edge_spoke_external_device_conn.md
@@ -24,6 +24,9 @@ resource "aviatrix_edge_spoke_external_device_conn" "test" {
   bgp_remote_as_num = "345"
   local_lan_ip      = "10.230.3.23"
   remote_lan_ip     = "10.0.60.1"
+  connection_type   = "bgp"
+  ha_enabled        = true
+  enable_bgp_lan_activemesh = true
 }
 ```
 ```hcl
@@ -83,6 +86,7 @@ The following arguments are supported:
   * `receive_interval` - (Optional) BFD receive interval in ms. Valid values between 10 to 60000. Default: 300.
   * `multiplier` - (Optional) BFD detection multiplier. Valid values between 2 to 255. Default: 3.
 * `enable_bgp_multihop` - (Optional) Whether to enable multihop on a BFD connection. Valid values: true, false. Default: true.
+* `enable_bgp_lan_activemesh` - (Optional) Switch to enable BGP LAN ActiveMesh mode. Valid values: true, false. Default: false.
 
 ## Import
 

--- a/docs/resources/aviatrix_edge_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_edge_spoke_external_device_conn.md
@@ -25,7 +25,6 @@ resource "aviatrix_edge_spoke_external_device_conn" "test" {
   local_lan_ip      = "10.230.3.23"
   remote_lan_ip     = "10.0.60.1"
   connection_type   = "bgp"
-  ha_enabled        = true
   enable_bgp_lan_activemesh = true
 }
 ```


### PR DESCRIPTION
Backport for - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2177

Adding enable_bgp_lan_activemesh to edge_spoke_external_device_connection to switch BGP LAN active mesh.