### PR TITLE
AVX-62741: add a simple cache for the app-domains API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.2.1 (Unreleased)
+## 8.0.0 (Unreleased)
 ### Notes:
-- Supported Controller version: **UserConnect-7.2.4996**
+- Supported Controller version: **UserConnect-8.0.xxxx**
 - Supported Terraform version **v1.x**
 
 ### Bug Fixes:
@@ -25,6 +25,7 @@
    a restriction on using ``user_data`` on Palo Alto Firewalls.
 5. Updated documentation for **aviatrix_spoke_gateway**. Clarified use of the ``included_advertised_spoke_routes`` attribute.
 6. Updated documentation for **aviatrix_smart_group** with examples of external groups usage.
+7. Improved performance for **aviatrix_smart_group** and **aviatrix_web_group** resources.
 
 ### Deprecations:
 Customers can no longer re-bootstrap their PKI with a custom root CA using Terraform. However, this functionality remains available through the Controller UI for added flexibility.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,11 @@ endif
 build13: fmtcheck
 	@echo "==> Installing plugin to $(DESTINATION)"
 	@mkdir -p $(DESTINATION)
-	go build -ldflags "-X github.com/AviatrixSystems/terraform-provider-aviatrix/v3/aviatrix.Version=99.0.0" -o $(DESTINATION)/terraform-provider-aviatrix_v99.0.0
+	CGO_ENABLED=0 \
+	go build \
+		-ldflags "-X github.com/AviatrixSystems/terraform-provider-aviatrix/v3/aviatrix.Version=99.0.0" \
+		-ldflags "-extldflags -static -s -w" \
+		-o $(DESTINATION)/terraform-provider-aviatrix_v99.0.0
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/goaviatrix/appdomain_cache.go
+++ b/goaviatrix/appdomain_cache.go
@@ -1,0 +1,121 @@
+package goaviatrix
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+)
+
+type AppdomainGroup struct {
+	UUID     string          `json:"uuid"`
+	Name     string          `json:"name"`
+	Selector json.RawMessage `json:"selector"`
+}
+
+type AppdomainCache struct {
+	lock      sync.Mutex
+	updatedAt time.Time
+
+	cache map[string]AppdomainGroup
+}
+
+func (a *AppdomainCache) expired() bool {
+	const cacheTime = 5 * time.Second
+	return time.Since(a.updatedAt) > cacheTime
+}
+
+func (a *AppdomainCache) refresh(ctx context.Context, c *Client) error {
+	const endpoint = "app-domains"
+
+	var response struct {
+		Groups []AppdomainGroup `json:"app_domains"`
+	}
+
+	err := c.GetAPIContext25(ctx, &response, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	a.updatedAt = time.Now()
+	a.cache = make(map[string]AppdomainGroup, len(response.Groups))
+	for _, group := range response.Groups {
+		a.cache[group.UUID] = group
+	}
+
+	return nil
+}
+
+func (a *AppdomainCache) Get(ctx context.Context, c *Client, uuid string) (AppdomainGroup, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if a.expired() || len(a.cache) == 0 {
+		if err := a.refresh(ctx, c); err != nil {
+			return AppdomainGroup{}, err
+		}
+	}
+
+	group, ok := a.cache[uuid]
+	if !ok {
+		return AppdomainGroup{}, ErrNotFound
+	}
+
+	return group, nil
+}
+
+func (a *AppdomainCache) List(ctx context.Context, c *Client) ([]AppdomainGroup, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if a.expired() || len(a.cache) == 0 {
+		if err := a.refresh(ctx, c); err != nil {
+			return nil, err
+		}
+	}
+
+	return slices.Collect(maps.Values(a.cache)), nil
+}
+
+func (a *AppdomainCache) Delete(ctx context.Context, c *Client, uuid string) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	a.cache = nil
+
+	endpoint := fmt.Sprintf("app-domains/%s", uuid)
+	return c.DeleteAPIContext25(ctx, endpoint, nil)
+}
+
+func (a *AppdomainCache) Update(ctx context.Context, c *Client, uuid string, value any) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	a.cache = nil
+
+	endpoint := fmt.Sprintf("app-domains/%s", uuid)
+	return c.PutAPIContext25(ctx, endpoint, value)
+}
+
+func (a *AppdomainCache) Create(ctx context.Context, c *Client, value any) (string, error) {
+	const endpoint = "app-domains"
+
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	a.cache = nil
+
+	var response struct {
+		UUID string `json:"uuid"`
+		// More possible fields, but we don't care.
+	}
+
+	if err := c.PostAPIContext25(ctx, &response, endpoint, value); err != nil {
+		return "", err
+	}
+
+	return response.UUID, nil
+}

--- a/goaviatrix/client.go
+++ b/goaviatrix/client.go
@@ -63,6 +63,7 @@ type Client struct {
 	IgnoreTagsConfig *IgnoreTagsConfig
 	cachedAccounts   []Account
 	cacheMutex       sync.Mutex
+	appdomainCache   AppdomainCache
 }
 
 type GetApiTokenResp struct {

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,7 +2,8 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files="$(gofmt -l "$(find . -name '*.go' | grep -v vendor)")"
+# shellcheck disable=SC2046
+gofmt_files="$(gofmt -l $(find . -name '*.go' | grep -v vendor))"
 if [[ -n ${gofmt_files} ]]; then
 	echo 'gofmt needs running on the following files:'
 	echo "${gofmt_files}"


### PR DESCRIPTION
Since there is no way to query the state of a single entry from the app-domains API, add a very conservative cache that mitigates refreshing a lot of smart or web groups. We deliberately serialize access the the API endpoint, dropping the cache after any modification or a conservative 5sec timeout.