### PR TITLE
AVX-64435 Updating the edge gateway jumbo frame default value.

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1905,17 +1905,20 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 	d.Set("gw_name", gw.GwName)
 	d.Set("gw_size", gw.GwSize)
 
-	sendComm, acceptComm, err := client.GetGatewayBgpCommunities(gateway.GwName)
-	if err != nil {
-		return fmt.Errorf("failed to get BGP communities for gateway %s: %w", gateway.GwName, err)
-	}
-	err = d.Set("bgp_send_communities", sendComm)
-	if err != nil {
-		return fmt.Errorf("failed to set bgp_send_communities: %w", err)
-	}
-	err = d.Set("bgp_accept_communities", acceptComm)
-	if err != nil {
-		return fmt.Errorf("failed to set bgp_accept_communities: %w", err)
+	// get the gateway bgp communities details only if gw size is not UNKNOWN or empty
+	if gw.GwSize != "UNKNOWN" && gw.GwSize != "" {
+		sendComm, acceptComm, err := client.GetGatewayBgpCommunities(gateway.GwName)
+		if err != nil {
+			return fmt.Errorf("failed to get BGP communities for gateway %s: %w", gateway.GwName, err)
+		}
+		err = d.Set("bgp_send_communities", sendComm)
+		if err != nil {
+			return fmt.Errorf("failed to set bgp_send_communities: %w", err)
+		}
+		err = d.Set("bgp_accept_communities", acceptComm)
+		if err != nil {
+			return fmt.Errorf("failed to set bgp_accept_communities: %w", err)
+		}
 	}
 
 	// edge cloud type

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -4065,6 +4065,18 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 		}
 	}
 
+	// for edge the enable_jumbo_frame is set to false by default if not explicitly set by the user
+	if val, ok := d.GetOk("enable_jumbo_frame"); ok {
+		enableJumboFrame, ok := val.(bool)
+		if !ok {
+			return fmt.Errorf("enable_jumbo_frame must be a boolean")
+		}
+		gateway.JumboFrame = enableJumboFrame // set to user-provided value
+	} else {
+		gateway.JumboFrame = false // new default for EAT's
+		_ = d.Set("enable_jumbo_frame", false)
+	}
+
 	// create the transit gateway
 	log.Printf("[INFO] Creating Aviatrix Transit Gateway: %#v", gateway)
 	d.SetId(gateway.GwName)

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -1905,7 +1905,8 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 	d.Set("gw_name", gw.GwName)
 	d.Set("gw_size", gw.GwSize)
 
-	// get the gateway bgp communities details only if gw size is not UNKNOWN or empty
+	// gateway bgp communities should be set only after the gateway is created and the gateway size is known.
+	// This will allow the AEP EAT gateways to be created before setting the communities.
 	if gw.GwSize != "UNKNOWN" && gw.GwSize != "" {
 		sendComm, acceptComm, err := client.GetGatewayBgpCommunities(gateway.GwName)
 		if err != nil {

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -299,7 +299,8 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceNameAEP, "eip_map.0.public_ip", "35.0.16.1"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "bgp_polling_time", "55"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "local_as_number", "65000"),
-						resource.TestCheckResourceAttr(resourceNameAEP, "enable_jumbo_frame", "true"),
+						// enable_jumbo_frame is false by default for edge EAT gateways
+						resource.TestCheckResourceAttr(resourceNameAEP, "enable_jumbo_frame", "false"),
 						resource.TestCheckResourceAttr(resourceNameAEP, "tunnel_detection_time", "10"),
 					),
 				},
@@ -594,7 +595,6 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_aep" {
     }
 	bgp_polling_time   = 55
 	local_as_number    = 65000
-	enable_jumbo_frame = true
 	tunnel_detection_time = 10
 }
 	`, rName, os.Getenv("AEP_VPC_ID"), os.Getenv("AEP_DEVICE_ID"))


### PR DESCRIPTION
- Testing the gateway size for edge AEP gateways to use x-large, large, medium and small sizes.
- The `enable_jumbo_frame` value is set to false by default for edge gateways.
- Added the fix for bgp communities error which is being thrown while creating the AEP transit gateway. This fix will unblock the gateway from being created. Adding @triwas for transit gateway changes fix.
- Gateway size - `x-large` works as expected with out any TF changes. The backend changes made to the gateway sizes in edge have fixed the issue.

```
resource "aviatrix_transit_gateway" "aep-transit-1" {
    cloud_type = 262144
    account_name = "edge_aep"
    gw_name = "aep-transit-1"
    vpc_id = "site-1"
    gw_size = "small"
    device_id = "d3307f37-10cd-459f-9025-ee2b009e4019"
    interfaces {
        gateway_ip    = "192.168.20.1"
        ip_address    = "192.168.20.11/24"
        logical_ifname = "wan0"
        public_ip = "67.207.104.19"
        secondary_private_cidr_list = ["192.168.19.16/29"]
    }

    interfaces {
        gateway_ip    = "192.168.21.1"
        ip_address    = "192.168.21.11/24"
        logical_ifname = "wan1"
        public_ip = "67.207.104.20"
        secondary_private_cidr_list = ["192.168.21.16/29"]
    }

    interfaces {
        dhcp   = true
        logical_ifname = "mgmt0"
    }

    interfaces {
        gateway_ip  = "192.168.22.1"
        ip_address  = "192.168.22.11/24"
        logical_ifname = "wan2"
    }

    interfaces {
        gateway_ip = "192.168.23.1"
        ip_address = "192.168.23.11/24"
        logical_ifname = "wan3"
    }

    interface_mapping{
      name  = "eth0"
      type  = "WAN"
      index = 0
    }

    interface_mapping{
      name  = "eth1"
      type  = "WAN"
      index = 1
    }

    interface_mapping{
      name  = "eth2"
      type  = "WAN"
      index = 2
    }

    interface_mapping{
      name  = "eth3"
      type  = "MANAGEMENT"
      index = 0
    }

    interface_mapping{
      name  = "eth4"
      type  = "WAN"
      index = 3
    }
}
```