### PR TITLE
AVX-64431: Add documentation and test for smart groups with serverles…

### DIFF
--- a/aviatrix/resource_aviatrix_smart_group_test.go
+++ b/aviatrix/resource_aviatrix_smart_group_test.go
@@ -443,6 +443,55 @@ resource "aviatrix_smart_group" "external_geo" {
 `
 }
 
+func TestAccAviatrixSmartGroup_serverless(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_SMART_GROUP")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Smart Group test as SKIP_SMART_GROUP is set")
+	}
+	resourceName := "aviatrix_smart_group.serverless"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProvidersVersionValidation,
+		CheckDestroy: testAccSmartGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSmartGroupServerless(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSmartGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "serverless-test-smart-group"),
+					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.0.type", "serverless_function"),
+					resource.TestCheckResourceAttr(resourceName, "selector.0.match_expressions.0.name", "test-function"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSmartGroupServerless() string {
+	return `
+resource "aviatrix_smart_group" "serverless" {
+	name = "serverless-test-smart-group"
+
+	selector {
+		match_expressions {
+			type = "serverless_function"
+			name = "test-function"
+		}
+	}
+}
+`
+}
+
 func testAccCheckSmartGroupExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]

--- a/docs/resources/aviatrix_smart_group.md
+++ b/docs/resources/aviatrix_smart_group.md
@@ -85,6 +85,13 @@ resource "aviatrix_smart_group" "test_smart_group_ip" {
       k8s_cluster_id = resource.aviatrix_kubernetes_cluster.test_cluster.cluster_id
     }
 
+    # Below are serverless functions examples
+
+    match_expressions {
+      type     = "serverless_function"
+      name     = "my-function"
+    }
+
     // Below are external group type examples
 
     // generic format


### PR DESCRIPTION
…s functions

This PR adds support for smart groups for serverless functions to the docs and the acceptance tests.

The implementation itself does not need any changes. The `type` field is not validated by the terraform provider.