### PR TITLE
AVX-64358: Add docs for onboarding GKE clusters [Backport 8.1]

### DIFF
--- a/docs/resources/aviatrix_kubernetes_cluster.md
+++ b/docs/resources/aviatrix_kubernetes_cluster.md
@@ -41,6 +41,19 @@ data "azurerm_kubernetes_cluster" "aks_cluster" {
 ```
 
 ```hcl
+# Register an GKE cluster so that the controller allows building Aviatrix Smart Groups from its workloads
+resource "aviatrix_kubernetes_cluster" "gke_cluster" {
+  cluster_id          = data.google_container_cluster.gke_cluster.self_link
+  use_csp_credentials = true
+}
+
+data "google_container_cluster" "gke_cluster" {
+  name     = "mycluster"
+  location = "us-central1"
+}
+```
+
+```hcl
 # Register a custom built cluster in AWS so that the controller allows building Aviatrix Smart Groups from its workloads
 data "aws_vpc" "vpc" {
   tags = {


### PR DESCRIPTION
Backport of #2219 for 8.1
Adds an example for onboarding a GKE cluster.