### PR TITLE
AVX-64348 Enable jumbo frame by default for CSP transit gateways [Backport rc-8.0]

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -484,6 +484,11 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Enable jumbo frame support for transit gateway. Valid values: true or false. Default value: true for CSP transit gateways and false for edge transit gateways.",
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					// Suppress diff if the user has not set the value (i.e., it's null in the config)
+					_, exists := d.GetOk("enable_jumbo_frame")
+					return !exists
+				},
 			},
 			"enable_gro_gso": {
 				Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -483,12 +483,8 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 			"enable_jumbo_frame": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Enable jumbo frame support for transit gateway. Valid values: true or false. Default value: true for CSP transit gateways and false for edge transit gateways.",
-				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
-					// Suppress diff if the user has not set the value (i.e., it's null in the config)
-					_, exists := d.GetOk("enable_jumbo_frame")
-					return !exists
-				},
 			},
 			"enable_gro_gso": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Backport for - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2229
Suppressing the difference for enable_jumbo_frame if the user does not provide the config value.
This handles any refresh state failures for the config.

```
resource "aviatrix_transit_gateway" "aws_transit_1" {
	cloud_type                       = 1
	account_name                     = "AWS"
	gw_name                          = "aws-transit-1"
	vpc_id                           = "vpc-0067620809bef32b2"
	vpc_reg                          = "us-east-2"
	gw_size                          = "t2.micro"
	subnet                           = "10.11.0.48/28"
}
```