### PR TITLE
AVX-64348 Enable jumbo frame by default for CSP transit gateways

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -955,8 +955,12 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			Transit:                  true,
 		}
 
-		// for CSPs the enable_jumbo_frame is set to true by default
-		if _, ok := d.GetOk("enable_jumbo_frame"); !ok {
+		// for CSPs the enable_jumbo_frame is set to true if not explicitly set by the user
+		if val, ok := d.GetOk("enable_jumbo_frame"); ok {
+			enableJumboFrame := val.(bool)
+			gateway.JumboFrame = enableJumboFrame // set to user-provided value
+		} else {
+			gateway.JumboFrame = true // new default for CSPs
 			_ = d.Set("enable_jumbo_frame", true)
 		}
 

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -957,7 +957,10 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 
 		// for CSPs the enable_jumbo_frame is set to true if not explicitly set by the user
 		if val, ok := d.GetOk("enable_jumbo_frame"); ok {
-			enableJumboFrame := val.(bool)
+			enableJumboFrame, ok := val.(bool)
+			if !ok {
+				return fmt.Errorf("enable_jumbo_frame must be a boolean")
+			}
 			gateway.JumboFrame = enableJumboFrame // set to user-provided value
 		} else {
 			gateway.JumboFrame = true // new default for CSPs

--- a/docs/guides/feature-changelist-v8.md
+++ b/docs/guides/feature-changelist-v8.md
@@ -48,4 +48,3 @@ The following attributes are removed:
 |(deprecated)|aviatrix_edge_equinix|aviatrix_dns_profile|**Yes**; please remove this attribute from the config.|
 |(deprecated)|aviatrix_edge_platform|aviatrix_dns_profile|**Yes**; please remove this attribute from the config.|
 |(deprecated)|aviatrix_edge_zededa|aviatrix_dns_profile|**Yes**; please remove this attribute from the config.|
-

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -73,6 +73,7 @@ type TransitVpc struct {
 	LogicalEipMap                map[string][]EipMap `json:"logical_intf_eip_map,omitempty"`
 	ZtpFileDownloadPath          string              `json:"-"`
 	ManagementEgressIPPrefix     string              `json:"mgmt_egress_ip,omitempty"`
+	JumboFrame                   bool                `json:"jumbo_frame,omitempty"`
 }
 
 type TransitGatewayAdvancedConfig struct {


### PR DESCRIPTION
Updating the default behavior of `enable_jumbo_frame` for transit csp gateways.