### PR TITLE
AVX-61734 Adding custom interface mapping to Self Managed Spoke

### DIFF
--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -320,11 +321,41 @@ func resourceAviatrixEdgeGatewaySelfmanaged() *schema.Resource {
 					},
 				},
 			},
+			"custom_interface_mapping": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "A list of custom interface mappings containing logical interfaces mapped to mac addresses or pci id's.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"logical_ifname": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Logical interface name e.g., wan0, mgmt0, lan0.",
+							ValidateFunc: validation.StringMatch(
+								regexp.MustCompile(`^(wan|mgmt|lan)[0-9]+$`),
+								"Logical interface name must start with 'wan','lan' or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt0', 'lan0').",
+							),
+						},
+						"identifier_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Type of identifier used to map the logical interface to the physical interface e.g., mac, pci, system-assigned.",
+							ValidateFunc: validation.StringInSlice([]string{"mac", "pci", "system-assigned"}, false),
+						},
+						"identifier_value": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Value of the identifier used to map the logical interface to the physical interface. Can be a MAC address, PCI ID, or auto if system-assigned.",
+							ValidateFunc: validateIdentifierValue,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
-func marshalEdgeGatewaySelfmanagedInput(d *schema.ResourceData) *goaviatrix.EdgeSpoke {
+func marshalEdgeGatewaySelfmanagedInput(d *schema.ResourceData) (*goaviatrix.EdgeSpoke, error) {
 	edgeSpoke := &goaviatrix.EdgeSpoke{
 		GwName:                             d.Get("gw_name").(string),
 		SiteId:                             d.Get("site_id").(string),
@@ -352,58 +383,29 @@ func marshalEdgeGatewaySelfmanagedInput(d *schema.ResourceData) *goaviatrix.Edge
 		RxQueueSize:                        d.Get("rx_queue_size").(string),
 	}
 
-	interfaces := d.Get("interfaces").(*schema.Set).List()
-	for _, if0 := range interfaces {
-		if1 := if0.(map[string]interface{})
-
-		if2 := &goaviatrix.EdgeSpokeInterface{
-			IfName:       if1["name"].(string),
-			Type:         if1["type"].(string),
-			Dhcp:         if1["enable_dhcp"].(bool),
-			PublicIp:     if1["wan_public_ip"].(string),
-			IpAddr:       if1["ip_address"].(string),
-			GatewayIp:    if1["gateway_ip"].(string),
-			DNSPrimary:   if1["dns_server_ip"].(string),
-			DNSSecondary: if1["secondary_dns_server_ip"].(string),
-			Tag:          if1["tag"].(string),
-		}
-
-		// vrrp and vrrp_virtual_ip are only applicable for LAN interfaces
-		if if1["type"].(string) == "LAN" {
-			if2.VrrpState = if1["enable_vrrp"].(bool)
-			if2.VirtualIp = if1["vrrp_virtual_ip"].(string)
-		}
-
-		edgeSpoke.InterfaceList = append(edgeSpoke.InterfaceList, if2)
+	if err := populateInterfaces(d, edgeSpoke); err != nil {
+		return nil, err
 	}
 
-	vlan := d.Get("vlan").(*schema.Set).List()
-	for _, vlan0 := range vlan {
-		vlan1 := vlan0.(map[string]interface{})
-
-		vlan2 := &goaviatrix.EdgeSpokeVlan{
-			ParentInterface: vlan1["parent_interface_name"].(string),
-			IpAddr:          vlan1["ip_address"].(string),
-			GatewayIp:       vlan1["gateway_ip"].(string),
-			PeerIpAddr:      vlan1["peer_ip_address"].(string),
-			PeerGatewayIp:   vlan1["peer_gateway_ip"].(string),
-			VirtualIp:       vlan1["vrrp_virtual_ip"].(string),
-			Tag:             vlan1["tag"].(string),
-		}
-
-		vlan2.VlanId = strconv.Itoa(vlan1["vlan_id"].(int))
-
-		edgeSpoke.VlanList = append(edgeSpoke.VlanList, vlan2)
+	if err := populateVlans(d, edgeSpoke); err != nil {
+		return nil, err
 	}
 
-	return edgeSpoke
+	if err := populateCustomInterfaceMapping(d, edgeSpoke); err != nil {
+		return nil, err
+	}
+
+	return edgeSpoke, nil
 }
 
 func resourceAviatrixEdgeGatewaySelfmanagedCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*goaviatrix.Client)
 
 	// read configs
-	edgeSpoke := marshalEdgeGatewaySelfmanagedInput(d)
+	edgeSpoke, err := marshalEdgeGatewaySelfmanagedInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// checks before creation
 	if !edgeSpoke.EnableEdgeActiveStandby && edgeSpoke.EnableEdgeActiveStandbyPreemptive {
@@ -620,6 +622,28 @@ func resourceAviatrixEdgeGatewaySelfmanagedRead(ctx context.Context, d *schema.R
 		d.Set("approved_learned_cidrs", nil)
 	}
 
+	if len(edgeSpoke.CustomInterfaceMapping) != 0 {
+		// get the order of custom interface mapping
+		userCustomInterfaceMapping, ok := d.Get("custom_interface_mapping").([]interface{})
+		if !ok {
+			return diag.Errorf("failed to get custom_interface_mapping")
+		}
+		userCustomInterfaceOrder, err := getCustomInterfaceOrder(userCustomInterfaceMapping)
+		if err != nil {
+			return diag.Errorf("failed to get custom_interface_order: %s\n", err)
+		}
+		customInterfaceMapping, err := setCustomInterfaceMapping(edgeSpoke.CustomInterfaceMapping, userCustomInterfaceOrder)
+		if !ok {
+			return diag.Errorf("failed to get custom_interface_mapping: %s\n", err)
+		}
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("custom_interface_mapping", customInterfaceMapping); err != nil {
+			return diag.Errorf("failed to set custom_interface_mapping: %s\n", err)
+		}
+	}
+
 	spokeBgpManualAdvertisedCidrs := getStringSet(d, "spoke_bgp_manual_advertise_cidrs")
 	if len(goaviatrix.Difference(spokeBgpManualAdvertisedCidrs, edgeSpoke.SpokeBgpManualAdvertisedCidrs)) != 0 ||
 		len(goaviatrix.Difference(edgeSpoke.SpokeBgpManualAdvertisedCidrs, spokeBgpManualAdvertisedCidrs)) != 0 {
@@ -647,7 +671,8 @@ func resourceAviatrixEdgeGatewaySelfmanagedRead(ctx context.Context, d *schema.R
 
 	var interfaces []map[string]interface{}
 	var vlan []map[string]interface{}
-	for _, if0 := range edgeSpoke.InterfaceList {
+	interfaceList := edgeSpoke.InterfaceList
+	for _, if0 := range interfaceList {
 		if1 := make(map[string]interface{})
 		if1["name"] = if0.IfName
 		if1["type"] = if0.Type
@@ -702,7 +727,10 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 	client := meta.(*goaviatrix.Client)
 
 	// read configs
-	edgeSpoke := marshalEdgeGatewaySelfmanagedInput(d)
+	edgeSpoke, err := marshalEdgeGatewaySelfmanagedInput(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// checks before update
 	if !edgeSpoke.EnableEdgeActiveStandby && edgeSpoke.EnableEdgeActiveStandbyPreemptive {
@@ -881,6 +909,10 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 			return diag.Errorf("could not update management egress ip prefix list, WAN/LAN/MANAGEMENT/VLAN interfaces, "+
 				"Edge active standby or Edge active standby preemptive during Edge as a Spoke update: %v", err)
 		}
+	}
+
+	if d.HasChange("custom_interface_mapping") {
+		return diag.Errorf("updating custom interface mapping after the selfmanaged Edge Gateway creation is not supported")
 	}
 
 	d.Partial(false)

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_helper.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_helper.go
@@ -1,0 +1,324 @@
+package aviatrix
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func validateIdentifierValue(val interface{}, key string) (warns []string, errs []error) {
+	value, ok := val.(string)
+	if !ok {
+		errs = append(errs, fmt.Errorf("%q must be a string, got: %T", key, val))
+		return warns, errs
+	}
+	// Check if the value is "auto"
+	if value == "auto" {
+		return
+	}
+	// Check if the value is a valid MAC address
+	macRegex := `^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$`
+	if matched, _ := regexp.MatchString(macRegex, value); matched {
+		return
+	}
+	// Check if the value is a valid PCI ID
+	pciRegex := `^(pci@)?[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]$`
+	if matched, _ := regexp.MatchString(pciRegex, value); matched {
+		return
+	}
+	errs = append(errs, fmt.Errorf("%q must be a valid MAC address, PCI ID, or 'auto', got: %s", key, value))
+	return warns, errs
+}
+
+func getCustomInterfaceMapDetails(customInterfaceMap []interface{}) (map[string]goaviatrix.CustomInterfaceMap, error) {
+	// Create a map to structure the Custom interface map data
+	customInterfaceMapStructured := make(map[string]goaviatrix.CustomInterfaceMap)
+
+	// Populate the structured map
+	for _, customInterfaceMap := range customInterfaceMap {
+		customInterface, ok := customInterfaceMap.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid type: expected map[string]interface{}, got %T", customInterfaceMap)
+		}
+		logicalIfName, ok := customInterface["logical_ifname"].(string)
+		if !ok {
+			return nil, fmt.Errorf("logical interface name must be a string")
+		}
+
+		identifierType, ok := customInterface["identifier_type"].(string)
+		if !ok {
+			return nil, fmt.Errorf("identifier type must be a string")
+		}
+		identifierValue, ok := customInterface["identifier_value"].(string)
+		if !ok {
+			return nil, fmt.Errorf("identifier value must be a string")
+		}
+
+		// Append the EIP entry to the corresponding interface
+		customInterfaceEntry := goaviatrix.CustomInterfaceMap{
+			IdentifierType:  identifierType,
+			IdentifierValue: identifierValue,
+		}
+		customInterfaceMapStructured[logicalIfName] = customInterfaceEntry
+	}
+
+	return customInterfaceMapStructured, nil
+}
+
+func setCustomInterfaceMapping(customInterfaceMap map[string]goaviatrix.CustomInterfaceMap, userCustomInterfaceOrder []string) ([]interface{}, error) {
+	var result []interface{}
+
+	// Iterate over the user-provided order
+	for _, logicalIfName := range userCustomInterfaceOrder {
+		logicalName := strings.ToUpper(logicalIfName)
+		mapping, exists := customInterfaceMap[logicalName]
+		if !exists {
+			return nil, fmt.Errorf("logical interface name %s not found in custom interface map", logicalIfName)
+		}
+
+		if mapping.IdentifierType == "" {
+			return nil, fmt.Errorf("identifier type cannot be empty for logical interface: %s", logicalIfName)
+		}
+		if mapping.IdentifierValue == "" {
+			return nil, fmt.Errorf("identifier value cannot be empty for logical interface: %s", logicalIfName)
+		}
+
+		entry := map[string]interface{}{
+			"logical_ifname":   logicalIfName,
+			"identifier_type":  mapping.IdentifierType,
+			"identifier_value": mapping.IdentifierValue,
+		}
+		result = append(result, entry)
+	}
+	return result, nil
+}
+
+func getCustomInterfaceOrder(userCustomInterfaceMapping []interface{}) ([]string, error) {
+	var order []string
+
+	for _, mapping := range userCustomInterfaceMapping {
+		mappingMap, ok := mapping.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid type: expected map[string]interface{}, got %T", mapping)
+		}
+
+		logicalIfName, ok := mappingMap["logical_ifname"].(string)
+		if !ok || logicalIfName == "" {
+			return nil, fmt.Errorf("logical_ifname must be a non-empty string")
+		}
+
+		order = append(order, logicalIfName)
+	}
+
+	return order, nil
+}
+
+func populateInterfaces(d *schema.ResourceData, edgeSpoke *goaviatrix.EdgeSpoke) error {
+	interfacesRaw, ok := d.Get("interfaces").(*schema.Set)
+	if !ok {
+		return fmt.Errorf("failed to get interfaces: expected *schema.Set, got %T", d.Get("interfaces"))
+	}
+
+	interfaces := interfacesRaw.List()
+	for _, if0 := range interfaces {
+		if1, ok := if0.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("failed to get interface: expected map[string]interface{}, got %T", if0)
+		}
+
+		if2, err := buildEdgeSpokeInterface(if1)
+		if err != nil {
+			return err
+		}
+
+		edgeSpoke.InterfaceList = append(edgeSpoke.InterfaceList, if2)
+	}
+	return nil
+}
+
+func buildEdgeSpokeInterface(if1 map[string]interface{}) (*goaviatrix.EdgeSpokeInterface, error) {
+	ifName, err := getStringFromMap(if1, "name")
+	if err != nil {
+		return nil, err
+	}
+
+	ifType, err := getStringFromMap(if1, "type")
+	if err != nil {
+		return nil, err
+	}
+
+	enableDhcp, err := getBoolFromMap(if1, "enable_dhcp")
+	if err != nil {
+		return nil, err
+	}
+
+	publicIP, err := getStringFromMap(if1, "wan_public_ip")
+	if err != nil {
+		return nil, err
+	}
+
+	ipAddr, err := getStringFromMap(if1, "ip_address")
+	if err != nil {
+		return nil, err
+	}
+
+	gatewayIP, err := getStringFromMap(if1, "gateway_ip")
+	if err != nil {
+		return nil, err
+	}
+
+	tag, err := getStringFromMap(if1, "tag")
+	if err != nil {
+		return nil, err
+	}
+
+	if2 := &goaviatrix.EdgeSpokeInterface{
+		IfName:    ifName,
+		Type:      ifType,
+		Dhcp:      enableDhcp,
+		PublicIp:  publicIP,
+		IpAddr:    ipAddr,
+		GatewayIp: gatewayIP,
+		Tag:       tag,
+	}
+
+	if ifType == "LAN" {
+		if err := populateLANFields(if1, if2); err != nil {
+			return nil, err
+		}
+	}
+
+	return if2, nil
+}
+
+func populateLANFields(if1 map[string]interface{}, if2 *goaviatrix.EdgeSpokeInterface) error {
+	enableVrrp, err := getBoolFromMap(if1, "enable_vrrp")
+	if err != nil {
+		return err
+	}
+
+	virtualIP, err := getStringFromMap(if1, "vrrp_virtual_ip")
+	if err != nil {
+		return err
+	}
+
+	if2.VrrpState = enableVrrp
+	if2.VirtualIp = virtualIP
+	return nil
+}
+
+func populateVlans(d *schema.ResourceData, edgeSpoke *goaviatrix.EdgeSpoke) error {
+	vlanRaw, ok := d.Get("vlan").(*schema.Set)
+	if !ok {
+		return fmt.Errorf("failed to get vlan: expected *schema.Set, got %T", d.Get("vlan"))
+	}
+
+	vlan := vlanRaw.List()
+	for _, vlan0 := range vlan {
+		vlan1, ok := vlan0.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("failed to get vlan entry: expected map[string]interface{}, got %T", vlan0)
+		}
+
+		vlan2, err := buildEdgeSpokeVlan(vlan1)
+		if err != nil {
+			return err
+		}
+
+		edgeSpoke.VlanList = append(edgeSpoke.VlanList, vlan2)
+	}
+	return nil
+}
+
+func buildEdgeSpokeVlan(vlan1 map[string]interface{}) (*goaviatrix.EdgeSpokeVlan, error) {
+	parentInterface, err := getStringFromMap(vlan1, "parent_interface_name")
+	if err != nil {
+		return nil, err
+	}
+
+	ipAddr, err := getStringFromMap(vlan1, "ip_address")
+	if err != nil {
+		return nil, err
+	}
+
+	gatewayIP, err := getStringFromMap(vlan1, "gateway_ip")
+	if err != nil {
+		return nil, err
+	}
+
+	peerIPAddr, err := getStringFromMap(vlan1, "peer_ip_address")
+	if err != nil {
+		return nil, err
+	}
+
+	peerGatewayIP, err := getStringFromMap(vlan1, "peer_gateway_ip")
+	if err != nil {
+		return nil, err
+	}
+
+	virtualIP, err := getStringFromMap(vlan1, "vrrp_virtual_ip")
+	if err != nil {
+		return nil, err
+	}
+
+	tag, err := getStringFromMap(vlan1, "tag")
+	if err != nil {
+		return nil, err
+	}
+
+	vlanID, err := getIntFromMap(vlan1, "vlan_id")
+	if err != nil {
+		return nil, err
+	}
+
+	return &goaviatrix.EdgeSpokeVlan{
+		ParentInterface: parentInterface,
+		IpAddr:          ipAddr,
+		GatewayIp:       gatewayIP,
+		PeerIpAddr:      peerIPAddr,
+		PeerGatewayIp:   peerGatewayIP,
+		VirtualIp:       virtualIP,
+		Tag:             tag,
+		VlanId:          strconv.Itoa(vlanID),
+	}, nil
+}
+
+func populateCustomInterfaceMapping(d *schema.ResourceData, edgeSpoke *goaviatrix.EdgeSpoke) error {
+	customInterfaceMapping, ok := d.Get("custom_interface_mapping").([]interface{})
+	if ok {
+		customInterfaceMap, err := getCustomInterfaceMapDetails(customInterfaceMapping)
+		if err != nil {
+			return err
+		}
+		edgeSpoke.CustomInterfaceMapping = customInterfaceMap
+	}
+	return nil
+}
+
+func getStringFromMap(data map[string]interface{}, key string) (string, error) {
+	value, ok := data[key].(string)
+	if !ok {
+		return "", fmt.Errorf("invalid type for '%s': expected string, got %T", key, data[key])
+	}
+	return value, nil
+}
+
+func getBoolFromMap(data map[string]interface{}, key string) (bool, error) {
+	value, ok := data[key].(bool)
+	if !ok {
+		return false, fmt.Errorf("invalid type for '%s': expected bool, got %T", key, data[key])
+	}
+	return value, nil
+}
+
+func getIntFromMap(data map[string]interface{}, key string) (int, error) {
+	value, ok := data[key].(int)
+	if !ok {
+		return 0, fmt.Errorf("invalid type for '%s': expected int, got %T", key, data[key])
+	}
+	return value, nil
+}

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_helper_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_helper_test.go
@@ -1,0 +1,737 @@
+package aviatrix
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestValidateIdentifierValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     interface{}
+		expectErr bool
+	}{
+		{
+			name:      "Valid auto value",
+			input:     "auto",
+			expectErr: false,
+		},
+		{
+			name:      "Valid MAC address",
+			input:     "00:1A:2B:3C:4D:5E",
+			expectErr: false,
+		},
+		{
+			name:      "Valid PCI ID",
+			input:     "0000:00:1f.2",
+			expectErr: false,
+		},
+		{
+			name:      "Invalid MAC address",
+			input:     "00:1A:2B:3C:4D",
+			expectErr: true,
+		},
+		{
+			name:      "Invalid PCI ID",
+			input:     "0000:00:1f",
+			expectErr: true,
+		},
+		{
+			name:      "Invalid random string",
+			input:     "invalid_value",
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, errs := validateIdentifierValue(test.input, "identifier_value")
+			if test.expectErr && len(errs) == 0 {
+				t.Errorf("expected an error but got none for input: %v", test.input)
+			}
+			if !test.expectErr && len(errs) > 0 {
+				t.Errorf("did not expect an error but got: %v for input: %v", errs, test.input)
+			}
+		})
+	}
+}
+
+func TestGetCustomInterfaceMapDetails(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               []interface{}
+		expected            map[string]goaviatrix.CustomInterfaceMap
+		expectErr           bool
+		expectedErrorString string
+	}{
+		{
+			name: "Valid input",
+			input: []interface{}{
+				map[string]interface{}{
+					"logical_ifname":   "wan0",
+					"identifier_type":  "mac",
+					"identifier_value": "00:1A:2B:3C:4D:5E",
+				},
+				map[string]interface{}{
+					"logical_ifname":   "mgmt0",
+					"identifier_type":  "pci",
+					"identifier_value": "0000:00:1f.2",
+				},
+			},
+			expected: map[string]goaviatrix.CustomInterfaceMap{
+				"wan0": {
+					IdentifierType:  "mac",
+					IdentifierValue: "00:1A:2B:3C:4D:5E",
+				},
+				"mgmt0": {
+					IdentifierType:  "pci",
+					IdentifierValue: "0000:00:1f.2",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Invalid input type",
+			input: []interface{}{
+				"invalid-entry",
+			},
+			expectErr:           true,
+			expectedErrorString: "invalid type: expected map[string]interface{}, got string",
+		},
+		{
+			name: "Missing logical_ifname",
+			input: []interface{}{
+				map[string]interface{}{
+					"identifier_type":  "mac",
+					"identifier_value": "00:1A:2B:3C:4D:5E",
+				},
+			},
+			expectErr:           true,
+			expectedErrorString: "logical interface name must be a string",
+		},
+		{
+			name: "Missing identifier_type",
+			input: []interface{}{
+				map[string]interface{}{
+					"logical_ifname":   "wan0",
+					"identifier_value": "00:1A:2B:3C:4D:5E",
+				},
+			},
+			expectErr:           true,
+			expectedErrorString: "identifier type must be a string",
+		},
+		{
+			name: "Missing identifier_value",
+			input: []interface{}{
+				map[string]interface{}{
+					"logical_ifname":  "wan0",
+					"identifier_type": "mac",
+				},
+			},
+			expectErr:           true,
+			expectedErrorString: "identifier value must be a string",
+		},
+		{
+			name:      "Empty input",
+			input:     []interface{}{},
+			expected:  map[string]goaviatrix.CustomInterfaceMap{},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := getCustomInterfaceMapDetails(test.input)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				} else if err.Error() != test.expectedErrorString {
+					t.Errorf("expected error: %s, got: %s", test.expectedErrorString, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("did not expect an error but got: %s", err)
+				}
+				if !reflect.DeepEqual(result, test.expected) {
+					t.Errorf("expected result: %+v, got: %+v", test.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestSetCustomInterfaceMapping(t *testing.T) {
+	tests := []struct {
+		name                     string
+		customInterfaceMap       map[string]goaviatrix.CustomInterfaceMap
+		userCustomInterfaceOrder []string
+		expected                 []interface{}
+		expectErr                bool
+		expectedError            string
+	}{
+		{
+			name: "Valid input with correct order",
+			customInterfaceMap: map[string]goaviatrix.CustomInterfaceMap{
+				"WAN0": {
+					IdentifierType:  "mac",
+					IdentifierValue: "00:1A:2B:3C:4D:5E",
+				},
+				"MGMT0": {
+					IdentifierType:  "pci",
+					IdentifierValue: "0000:00:1f.2",
+				},
+			},
+			userCustomInterfaceOrder: []string{"mgmt0", "wan0"},
+			expected: []interface{}{
+				map[string]interface{}{
+					"logical_ifname":   "mgmt0",
+					"identifier_type":  "pci",
+					"identifier_value": "0000:00:1f.2",
+				},
+				map[string]interface{}{
+					"logical_ifname":   "wan0",
+					"identifier_type":  "mac",
+					"identifier_value": "00:1A:2B:3C:4D:5E",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Logical interface name not found",
+			customInterfaceMap: map[string]goaviatrix.CustomInterfaceMap{
+				"WAN0": {
+					IdentifierType:  "mac",
+					IdentifierValue: "00:1A:2B:3C:4D:5E",
+				},
+			},
+			userCustomInterfaceOrder: []string{"mgmt0"},
+			expectErr:                true,
+			expectedError:            "logical interface name mgmt0 not found in custom interface map",
+		},
+		{
+			name: "Empty identifier type",
+			customInterfaceMap: map[string]goaviatrix.CustomInterfaceMap{
+				"WAN0": {
+					IdentifierType:  "",
+					IdentifierValue: "00:1A:2B:3C:4D:5E",
+				},
+			},
+			userCustomInterfaceOrder: []string{"wan0"},
+			expectErr:                true,
+			expectedError:            "identifier type cannot be empty for logical interface: wan0",
+		},
+		{
+			name: "Empty identifier value",
+			customInterfaceMap: map[string]goaviatrix.CustomInterfaceMap{
+				"WAN0": {
+					IdentifierType:  "mac",
+					IdentifierValue: "",
+				},
+			},
+			userCustomInterfaceOrder: []string{"wan0"},
+			expectErr:                true,
+			expectedError:            "identifier value cannot be empty for logical interface: wan0",
+		},
+		{
+			name: "Valid input with mixed case logical interface names",
+			customInterfaceMap: map[string]goaviatrix.CustomInterfaceMap{
+				"WAN0": {
+					IdentifierType:  "mac",
+					IdentifierValue: "00:1A:2B:3C:4D:5E",
+				},
+				"MGMT0": {
+					IdentifierType:  "pci",
+					IdentifierValue: "0000:00:1f.2",
+				},
+			},
+			userCustomInterfaceOrder: []string{"mgmt0", "wan0"},
+			expected: []interface{}{
+				map[string]interface{}{
+					"logical_ifname":   "mgmt0",
+					"identifier_type":  "pci",
+					"identifier_value": "0000:00:1f.2",
+				},
+				map[string]interface{}{
+					"logical_ifname":   "wan0",
+					"identifier_type":  "mac",
+					"identifier_value": "00:1A:2B:3C:4D:5E",
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := setCustomInterfaceMapping(test.customInterfaceMap, test.userCustomInterfaceOrder)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				} else if err.Error() != test.expectedError {
+					t.Errorf("expected error: %s, got: %s", test.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("did not expect an error but got: %s", err)
+				}
+				if !reflect.DeepEqual(result, test.expected) {
+					t.Errorf("expected result: %+v, got: %+v", test.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestGetCustomInterfaceOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []interface{}
+		expected      []string
+		expectErr     bool
+		expectedError string
+	}{
+		{
+			name: "Valid input",
+			input: []interface{}{
+				map[string]interface{}{
+					"logical_ifname": "wan0",
+				},
+				map[string]interface{}{
+					"logical_ifname": "mgmt0",
+				},
+			},
+			expected:  []string{"wan0", "mgmt0"},
+			expectErr: false,
+		},
+		{
+			name: "Invalid type in mapping",
+			input: []interface{}{
+				"invalid_type",
+			},
+			expectErr:     true,
+			expectedError: "invalid type: expected map[string]interface{}, got string",
+		},
+		{
+			name: "Missing logical_ifname",
+			input: []interface{}{
+				map[string]interface{}{
+					"identifier_type": "mac",
+				},
+			},
+			expectErr:     true,
+			expectedError: "logical_ifname must be a non-empty string",
+		},
+		{
+			name: "Empty logical_ifname",
+			input: []interface{}{
+				map[string]interface{}{
+					"logical_ifname": "",
+				},
+			},
+			expectErr:     true,
+			expectedError: "logical_ifname must be a non-empty string",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := getCustomInterfaceOrder(test.input)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				} else if err.Error() != test.expectedError {
+					t.Errorf("expected error: %s, got: %s", test.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("did not expect an error but got: %s", err)
+				}
+				if !reflect.DeepEqual(result, test.expected) {
+					t.Errorf("expected result: %+v, got: %+v", test.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildEdgeSpokeInterface(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         map[string]interface{}
+		expected      *goaviatrix.EdgeSpokeInterface
+		expectErr     bool
+		expectedError string
+	}{
+		{
+			name: "Valid input for non-LAN interface",
+			input: map[string]interface{}{
+				"name":          "eth0",
+				"type":          "WAN",
+				"enable_dhcp":   true,
+				"wan_public_ip": "192.168.1.1",
+				"ip_address":    "192.168.1.2",
+				"gateway_ip":    "192.168.1.254",
+				"tag":           "tag1",
+			},
+			expected: &goaviatrix.EdgeSpokeInterface{
+				IfName:    "eth0",
+				Type:      "WAN",
+				Dhcp:      true,
+				PublicIp:  "192.168.1.1",
+				IpAddr:    "192.168.1.2",
+				GatewayIp: "192.168.1.254",
+				Tag:       "tag1",
+			},
+			expectErr: false,
+		},
+		{
+			name: "Valid input for LAN interface",
+			input: map[string]interface{}{
+				"name":            "eth1",
+				"type":            "LAN",
+				"enable_dhcp":     false,
+				"wan_public_ip":   "192.168.2.1",
+				"ip_address":      "192.168.2.2",
+				"gateway_ip":      "192.168.2.254",
+				"tag":             "tag2",
+				"enable_vrrp":     true,
+				"vrrp_virtual_ip": "192.168.2.100",
+			},
+			expected: &goaviatrix.EdgeSpokeInterface{
+				IfName:    "eth1",
+				Type:      "LAN",
+				Dhcp:      false,
+				PublicIp:  "192.168.2.1",
+				IpAddr:    "192.168.2.2",
+				GatewayIp: "192.168.2.254",
+				Tag:       "tag2",
+				VrrpState: true,
+				VirtualIp: "192.168.2.100",
+			},
+			expectErr: false,
+		},
+		{
+			name: "Missing required field: name",
+			input: map[string]interface{}{
+				"type":          "WAN",
+				"enable_dhcp":   true,
+				"wan_public_ip": "192.168.1.1",
+				"ip_address":    "192.168.1.2",
+				"gateway_ip":    "192.168.1.254",
+				"tag":           "tag1",
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'name': expected string, got <nil>",
+		},
+		{
+			name: "Missing required field: type",
+			input: map[string]interface{}{
+				"name":          "eth0",
+				"enable_dhcp":   true,
+				"wan_public_ip": "192.168.1.1",
+				"ip_address":    "192.168.1.2",
+				"gateway_ip":    "192.168.1.254",
+				"tag":           "tag1",
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'type': expected string, got <nil>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := buildEdgeSpokeInterface(test.input)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				} else if err.Error() != test.expectedError {
+					t.Errorf("expected error: %s, got: %s", test.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("did not expect an error but got: %s", err)
+				}
+				if !reflect.DeepEqual(result, test.expected) {
+					t.Errorf("expected result: %+v, got: %+v", test.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestPopulateLANFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         map[string]interface{}
+		expected      *goaviatrix.EdgeSpokeInterface
+		expectErr     bool
+		expectedError string
+	}{
+		{
+			name: "Valid input",
+			input: map[string]interface{}{
+				"enable_vrrp":     true,
+				"vrrp_virtual_ip": "192.168.1.100",
+			},
+			expected: &goaviatrix.EdgeSpokeInterface{
+				VrrpState: true,
+				VirtualIp: "192.168.1.100",
+			},
+			expectErr: false,
+		},
+		{
+			name: "Missing enable_vrrp field",
+			input: map[string]interface{}{
+				"vrrp_virtual_ip": "192.168.1.100",
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'enable_vrrp': expected bool, got <nil>",
+		},
+		{
+			name: "Missing vrrp_virtual_ip field",
+			input: map[string]interface{}{
+				"enable_vrrp": true,
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'vrrp_virtual_ip': expected string, got <nil>",
+		},
+		{
+			name: "Invalid type for enable_vrrp",
+			input: map[string]interface{}{
+				"enable_vrrp":     "true",
+				"vrrp_virtual_ip": "192.168.1.100",
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'enable_vrrp': expected bool, got string",
+		},
+		{
+			name: "Invalid type for vrrp_virtual_ip",
+			input: map[string]interface{}{
+				"enable_vrrp":     true,
+				"vrrp_virtual_ip": 12345,
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'vrrp_virtual_ip': expected string, got int",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if2 := &goaviatrix.EdgeSpokeInterface{}
+			err := populateLANFields(test.input, if2)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				} else if err.Error() != test.expectedError {
+					t.Errorf("expected error: %s, got: %s", test.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("did not expect an error but got: %s", err)
+				}
+				if !reflect.DeepEqual(if2, test.expected) {
+					t.Errorf("expected result: %+v, got: %+v", test.expected, if2)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildEdgeSpokeVlan(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         map[string]interface{}
+		expected      *goaviatrix.EdgeSpokeVlan
+		expectErr     bool
+		expectedError string
+	}{
+		{
+			name: "Valid input",
+			input: map[string]interface{}{
+				"parent_interface_name": "eth0",
+				"ip_address":            "192.168.1.2",
+				"gateway_ip":            "192.168.1.254",
+				"peer_ip_address":       "192.168.1.3",
+				"peer_gateway_ip":       "192.168.1.253",
+				"vrrp_virtual_ip":       "192.168.1.100",
+				"tag":                   "tag1",
+				"vlan_id":               100,
+			},
+			expected: &goaviatrix.EdgeSpokeVlan{
+				ParentInterface: "eth0",
+				IpAddr:          "192.168.1.2",
+				GatewayIp:       "192.168.1.254",
+				PeerIpAddr:      "192.168.1.3",
+				PeerGatewayIp:   "192.168.1.253",
+				VirtualIp:       "192.168.1.100",
+				Tag:             "tag1",
+				VlanId:          "100",
+			},
+			expectErr: false,
+		},
+		{
+			name: "Missing parent_interface_name",
+			input: map[string]interface{}{
+				"ip_address":      "192.168.1.2",
+				"gateway_ip":      "192.168.1.254",
+				"peer_ip_address": "192.168.1.3",
+				"peer_gateway_ip": "192.168.1.253",
+				"vrrp_virtual_ip": "192.168.1.100",
+				"tag":             "tag1",
+				"vlan_id":         100,
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'parent_interface_name': expected string, got <nil>",
+		},
+		{
+			name: "Invalid type for vlan_id",
+			input: map[string]interface{}{
+				"parent_interface_name": "eth0",
+				"ip_address":            "192.168.1.2",
+				"gateway_ip":            "192.168.1.254",
+				"peer_ip_address":       "192.168.1.3",
+				"peer_gateway_ip":       "192.168.1.253",
+				"vrrp_virtual_ip":       "192.168.1.100",
+				"tag":                   "tag1",
+				"vlan_id":               "invalid",
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'vlan_id': expected int, got string",
+		},
+		{
+			name: "Missing ip_address",
+			input: map[string]interface{}{
+				"parent_interface_name": "eth0",
+				"gateway_ip":            "192.168.1.254",
+				"peer_ip_address":       "192.168.1.3",
+				"peer_gateway_ip":       "192.168.1.253",
+				"vrrp_virtual_ip":       "192.168.1.100",
+				"tag":                   "tag1",
+				"vlan_id":               100,
+			},
+			expectErr:     true,
+			expectedError: "invalid type for 'ip_address': expected string, got <nil>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := buildEdgeSpokeVlan(test.input)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				} else if err.Error() != test.expectedError {
+					t.Errorf("expected error: %s, got: %s", test.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("did not expect an error but got: %s", err)
+				}
+				if !reflect.DeepEqual(result, test.expected) {
+					t.Errorf("expected result: %+v, got: %+v", test.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestPopulateCustomInterfaceMapping(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         map[string]interface{}
+		expected      map[string]goaviatrix.CustomInterfaceMap
+		expectErr     bool
+		expectedError string
+	}{
+		{
+			name: "Valid input",
+			input: map[string]interface{}{
+				"custom_interface_mapping": []interface{}{
+					map[string]interface{}{
+						"logical_ifname":   "wan0",
+						"identifier_type":  "mac",
+						"identifier_value": "00:1A:2B:3C:4D:5E",
+					},
+					map[string]interface{}{
+						"logical_ifname":   "mgmt0",
+						"identifier_type":  "pci",
+						"identifier_value": "0000:00:1f.2",
+					},
+				},
+			},
+			expected: map[string]goaviatrix.CustomInterfaceMap{
+				"wan0": {
+					IdentifierType:  "mac",
+					IdentifierValue: "00:1A:2B:3C:4D:5E",
+				},
+				"mgmt0": {
+					IdentifierType:  "pci",
+					IdentifierValue: "0000:00:1f.2",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Empty custom_interface_mapping",
+			input: map[string]interface{}{
+				"custom_interface_mapping": []interface{}{},
+			},
+			expected:  map[string]goaviatrix.CustomInterfaceMap{},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+				"custom_interface_mapping": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"logical_ifname": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"identifier_type": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"identifier_value": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			}, test.input)
+
+			edgeSpoke := &goaviatrix.EdgeSpoke{}
+			err := populateCustomInterfaceMapping(d, edgeSpoke)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				} else if err.Error() != test.expectedError {
+					t.Errorf("expected error: %s, got: %s", test.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("did not expect an error but got: %s", err)
+				}
+				if !reflect.DeepEqual(edgeSpoke.CustomInterfaceMapping, test.expected) {
+					t.Errorf("expected result: %+v, got: %+v", test.expected, edgeSpoke.CustomInterfaceMapping)
+				}
+			}
+		})
+	}
+}

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
@@ -97,9 +97,9 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 		ip_address  = "172.16.15.162/20"
 		gateway_ip  = "172.16.0.1"
 	}
-	
+
 	custom_interface_mapping {
-	    logical_ifname = "wan0"
+		logical_ifname = "wan0"
 		identifier_type = "mac"
 		identifier_value = "00:00:00:00:00:00"
 	}
@@ -108,7 +108,7 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 		logical_ifname = "lan0"
 		identifier_type = "mac"
 		identifier_value = "00:00:00:00:00:00"
-    }
+	}
 
 	custom_interface_mapping {
 		logical_ifname = "mgmt0"

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
@@ -41,6 +41,15 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.dns_server_ip", "8.8.8.8"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.secondary_dns_server_ip", "9.9.9.9"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.2.logical_ifname", "wan0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.2.identifier_type", "mac"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.2.identifier_value", "00:00:00:00:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.1.logical_ifname", "lan0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.1.identifier_type", "mac"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.1.identifier_value", "00:00:00:00:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.0.logical_ifname", "mgmt0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.0.identifier_type", "mac"),
+					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.0.identifier_value", "00:00:00:00:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
@@ -87,6 +96,24 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 		enable_dhcp = false
 		ip_address  = "172.16.15.162/20"
 		gateway_ip  = "172.16.0.1"
+	}
+	
+	custom_interface_mapping {
+	    logical_ifname = "wan0"
+		identifier_type = "mac"
+		identifier_value = "00:00:00:00:00:00"
+	}
+
+	custom_interface_mapping {
+		logical_ifname = "lan0"
+		identifier_type = "mac"
+		identifier_value = "00:00:00:00:00:00"
+    }
+
+	custom_interface_mapping {
+		logical_ifname = "mgmt0"
+		identifier_type = "mac"
+		identifier_value = "00:00:00:00:00:00"
 	}
 }
   `, gwName, siteId, path)

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -48,6 +48,24 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
     ip_address  = "172.16.15.162/20"
     gateway_ip  = "172.16.0.1"
   }
+
+  custom_interface_mapping {
+	  logical_ifname   = "wan0"
+    identifier_type  = "system-assigned"
+    identifier_value = "auto"
+  }
+
+  custom_interface_mapping {
+    logical_ifname   = "lan0"
+    identifier_type  = "mac"
+    identifier_value = "00:0c:29:63:82:b2"
+  }
+
+  custom_interface_mapping {
+    logical_ifname   = "mgmt0"
+    identifier_type  = "pci"
+    identifier_value = "pci@0000:04:00.0"
+  }
 }
 ```
 
@@ -103,6 +121,10 @@ The following arguments are supported:
   * `peer_gateway_ip` - (Optional) LAN sub-interface gateway IP on HA gateway.
   * `vrrp_virtual_ip` - (Optional) LAN sub-interface virtual IP.
   * `tag` - (Optional) Tag.
+* `custom_interface_mapping` - (Optional) A list of custom interface mappings containing logical interfaces mapped to mac addresses or pci id's.
+  * `logical_ifname` - (Required) Logical interface name must start with 'wan','lan' or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt0', 'lan0').
+  * `idenitifer_type` - (Required) Type of identifier used to map the logical interface to the physical interface e.g., mac, pci, system-assigned.
+  * `idenitifer_value` - (Required) Value of the identifier used to map the logical interface to the physical interface. Can be a MAC address, PCI ID, or auto if system-assigned.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -50,7 +50,7 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
   }
 
   custom_interface_mapping {
-	  logical_ifname   = "wan0"
+    logical_ifname   = "wan0"
     identifier_type  = "system-assigned"
     identifier_value = "auto"
   }

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -54,7 +54,8 @@ type EdgeSpoke struct {
 	InterfaceList                      []*EdgeSpokeInterface
 	Interfaces                         string `json:"interfaces,omitempty"`
 	VlanList                           []*EdgeSpokeVlan
-	Vlan                               string `json:"vlan,omitempty"`
+	Vlan                               string                        `json:"vlan,omitempty"`
+	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
 }
 
 type EdgeSpokeInterface struct {
@@ -70,6 +71,11 @@ type EdgeSpokeInterface struct {
 	VrrpState     bool             `json:"vrrp_state,omitempty"`
 	VirtualIp     string           `json:"virtual_ip,omitempty"`
 	Tag           string           `json:"tag,omitempty"`
+}
+
+type CustomInterfaceMap struct {
+	IdentifierType  string `json:"identifier_type"`
+	IdentifierValue string `json:"identifier_value"`
 }
 
 type EdgeSpokeVlan struct {
@@ -96,22 +102,23 @@ type EdgeSpokeResp struct {
 	EnableEdgeActiveStandbyPreemptive  bool   `json:"edge_active_standby_preemptive"`
 	LocalAsNumber                      string `json:"local_as_number"`
 	PrependAsPath                      []string
-	PrependAsPathReturn                string                `json:"prepend_as_path"`
-	IncludeCidrList                    []string              `json:"include_cidr_list"`
-	EnableLearnedCidrsApproval         bool                  `json:"enable_learned_cidrs_approval"`
-	ApprovedLearnedCidrs               []string              `form:"approved_learned_cidrs,omitempty"`
-	SpokeBgpManualAdvertisedCidrs      []string              `json:"bgp_manual_spoke_advertise_cidrs"`
-	EnablePreserveAsPath               bool                  `json:"preserve_as_path"`
-	BgpPollingTime                     int                   `json:"bgp_polling_time"`
-	BgpBfdPollingTime                  int                   `json:"bgp_neighbor_status_polling_time"`
-	BgpHoldTime                        int                   `json:"bgp_hold_time"`
-	EnableEdgeTransitiveRouting        bool                  `json:"edge_transitive_routing"`
-	EnableJumboFrame                   bool                  `json:"jumbo_frame"`
-	Latitude                           float64               `json:"latitude"`
-	Longitude                          float64               `json:"longitude"`
-	RxQueueSize                        string                `json:"rx_queue_size"`
-	State                              string                `json:"vpc_state"`
-	InterfaceList                      []*EdgeSpokeInterface `json:"interfaces"`
+	PrependAsPathReturn                string                        `json:"prepend_as_path"`
+	IncludeCidrList                    []string                      `json:"include_cidr_list"`
+	EnableLearnedCidrsApproval         bool                          `json:"enable_learned_cidrs_approval"`
+	ApprovedLearnedCidrs               []string                      `form:"approved_learned_cidrs,omitempty"`
+	SpokeBgpManualAdvertisedCidrs      []string                      `json:"bgp_manual_spoke_advertise_cidrs"`
+	EnablePreserveAsPath               bool                          `json:"preserve_as_path"`
+	BgpPollingTime                     int                           `json:"bgp_polling_time"`
+	BgpBfdPollingTime                  int                           `json:"bgp_neighbor_status_polling_time"`
+	BgpHoldTime                        int                           `json:"bgp_hold_time"`
+	EnableEdgeTransitiveRouting        bool                          `json:"edge_transitive_routing"`
+	EnableJumboFrame                   bool                          `json:"jumbo_frame"`
+	Latitude                           float64                       `json:"latitude"`
+	Longitude                          float64                       `json:"longitude"`
+	RxQueueSize                        string                        `json:"rx_queue_size"`
+	State                              string                        `json:"vpc_state"`
+	InterfaceList                      []*EdgeSpokeInterface         `json:"interfaces"`
+	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
 }
 
 type EdgeSpokeListResp struct {


### PR DESCRIPTION
Adding `custom_interface_mapping` to EAS self-managed gateways
Using these custom mappings, physical ports can be mapped to specific interfaces.

Custom interface mapping works with both MAC and PCI id's. A `system-assigned` option is also available if the user does not want to configure a specific port.

```
resource "aviatrix_edge_gateway_selfmanaged" "edge_self_managed_28" {
    gw_name = "eas_self_managed_28"
    ztp_file_type = "cloud-init"
    ztp_file_download_path = "ztp"
    site_id = "eas-site-28"
    management_egress_ip_prefix_list = [ 
        "162.43.140.85/31"
    ]
    interfaces {
        name = "eth0"
        type = "WAN"
        ip_address = "192.168.16.10/24"
        gateway_ip = "192.168.16.1"
    }

    interfaces {
        name = "eth1"
        type = "LAN"
        ip_address = "192.168.17.10/24"
        gateway_ip = "192.168.17.1"
    }

    interfaces {
        name = "eth2"
        type = "MANAGEMENT"
        enable_dhcp = true
    }

    custom_interface_mapping {
	logical_ifname = "wan0"
        identifier_type = "system-assigned"
        identifier_value = "auto"
    }

    custom_interface_mapping {
        logical_ifname = "lan0"
        identifier_type = "mac"
        identifier_value = "00:0c:29:63:82:b2"
    }

    custom_interface_mapping {
        logical_ifname = "mgmt0"
        identifier_type = "pci"
        identifier_value = "pci@0000:04:00.0"
    }
}
```