### PR TITLE
AVX-64383: Fix reading smart groups into tfstate (#2220)

### DIFF
--- a/aviatrix/resource_aviatrix_smart_group_test.go
+++ b/aviatrix/resource_aviatrix_smart_group_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
@@ -476,8 +477,9 @@ func testAccSmartGroupDestroy(s *terraform.State) error {
 		}
 
 		_, err := client.GetSmartGroup(context.Background(), rs.Primary.ID)
-		if err == nil || err != goaviatrix.ErrNotFound {
-			return fmt.Errorf("smart group configured when it should be destroyed")
+		expectedError := "App domain not found"
+		if err == nil || !strings.Contains(err.Error(), expectedError) {
+			return fmt.Errorf("smart group configured when it should be destroyed, want %s, got: %w", expectedError, err)
 		}
 	}
 

--- a/goaviatrix/smart_group.go
+++ b/goaviatrix/smart_group.go
@@ -207,16 +207,14 @@ func (c *Client) CreateSmartGroup(ctx context.Context, smartGroup *SmartGroup) (
 func (c *Client) GetSmartGroup(ctx context.Context, uuid string) (*SmartGroup, error) {
 	endpoint := fmt.Sprintf("app-domains/%s", uuid)
 
-	var response struct {
-		Group SmartGroupResult `json:"app_domains"`
-	}
+	var response SmartGroupResult
 
 	err := c.GetAPIContext25(ctx, &response, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return createSmartGroup(response.Group), nil
+	return createSmartGroup(response), nil
 }
 
 func (c *Client) UpdateSmartGroup(ctx context.Context, smartGroup *SmartGroup, uuid string) error {


### PR DESCRIPTION
Backport of #2220 for the 8.1 branch.

This PR fixes the bug where the state of an aviatrix_smart_group is not deserialized correctly from the controller response.
This results in all properties in the tfstate being nil or empty, and every terraform plan being dirty, even immediately after applying.