### PR TITLE
AVX-63900 Reverting the changes for custom interface mapping in self managed spoke gateways [Backport rc-8.1]

### DIFF
--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
@@ -41,15 +41,6 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "10.230.5.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.dns_server_ip", "8.8.8.8"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.secondary_dns_server_ip", "9.9.9.9"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.2.logical_ifname", "wan0"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.2.identifier_type", "mac"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.2.identifier_value", "00:00:00:00:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.1.logical_ifname", "lan0"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.1.identifier_type", "mac"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.1.identifier_value", "00:00:00:00:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.0.logical_ifname", "mgmt0"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.0.identifier_type", "mac"),
-					resource.TestCheckResourceAttr(resourceName, "custom_interface_mapping.0.identifier_value", "00:00:00:00:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
 				),
@@ -96,24 +87,6 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 		enable_dhcp = false
 		ip_address  = "172.16.15.162/20"
 		gateway_ip  = "172.16.0.1"
-	}
-
-	custom_interface_mapping {
-		logical_ifname = "wan0"
-		identifier_type = "mac"
-		identifier_value = "00:00:00:00:00:00"
-	}
-
-	custom_interface_mapping {
-		logical_ifname = "lan0"
-		identifier_type = "mac"
-		identifier_value = "00:00:00:00:00:00"
-	}
-
-	custom_interface_mapping {
-		logical_ifname = "mgmt0"
-		identifier_type = "mac"
-		identifier_value = "00:00:00:00:00:00"
 	}
 }
   `, gwName, siteId, path)

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -48,24 +48,6 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
     ip_address  = "172.16.15.162/20"
     gateway_ip  = "172.16.0.1"
   }
-
-  custom_interface_mapping {
-    logical_ifname   = "wan0"
-    identifier_type  = "system-assigned"
-    identifier_value = "auto"
-  }
-
-  custom_interface_mapping {
-    logical_ifname   = "lan0"
-    identifier_type  = "mac"
-    identifier_value = "00:0c:29:63:82:b2"
-  }
-
-  custom_interface_mapping {
-    logical_ifname   = "mgmt0"
-    identifier_type  = "pci"
-    identifier_value = "pci@0000:04:00.0"
-  }
 }
 ```
 
@@ -121,10 +103,6 @@ The following arguments are supported:
   * `peer_gateway_ip` - (Optional) LAN sub-interface gateway IP on HA gateway.
   * `vrrp_virtual_ip` - (Optional) LAN sub-interface virtual IP.
   * `tag` - (Optional) Tag.
-* `custom_interface_mapping` - (Optional) A list of custom interface mappings containing logical interfaces mapped to mac addresses or pci id's.
-  * `logical_ifname` - (Required) Logical interface name must start with 'wan','lan' or 'mgmt' followed by a number (e.g., 'wan0', 'mgmt0', 'lan0').
-  * `identifier_type` - (Required) Type of identifier used to map the logical interface to the physical interface e.g., mac, pci, system-assigned.
-  * `identifier_value` - (Required) Value of the identifier used to map the logical interface to the physical interface. Can be a MAC address, PCI ID, or auto if system-assigned.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Backport for https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2245
- Reverting the custom interface mapping changes from this PR - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2210
- Keeping the custom interface mapping helper functions for future implementation support.

This custom mapping will be useful for self-managed platforms like ESXi and KVM. When a VM is deployed on these platforms, the interfaces might not follow PCI ordering, which has caused issues in the past. Determining the actual interface pattern and configuring the correct interface_mapping for such platforms has been a challenge. Using MAC addresses or PCI bus IDs as the basis for mapping would provide a more deterministic and flexible way to discover and configure interfaces, potentially even dynamically at runtime, instead of doing it all at boot time.

However, we have decided not to include this in version 8.1 for the following reasons:

In 8.1, cloud_init not only includes edge metadata but also contains the ZTP (Zero Touch Provisioning) code that brings up the edge and transitions it to phase-2. Adding support for this custom mapping—along with the code to handle it—would increase the size of the cloud_init file, potentially exceeding 16 KB. This would require an updated implementation by the Edge team to support containerized ESXi/KVM gateways. Specifically, the interface mapping would need to be split—initially bringing up only the management interface and deferring the rest of the interface configuration to phase-2. This would involve careful planning and rework, which is not feasible for 8.1 as we are already past CF1.

Furthermore, starting in 8.1, even self-managed edges support image upgrades via the config. This means a new cloud_init file can be downloaded and used without requiring deletion and recreation of the edge configuration in the controller. However, this custom mapping based on MAC or PCI IDs adds complexity during image upgrades—especially for self-managed edges. When moving an edge to a different host, the MAC and PCI IDs of the interfaces may change. Therefore, a new workflow is needed to collect updated MAC or PCI bus IDs during the image upgrade process. Supporting this would require additional configuration logic and new APIs, which again is out of scope for 8.1 since we're already past CF1.