### PR TITLE
AVX-64463: BGP communities create logic fix for transits and spokes

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -670,10 +670,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 	setComm := false
 	commSendCurr, commAcceptCurr, err := client.GetGatewayBgpCommunities(gateway.GwName)
 	acceptComm, ok := d.Get("bgp_accept_communities").(bool)
-	if !ok {
-		return fmt.Errorf("failed to assert bgp_accept_communities as a boolean")
-	}
-	if acceptComm != commAcceptCurr || err != nil {
+	if ok && acceptComm != commAcceptCurr || err != nil {
 		setComm = true
 		err := client.SetGatewayBgpCommunitiesAccept(gateway.GwName, acceptComm)
 		if err != nil {
@@ -1869,10 +1866,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 	commSendCurr, commAcceptCurr, err := client.GetGatewayBgpCommunities(gateway.GwName)
 	if d.HasChange("bgp_accept_communities") {
 		acceptComm, ok := d.Get("bgp_accept_communities").(bool)
-		if !ok {
-			return fmt.Errorf("failed to assert bgp_accept_communities as a boolean")
-		}
-		if acceptComm != commAcceptCurr || err != nil {
+		if ok && acceptComm != commAcceptCurr || err != nil {
 			err := client.SetGatewayBgpCommunitiesAccept(gateway.GwName, acceptComm)
 			if err != nil {
 				return fmt.Errorf("failed to set accept BGP communities for gateway %s: %w", gateway.GwName, err)


### PR DESCRIPTION
Transit creation was throwing errors such as:
```
│ Error: failed to set accept BGP communities for gateway eat-136: rest API set_gateway_accept_bgp_communities_override Post failed: Gateway with name eat-136 does not exist
```
This fixes the terraform logic so that we apply communities attributes only if they are present.