### PR TITLE
AVX-62963: Removed input validation for type key, this will be handled by the API

### DIFF
--- a/aviatrix/resource_aviatrix_smart_group.go
+++ b/aviatrix/resource_aviatrix_smart_group.go
@@ -61,10 +61,9 @@ func resourceAviatrixSmartGroup() *schema.Resource {
 										Description:  "Edge Site-ID this expression matches.",
 									},
 									"type": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"vm", "vpc", "subnet", "k8s", "k8s_node"}, false),
-										Description:  "Type of resource this expression matches.",
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Type of resource this expression matches.",
 									},
 									goaviatrix.K8sClusterIdKey: {
 										Type:        schema.TypeString,

--- a/docs/resources/aviatrix_smart_group.md
+++ b/docs/resources/aviatrix_smart_group.md
@@ -147,7 +147,7 @@ The following arguments are supported:
     * `cidr` - (Optional) - CIDR block or IP Address this expression matches. `cidr` cannot be used with any other filters in the same `match_expressions` block.
     * `fqdn` - (Optional) - FQDN address this expression matches. `fqdn` cannot be used with any other filters in the same `match_expressions` block.
     * `site` - (Optional) - Edge Site-ID this expression matches. `site` cannot be used with any other filters in the same `match_expressions` block.
-    * `type` - (Optional) - Type of resource this expression matches. Must be one of "vm", "vpc", "subnet" or "k8s". `type` is required when `cidr`, `fqdn` and `site` are all not used.
+    * `type` - (Optional) - Type of resource this expression matches. If not using the external selector it must be one of "vm", "vpc", "subnet" or "k8s". `type` is required when `cidr`, `fqdn` and `site` are all not used.
     * `res_id` - (Optional) - Resource ID this expression matches.
     * `account_id` - (Optional) - Account ID this expression matches.
     * `account_name` - (Optional) - Account name this expression matches.


### PR DESCRIPTION
Removing the input validation for type key in external group creation, the input validation gets complicated as it needs to be avoided if there is an external keyword mentioned, I think it's best if we let the API handle this validation check instead of having it in the TF.