### PR TITLE
AVX-65770: Support configuring AEP API endpoint

### DIFF
--- a/goaviatrix/account.go
+++ b/goaviatrix/account.go
@@ -62,6 +62,7 @@ type Account struct {
 	GroupNames                            string   `form:"groups,omitempty"`
 	GroupNamesRead                        []string `json:"rbac_groups,omitempty"`
 	EdgeCSPUsername                       string   `json:"edge_csp_username"`
+	EdgeCSPApiEndpoint                    string   `json:"edge_csp_api_endpoint,omitempty"`
 	EdgeEquinixUsername                   string   `json:"equinix_username"`
 }
 
@@ -72,6 +73,7 @@ type EdgeAccount struct {
 	CloudType           int    `json:"cloud_type,omitempty"`
 	EdgeCSPUsername     string `json:"edge_csp_username,omitempty"`
 	EdgeCSPPassword     string `json:"edge_csp_password,omitempty"`
+	EdgeCSPApiEndpoint  string `json:"edge_csp_api_endpoint,omitempty"`
 	EdgeEquinixUsername string `json:"equinix_username,omitempty"`
 }
 


### PR DESCRIPTION
Add `edge_csp_api_endpoint` parameter for `aviatrix_account`, allowing staging AEP accounts to be created. This is intented to only be used internally for e2e testing, so it is not added to the documentation.

Sample usage:
```
resource "aviatrix_account" "aep_staging" {
  account_name = "aep-staging"
  cloud_type = 262144
  edge_csp_api_endpoint = "https://api.staging.edge.aviatrix.com"
}
```