### PR TITLE
AVX-62920 Update Megaport EAS without Vlan config

### DIFF
--- a/aviatrix/resource_aviatrix_edge_megaport_test.go
+++ b/aviatrix/resource_aviatrix_edge_megaport_test.go
@@ -123,7 +123,7 @@ func testAccEdgeMegaportBasic(accountName, gwName, siteId, path string) string {
  `, accountName, gwName, siteId, path)
 }
 
-func testAccEdgeMegaportUpdate(accountName, gwName, siteId, path string) string {
+func testAccEdgeMegaportUpdate(accountName, gwName, siteID, path string) string {
 	return fmt.Sprintf(`
 	resource "aviatrix_account" "test" {
 		account_name          = "%s"
@@ -173,7 +173,7 @@ func testAccEdgeMegaportUpdate(accountName, gwName, siteId, path string) string 
 			ip_address                     = "10.220.21.11/24"
 		}
 	}
- `, accountName, gwName, siteId, path)
+ `, accountName, gwName, siteID, path)
 }
 
 func testAccCheckEdgeMegaportExists(resourceName string) resource.TestCheckFunc {

--- a/aviatrix/resource_aviatrix_edge_megaport_test.go
+++ b/aviatrix/resource_aviatrix_edge_megaport_test.go
@@ -51,6 +51,16 @@ func TestAccAviatrixEdgeMegaport_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccEdgeMegaportUpdate(accountName, gwName, siteId, path),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeMegaportExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.220.14.10/24"),
+					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "192.168.95.14/24"),
+					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "192.168.85.14/24"),
+					resource.TestCheckResourceAttr(resourceName, "interfaces.3.ip_address", "192.168.75.14/24"),
+				),
+			},
+			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -95,6 +105,59 @@ func testAccEdgeMegaportBasic(accountName, gwName, siteId, path string) string {
 		interfaces {
 			gateway_ip     = "192.168.77.1"
 			ip_address     = "192.168.77.14/24"
+			logical_ifname = "wan2"
+			wan_public_ip  = "67.72.12.149"
+		}
+
+		interfaces {
+			enable_dhcp   = true
+			logical_ifname = "mgmt0"
+		}
+
+		vlan {
+			parent_logical_interface_name = "lan0"
+			vlan_id                        = 21
+			ip_address                     = "10.220.21.11/24"
+		}
+	}
+ `, accountName, gwName, siteId, path)
+}
+
+func testAccEdgeMegaportUpdate(accountName, gwName, siteId, path string) string {
+	return fmt.Sprintf(`
+	resource "aviatrix_account" "test" {
+		account_name          = "%s"
+		cloud_type            = 1048576
+	}
+	resource "aviatrix_edge_megaport" "test_spoke" {
+		account_name                       = aviatrix_account.test.account_name
+		gw_name                            = "%s"
+		site_id                            = "%s"
+		ztp_file_download_path             = "%s"
+
+		interfaces {
+			gateway_ip     = "10.220.15.1"
+			ip_address     = "10.220.15.10/24"
+			logical_ifname = "lan0"
+		}
+
+		interfaces {
+			gateway_ip     = "192.168.95.1"
+			ip_address     = "192.168.95.14/24"
+			logical_ifname = "wan0"
+			wan_public_ip  = "67.207.104.19"
+		}
+
+		interfaces {
+			gateway_ip     = "192.168.85.1"
+			ip_address     = "192.168.85.14/24"
+			logical_ifname = "wan1"
+			wan_public_ip  = "67.71.12.148"
+		}
+
+		interfaces {
+			gateway_ip     = "192.168.75.1"
+			ip_address     = "192.168.75.14/24"
 			logical_ifname = "wan2"
 			wan_public_ip  = "67.72.12.149"
 		}

--- a/goaviatrix/edge_megaport.go
+++ b/goaviatrix/edge_megaport.go
@@ -243,16 +243,13 @@ func (c *Client) UpdateEdgeMegaport(ctx context.Context, edgeMegaport *EdgeMegap
 
 	edgeMegaport.Interfaces = b64.StdEncoding.EncodeToString(interfaces)
 
-	if len(edgeMegaport.VlanList) == 0 {
-		edgeMegaport.VlanList = []*EdgeMegaportVlan{}
+	if len(edgeMegaport.VlanList) != 0 {
+		vlan, err := json.Marshal(edgeMegaport.VlanList)
+		if err != nil {
+			return err
+		}
+		edgeMegaport.Vlan = b64.StdEncoding.EncodeToString(vlan)
 	}
-
-	vlan, err := json.Marshal(edgeMegaport.VlanList)
-	if err != nil {
-		return err
-	}
-
-	edgeMegaport.Vlan = b64.StdEncoding.EncodeToString(vlan)
 
 	return c.PostAPIContext2(ctx, nil, edgeMegaport.Action, edgeMegaport, BasicCheck)
 }


### PR DESCRIPTION
- Modifying the update functionality to add vlan config to the update payload only if its user provided. Passing empty vlan config was causing the api to throw an error
- Added UT to test the update functionality
- The update error was the side effect of the additional checks added to Vlan config in this PR - https://github.com/AviatrixDev/cloudn/pull/42320

```
resource "aviatrix_edge_megaport" "edge_megaport_11" {
    gw_name = "e2e-megaport-eas-11"
    ztp_file_download_path = "ztp"
    account_name = "megaportacct2"
    site_id = "eas-site-11"
    management_egress_ip_prefix_list = [ 
        "162.43.140.85/31"
    ]
    local_as_number = "65214"
    interfaces {
        logical_ifname = "wan0"
        ip_address = "192.168.16.10/24"
        gateway_ip = "192.168.16.1"
    }

    interfaces {
        logical_ifname = "wan1"
        ip_address = "192.168.17.10/24"
        gateway_ip = "192.168.17.1"
    }

    interfaces {
        logical_ifname = "wan2"
        ip_address = "192.168.18.10/24"
        gateway_ip = "192.168.18.1"
    }

    interfaces {
        logical_ifname = "lan0"
        ip_address = "192.168.19.10/24"
    }

    interfaces {
        logical_ifname = "mgmt0"
        enable_dhcp = true
    }
}
```
Apply the above config. Update the interface ip_addresses/gateway_ips and verify that the update goes through without any errors