### PR TITLE
AVX-62274 Updating the sort order for interfaces in EAT [Backport rc-8.0]

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2960,7 +2960,7 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 					gateway.CloudType = cloudType
 					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 					defer cancel()
-					err = client.UpdateTransitGateway(ctx, gateway)
+					err = client.UpdateEdgeGatewayV2(ctx, gateway)
 					if err != nil {
 						return fmt.Errorf("failed to update logical eip map for edge gateway: %w", err)
 					}
@@ -4035,7 +4035,7 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			// update logical eip map
-			err = client.UpdateTransitGateway(ctx, gateway)
+			err = client.UpdateEdgeGatewayV2(ctx, gateway)
 			if err != nil {
 				return fmt.Errorf("failed to update logical eip map for edge gateway: %w", err)
 			}

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -4032,17 +4032,24 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 			// print eip map for edge mega port
 			log.Printf("[INFO] EIP Map for Edge Mega Port: %#v", eipMapList)
 			gateway.LogicalEipMap = eipMapList
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			// update logical eip map
+			err = client.UpdateTransitGateway(ctx, gateway)
+			if err != nil {
+				return fmt.Errorf("failed to update logical eip map for edge gateway: %w", err)
+			}
 		} else {
 			eipMapJSON, err := json.Marshal(eipMapList)
 			if err != nil {
 				return fmt.Errorf("failed to marshal eip_map to JSON: %w", err)
 			}
 			gateway.EipMap = string(eipMapJSON)
-		}
-		// update EIP map
-		err = client.UpdateEdgeGateway(gateway)
-		if err != nil {
-			return fmt.Errorf("failed to update edge gateway: %s", err)
+			// update EIP map
+			err = client.UpdateEdgeGateway(gateway)
+			if err != nil {
+				return fmt.Errorf("failed to update edge gateway: %w", err)
+			}
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -1500,3 +1500,68 @@ func TestGetUserInterfaceOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestSortInterfacesByCustomOrder(t *testing.T) {
+	tests := []struct {
+		name               string
+		interfaces         []goaviatrix.EdgeTransitInterface
+		userInterfaceOrder []string
+		expected           []goaviatrix.EdgeTransitInterface
+	}{
+		{
+			name: "Sort interfaces based on custom order",
+			interfaces: []goaviatrix.EdgeTransitInterface{
+				{LogicalIfName: "wan2"},
+				{LogicalIfName: "wan0"},
+				{LogicalIfName: "mgmt0"},
+				{LogicalIfName: "wan1"},
+			},
+			userInterfaceOrder: []string{"wan0", "wan1", "mgmt0", "wan2"},
+			expected: []goaviatrix.EdgeTransitInterface{
+				{LogicalIfName: "wan0"},
+				{LogicalIfName: "wan1"},
+				{LogicalIfName: "mgmt0"},
+				{LogicalIfName: "wan2"},
+			},
+		},
+		{
+			name: "Handles interfaces not in custom order",
+			interfaces: []goaviatrix.EdgeTransitInterface{
+				{LogicalIfName: "extra0"},
+				{LogicalIfName: "wan1"},
+				{LogicalIfName: "mgmt0"},
+			},
+			userInterfaceOrder: []string{"wan1", "mgmt0"},
+			expected: []goaviatrix.EdgeTransitInterface{
+				{LogicalIfName: "wan1"},
+				{LogicalIfName: "mgmt0"},
+				{LogicalIfName: "extra0"},
+			},
+		},
+		{
+			name: "Handles empty custom order",
+			interfaces: []goaviatrix.EdgeTransitInterface{
+				{LogicalIfName: "wan2"},
+				{LogicalIfName: "wan0"},
+			},
+			userInterfaceOrder: []string{},
+			expected: []goaviatrix.EdgeTransitInterface{
+				{LogicalIfName: "wan2"},
+				{LogicalIfName: "wan0"},
+			},
+		},
+		{
+			name:               "Handles empty interface list",
+			interfaces:         []goaviatrix.EdgeTransitInterface{},
+			userInterfaceOrder: []string{"wan0", "wan1"},
+			expected:           []goaviatrix.EdgeTransitInterface{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sortInterfacesByCustomOrder(tt.interfaces, tt.userInterfaceOrder)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -1108,6 +1108,9 @@ func TestSetInterfaceMappingDetails(t *testing.T) {
 }
 
 func TestSetInterfaceDetails(t *testing.T) {
+	// Define the interface order
+	interfaceOrder := []string{"wan0", "wan1", "mgmt0", "wan2", "wan3"}
+
 	// Define test cases
 	tests := []struct {
 		name       string
@@ -1132,16 +1135,16 @@ func TestSetInterfaceDetails(t *testing.T) {
 		{
 			name: "Multiple WAN and MANAGEMENT interfaces",
 			interfaces: []goaviatrix.EdgeTransitInterface{
-				{LogicalIfName: "wan0", IpAddress: "10.0.0.2"},
-				{LogicalIfName: "wan1", IpAddress: "10.0.0.3"},
 				{LogicalIfName: "wan2", GatewayIp: "192.168.1.1"},
 				{LogicalIfName: "mgmt0", Dhcp: true},
+				{LogicalIfName: "wan0", IpAddress: "10.0.0.2"},
+				{LogicalIfName: "wan1", IpAddress: "10.0.0.3"},
 			},
 			expected: []map[string]interface{}{
 				{"logical_ifname": "wan0", "ip_address": "10.0.0.2"},
 				{"logical_ifname": "wan1", "ip_address": "10.0.0.3"},
-				{"logical_ifname": "wan2", "gateway_ip": "192.168.1.1"},
 				{"logical_ifname": "mgmt0", "dhcp": true},
+				{"logical_ifname": "wan2", "gateway_ip": "192.168.1.1"},
 			},
 		},
 		{
@@ -1183,7 +1186,7 @@ func TestSetInterfaceDetails(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := setInterfaceDetails(tt.interfaces)
+			result := setInterfaceDetails(tt.interfaces, interfaceOrder)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -1432,6 +1435,36 @@ func TestParseInterface(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
 			}
+		})
+	}
+}
+
+func TestGetUserInterfaceOrder(t *testing.T) {
+	tests := []struct {
+		name       string
+		interfaces []interface{}
+		expected   []string
+	}{
+		{
+			name: "Valid interface list",
+			interfaces: []interface{}{
+				map[string]interface{}{"logical_ifname": "wan0"},
+				map[string]interface{}{"logical_ifname": "wan1"},
+				map[string]interface{}{"logical_ifname": "mgmt0"},
+			},
+			expected: []string{"wan0", "wan1", "mgmt0"},
+		},
+		{
+			name:       "Empty interface list",
+			interfaces: []interface{}{},
+			expected:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getUserInterfaceOrder(tt.interfaces)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -377,11 +377,11 @@ func createOrderMap(order []string) map[string]int {
 }
 
 // Sorting function that uses the interface order
-func sortInterfacesByCustomOrder(interfaces []goaviatrix.EdgeTransitInterface) []goaviatrix.EdgeTransitInterface {
-	orderMap := createOrderMap(interfaceOrder)
+func sortInterfacesByCustomOrder(interfaces []goaviatrix.EdgeTransitInterface, userInterfaceOrder []string) []goaviatrix.EdgeTransitInterface {
+	orderMap := createOrderMap(userInterfaceOrder)
 	sort.SliceStable(interfaces, func(i, j int) bool {
-		iIndex, iExists := orderMap[interfaces[i].Name]
-		jIndex, jExists := orderMap[interfaces[j].Name]
+		iIndex, iExists := orderMap[interfaces[i].LogicalIfName]
+		jIndex, jExists := orderMap[interfaces[j].LogicalIfName]
 		if !iExists {
 			iIndex = len(orderMap)
 		}

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -293,7 +293,7 @@ func (c *Client) UpdateEdgeGateway(gateway *TransitVpc) error {
 	return c.PostAPI(action, form, BasicCheck)
 }
 
-func (c *Client) UpdateTransitGateway(ctx context.Context, gateway *TransitVpc) error {
+func (c *Client) UpdateEdgeGatewayV2(ctx context.Context, gateway *TransitVpc) error {
 	gateway.CID = c.CID
 	gateway.Action = "update_edge_gateway"
 	return c.PostAPIContext2(ctx, nil, gateway.Action, gateway, BasicCheck)

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -2,6 +2,7 @@ package goaviatrix
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -13,11 +14,11 @@ import (
 // Gateway simple struct to hold gateway details
 type TransitVpc struct {
 	AccountName                  string `form:"account_name,omitempty" json:"account_name,omitempty"`
-	Action                       string `form:"action,omitempty"`
-	CID                          string `form:"CID,omitempty"`
+	Action                       string `form:"action,omitempty" json:"action,omitempty"`
+	CID                          string `form:"CID,omitempty" json:"CID,omitempty"`
 	CloudType                    int    `form:"cloud_type,omitempty" json:"cloud_type,omitempty"`
 	DnsServer                    string `form:"dns_server,omitempty" json:"dns_server,omitempty"`
-	GwName                       string `form:"gw_name,omitempty" json:"vpc_name,omitempty"`
+	GwName                       string `form:"gw_name,omitempty" json:"name,omitempty"`
 	GwSize                       string `form:"gw_size,omitempty"`
 	VpcID                        string `form:"vpc_id,omitempty" json:"vpc_id,omitempty"`
 	VNetNameResourceGroup        string `form:"vnet_and_resource_group_names,omitempty"`
@@ -290,6 +291,12 @@ func (c *Client) UpdateEdgeGateway(gateway *TransitVpc) error {
 	}
 	log.Printf("Formm details: %v", form)
 	return c.PostAPI(action, form, BasicCheck)
+}
+
+func (c *Client) UpdateTransitGateway(ctx context.Context, gateway *TransitVpc) error {
+	gateway.CID = c.CID
+	gateway.Action = "update_edge_gateway"
+	return c.PostAPIContext2(ctx, nil, gateway.Action, gateway, BasicCheck)
 }
 
 func (c *Client) DeleteEdgeGateway(gateway *Gateway) error {


### PR DESCRIPTION
Backport for https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2181

- Fixing the sort order of interfaces using the order provided by the user
- The older code for updating the eip_map was sending the data as form string. For Megaport, we require eip_map to be provided as a json objects instead. In this PR, I have updated the eip_map code to use the API v2 version which accepts json object. This ensures that the eip_map gets updated correctly and the original object structure is passed directly for the update.