### PR TITLE
AVX-64537: bump spoke transit attach timeout

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_spoke_transit_attachment.go
@@ -133,7 +133,7 @@ func resourceAviatrixSpokeTransitAttachmentCreate(d *schema.ResourceData, meta i
 	flag := false
 	defer resourceAviatrixSpokeTransitAttachmentReadIfRequired(d, meta, &flag)
 
-	timeout := 5 * time.Minute
+	timeout := 15 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	try, maxTries, backoff := 0, 10, 1000*time.Millisecond


### PR DESCRIPTION
Previously I bumped this timer from 30s to 5 min. Its still to short so bumping again to 15 min.