### PR TITLE
AVX-64737: NAT API failure fix: flush data before encoding

### DIFF
--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -652,11 +652,11 @@ func (c *Client) EnableCustomizedSNat(gateway *Gateway) error {
 
 	var b bytes.Buffer
 	w := zlib.NewWriter(&b)
-	defer w.Close()
 	_, err = w.Write(args)
 	if err != nil {
 		return err
 	}
+	w.Close() // Ensure all data is flushed
 
 	gateway.PolicyList = base64.StdEncoding.EncodeToString(b.Bytes())
 	gateway.Compress = true
@@ -681,11 +681,11 @@ func (c *Client) DisableCustomSNat(gateway *Gateway) error {
 
 	var b bytes.Buffer
 	w := zlib.NewWriter(&b)
-	defer w.Close()
 	_, err = w.Write(args)
 	if err != nil {
 		return err
 	}
+	w.Close() // Ensure all data is flushed
 
 	gateway.PolicyList = base64.StdEncoding.EncodeToString(b.Bytes())
 	gateway.Compress = true


### PR DESCRIPTION
Problem: getting "Error reading decompressed data: unexpected EOF" when sending NAT API with encoded data.
Fix: To ensure that all data is flushed before encoding, explicitly call w.Close() before accessing b.Bytes() (defer w.Close() flush at the function end which is too late).

problem reproduced and fix verified.