### PR TITLE
AVX-64537: extend spoke transit attach timeout

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -133,7 +133,7 @@ func resourceAviatrixSpokeTransitAttachmentCreate(d *schema.ResourceData, meta i
 	flag := false
 	defer resourceAviatrixSpokeTransitAttachmentReadIfRequired(d, meta, &flag)
 
-	timeout := 30 * time.Second
+	timeout := 5 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	try, maxTries, backoff := 0, 10, 1000*time.Millisecond


### PR DESCRIPTION
This PR extends the time out for CreateSpokeTransitAttachment from 30 sec to 5 min. Initially I thought 60 sec would be a good bump but realistically devs might not be aware of this timeout and it was defined arbitrarily not with a specific reason for the amount of time so we should give some breathing room. 5 min is to long by any standard so I figured its a good amount that leaves plenty of breathing room for any changes to the cloudxd workflow that might extend an attachment time.

Update:
Further argument for 5 min extension, multiple attachment calls could be blocked on each other due to locking on the transit GW.

Validated on my dev deployment. Previously this would fail almost 100% of the time due to the timeout being to short.