### PR TITLE
AVX-64537: extend spoke transit attach timeout (#2238) [backport to rc-8.1]

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -133,7 +133,7 @@ func resourceAviatrixSpokeTransitAttachmentCreate(d *schema.ResourceData, meta i
 	flag := false
 	defer resourceAviatrixSpokeTransitAttachmentReadIfRequired(d, meta, &flag)
 
-	timeout := 30 * time.Second
+	timeout := 5 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	try, maxTries, backoff := 0, 10, 1000*time.Millisecond


### PR DESCRIPTION
(cherry picked from commit 5d1ee23c4a29c4c219953a533bb801e21122b1da)