### PR TITLE
AVX-65453: Change attribute type for per connection communities.

### DIFF
--- a/goaviatrix/edge_external_device_conn.go
+++ b/goaviatrix/edge_external_device_conn.go
@@ -15,8 +15,8 @@ type EdgeExternalDeviceConn struct {
 	BgpLocalAsNum              int    `json:"local_asn,omitempty"`
 	BgpRemoteAsNum             int    `json:"external_device_asn,omitempty"`
 	BgpSendCommunities         string `json:"conn_bgp_send_communities,omitempty"`
-	BgpSendCommunitiesAdditive string `json:"conn_bgp_send_communities_additive,omitempty"`
-	BgpSendCommunitiesBlock    string `json:"conn_bgp_send_communities_block,omitempty"`
+	BgpSendCommunitiesAdditive bool   `json:"conn_bgp_send_communities_additive,omitempty"`
+	BgpSendCommunitiesBlock    bool   `json:"conn_bgp_send_communities_block,omitempty"`
 	RemoteGatewayIP            string `json:"external_device_ip_address,omitempty"`
 	RemoteSubnet               string `json:"remote_subnet,omitempty"`
 	DirectConnect              string `json:"direct_connect,omitempty"`

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -32,8 +32,8 @@ type ExternalDeviceConn struct {
 	BgpLocalAsNum              int    `form:"bgp_local_as_number,omitempty"`
 	BgpRemoteAsNum             int    `form:"external_device_as_number,omitempty"`
 	BgpSendCommunities         string `json:"conn_bgp_send_communities,omitempty"`
-	BgpSendCommunitiesAdditive string `json:"conn_bgp_send_communities_additive,omitempty"`
-	BgpSendCommunitiesBlock    string `json:"conn_bgp_send_communities_block,omitempty"`
+	BgpSendCommunitiesAdditive bool   `json:"conn_bgp_send_communities_additive,omitempty"`
+	BgpSendCommunitiesBlock    bool   `json:"conn_bgp_send_communities_block,omitempty"`
 	RemoteGatewayIP            string `form:"external_device_ip_address,omitempty"`
 	RemoteSubnet               string `form:"remote_subnet,omitempty"`
 	DirectConnect              string `form:"direct_connect,omitempty"`
@@ -92,8 +92,8 @@ type EditExternalDeviceConnDetail struct {
 	BgpRemoteAsNum             string        `json:"bgp_remote_asn_number,omitempty"`
 	BgpStatus                  string        `json:"bgp_status,omitempty"`
 	BgpSendCommunities         string        `json:"conn_bgp_send_communities,omitempty"`
-	BgpSendCommunitiesAdditive string        `json:"conn_bgp_send_communities_additive,omitempty"`
-	BgpSendCommunitiesBlock    string        `json:"conn_bgp_send_communities_block,omitempty"`
+	BgpSendCommunitiesAdditive bool          `json:"conn_bgp_send_communities_additive,omitempty"`
+	BgpSendCommunitiesBlock    bool          `json:"conn_bgp_send_communities_block,omitempty"`
 	EnableBgpLanActiveMesh     bool          `json:"bgp_lan_activemesh,omitempty"`
 	RemoteGatewayIP            string        `json:"peer_ip,omitempty"`
 	RemoteSubnet               string        `json:"remote_cidr,omitempty"`


### PR DESCRIPTION
Tested with TF, and it applies correctly:

```
# Create an Aviatrix Transit External Device Connection
resource "aviatrix_transit_external_device_conn" "to_transit2" {
  vpc_id                    = "vpc-0fb4c51c6a1327c61"
  connection_name           = "test-conn-1"
  gw_name                   = "test-transit-1"
  connection_type           = "bgp"
  bgp_local_as_num          = "65111"
  bgp_remote_as_num         = "65112"
  remote_gateway_ip         = "1.2.3.4"
  ha_enabled                = true
  backup_bgp_remote_as_num  = "65112"
  backup_remote_gateway_ip  = "5.6.7.8"
  connection_bgp_send_communities = "111:111"
  connection_bgp_send_communities_additive = true
}
```