### PR TITLE
AVX-58677 Updating the vlan interfaces and sorting order of interfaces

### DIFF
--- a/aviatrix/resource_aviatrix_edge_megaport.go
+++ b/aviatrix/resource_aviatrix_edge_megaport.go
@@ -814,8 +814,8 @@ func resourceAviatrixEdgeMegaportRead(ctx context.Context, d *schema.ResourceDat
 				vlan1["peer_gateway_ip"] = vlan0.PeerGatewayIP
 				vlan1["vrrp_virtual_ip"] = vlan0.VirtualIP
 				vlan1["tag"] = vlan0.Tag
-				vlanId, _ := strconv.Atoi(vlan0.VlanID)
-				vlan1["vlan_id"] = vlanId
+				vlanID, _ := strconv.Atoi(vlan0.VlanID)
+				vlan1["vlan_id"] = vlanID
 
 				vlan = append(vlan, vlan1)
 			}

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -410,10 +410,19 @@ func sortInterfaceMappingByCustomOrder(interfaceMapping []goaviatrix.InterfaceMa
 	return interfaceMapping
 }
 
-// Sorting interfaces by type and index
-func sortInterfacesByTypeIndex(interfaces []goaviatrix.MegaportInterface) []goaviatrix.MegaportInterface {
+// Sorting EAS interfaces using the custom order
+func sortSpokeInterfacesByCustomOrder(interfaces []goaviatrix.MegaportInterface, userInterfaceOrder []string) []goaviatrix.MegaportInterface {
+	orderMap := createOrderMap(userInterfaceOrder)
 	sort.SliceStable(interfaces, func(i, j int) bool {
-		return interfaces[i].LogicalInterfaceName < interfaces[j].LogicalInterfaceName
+		iIndex, iExists := orderMap[interfaces[i].LogicalInterfaceName]
+		jIndex, jExists := orderMap[interfaces[j].LogicalInterfaceName]
+		if !iExists {
+			iIndex = len(orderMap)
+		}
+		if !jExists {
+			jIndex = len(orderMap)
+		}
+		return iIndex < jIndex
 	})
 	return interfaces
 }

--- a/aviatrix/utils_test.go
+++ b/aviatrix/utils_test.go
@@ -1,0 +1,68 @@
+package aviatrix
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+)
+
+func TestSortSpokeInterfacesByCustomOrder(t *testing.T) {
+	// Define test cases
+	tests := []struct {
+		name               string
+		interfaces         []goaviatrix.MegaportInterface
+		userInterfaceOrder []string
+		expected           []goaviatrix.MegaportInterface
+	}{
+		{
+			name: "Sort interfaces based on custom order",
+			interfaces: []goaviatrix.MegaportInterface{
+				{LogicalInterfaceName: "wan2"},
+				{LogicalInterfaceName: "wan0"},
+				{LogicalInterfaceName: "wan1"},
+			},
+			userInterfaceOrder: []string{"wan0", "wan1", "wan2"},
+			expected: []goaviatrix.MegaportInterface{
+				{LogicalInterfaceName: "wan0"},
+				{LogicalInterfaceName: "wan1"},
+				{LogicalInterfaceName: "wan2"},
+			},
+		},
+		{
+			name: "Unordered interfaces with missing custom order",
+			interfaces: []goaviatrix.MegaportInterface{
+				{LogicalInterfaceName: "wan3"},
+				{LogicalInterfaceName: "wan1"},
+				{LogicalInterfaceName: "wan2"},
+			},
+			userInterfaceOrder: []string{"wan1", "wan2"},
+			expected: []goaviatrix.MegaportInterface{
+				{LogicalInterfaceName: "wan1"},
+				{LogicalInterfaceName: "wan2"},
+				{LogicalInterfaceName: "wan3"},
+			},
+		},
+		{
+			name: "Empty custom order",
+			interfaces: []goaviatrix.MegaportInterface{
+				{LogicalInterfaceName: "wan1"},
+				{LogicalInterfaceName: "wan2"},
+			},
+			userInterfaceOrder: []string{},
+			expected: []goaviatrix.MegaportInterface{
+				{LogicalInterfaceName: "wan1"},
+				{LogicalInterfaceName: "wan2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sortSpokeInterfacesByCustomOrder(tt.interfaces, tt.userInterfaceOrder)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("sortSpokeInterfacesByCustomOrder() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/goaviatrix/edge_megaport.go
+++ b/goaviatrix/edge_megaport.go
@@ -161,7 +161,6 @@ func (c *Client) CreateEdgeMegaport(ctx context.Context, edgeMegaport *EdgeMegap
 	edgeMegaport.Interfaces = b64.StdEncoding.EncodeToString(interfaces)
 
 	if len(edgeMegaport.VlanList) != 0 {
-		edgeMegaport.VlanList = []*EdgeMegaportVlan{}
 		vlan, err := json.Marshal(edgeMegaport.VlanList)
 		if err != nil {
 			return err

--- a/goaviatrix/edge_megaport.go
+++ b/goaviatrix/edge_megaport.go
@@ -128,18 +128,18 @@ type EdgeMegaportListResp struct {
 }
 
 type MegaportInterface struct {
-	LogicalInterfaceName string  `json:"logical_ifname"`
-	Name                 string  `json:"ifname,omitempty"`
-	PublicIP             string  `json:"public_ip,omitempty"`
-	Tag                  string  `json:"tag,omitempty"`
-	Dhcp                 bool    `json:"dhcp,omitempty"`
-	IPAddr               string  `json:"ipaddr,omitempty"`
-	GatewayIP            string  `json:"gateway_ip,omitempty"`
-	DNSPrimary           string  `json:"dns_primary,omitempty"`
-	DNSSecondary         string  `json:"dns_secondary,omitempty"`
-	SubInterfaces        []*Vlan `json:"subinterfaces,omitempty"`
-	VrrpState            bool    `json:"vrrp_state,omitempty"`
-	VirtualIP            string  `json:"virtual_ip,omitempty"`
+	LogicalInterfaceName string              `json:"logical_ifname"`
+	Name                 string              `json:"ifname,omitempty"`
+	PublicIP             string              `json:"public_ip,omitempty"`
+	Tag                  string              `json:"tag,omitempty"`
+	Dhcp                 bool                `json:"dhcp,omitempty"`
+	IPAddr               string              `json:"ipaddr,omitempty"`
+	GatewayIP            string              `json:"gateway_ip,omitempty"`
+	DNSPrimary           string              `json:"dns_primary,omitempty"`
+	DNSSecondary         string              `json:"dns_secondary,omitempty"`
+	SubInterfaces        []*EdgeMegaportVlan `json:"subinterfaces,omitempty"`
+	VrrpState            bool                `json:"vrrp_state,omitempty"`
+	VirtualIP            string              `json:"virtual_ip,omitempty"`
 }
 
 type CreateEdgeMegaportResp struct {
@@ -160,16 +160,14 @@ func (c *Client) CreateEdgeMegaport(ctx context.Context, edgeMegaport *EdgeMegap
 
 	edgeMegaport.Interfaces = b64.StdEncoding.EncodeToString(interfaces)
 
-	if len(edgeMegaport.VlanList) == 0 {
+	if len(edgeMegaport.VlanList) != 0 {
 		edgeMegaport.VlanList = []*EdgeMegaportVlan{}
+		vlan, err := json.Marshal(edgeMegaport.VlanList)
+		if err != nil {
+			return err
+		}
+		edgeMegaport.Vlan = b64.StdEncoding.EncodeToString(vlan)
 	}
-
-	vlan, err := json.Marshal(edgeMegaport.VlanList)
-	if err != nil {
-		return err
-	}
-
-	edgeMegaport.Vlan = b64.StdEncoding.EncodeToString(vlan)
 
 	var data CreateEdgeMegaportResp
 


### PR DESCRIPTION
- Updating the order of interfaces. Using the user provided interface order to set the interfaces in the state file.
- Updating the VLan interfaces to use the EdgeMegaportVlan structure

```
resource "aviatrix_edge_megaport" "edge_megaport_10" {
    gw_name = "e2e-megaport-eas-10"
    ztp_file_download_path = "ztp"
    account_name = "megaportacct2"
    site_id = "eas-site-10"
    management_egress_ip_prefix_list = [ 
        "162.43.140.85/31"
    ]
    local_as_number = "65214"
    interfaces {
        logical_ifname = "wan0"
        ip_address = "192.168.16.10/24"
        gateway_ip = "192.168.16.1"
    }

    interfaces {
        logical_ifname = "wan1"
        ip_address = "192.168.17.10/24"
        gateway_ip = "192.168.17.1"
    }

    interfaces {
        logical_ifname = "wan2"
        ip_address = "192.168.18.10/24"
        gateway_ip = "192.168.18.1"
    }

    interfaces {
        logical_ifname = "lan0"
        ip_address = "192.168.19.10/24"
    }

    interfaces {
        logical_ifname = "mgmt0"
        enable_dhcp = true
    }

    vlan {
        parent_logical_interface_name = "lan0"
        vlan_id = 100
        ip_address = "192.168.20.10/24"
    }
}
```