### PR TITLE
AVX-57382: Converting region to always be lowercase no-space

### DIFF
--- a/goaviatrix/smart_group.go
+++ b/goaviatrix/smart_group.go
@@ -108,6 +108,10 @@ func NewSmartGroupMatchExpression(filterMap map[string]interface{}) *SmartGroupM
 func setFilterInterface(filterField *string, filterMap map[string]interface{}, fieldKey string) {
 	if val, ok := filterMap[fieldKey]; ok {
 		*filterField = val.(string)
+		if fieldKey == RegionKey {
+			// Ensure that the region is always in lowercase, no-space
+			*filterField = strings.ToLower(strings.ReplaceAll(*filterField, " ", ""))
+		}
 	}
 }
 


### PR DESCRIPTION
The region value for Azure might have upper case and space like East US, this needs to be always in lowercase, no space for smartgroup resolver to resolve it when comparing with CAI.

For all the other CSPs the region values are always in lowercase, no-space. So we can do this check universally for all CSPs, which will help us fix the issue with Azure TF.

Tested it by creating a smgrp with:
```
 #Create an Aviatrix Smart Group
resource "aviatrix_smart_group" "test_smart_group_ip" {
  name = "smart-group-src2"
  selector {
    match_expressions {
      type         = "vm"
      region       = "East US"
    }
  }
}

```
And it was resolved correctly with right policies sent to GW.