### PR TITLE
AVX-66291 Fix the edit_gw_customized_snat_config API

### DIFF
--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -660,6 +660,8 @@ func (c *Client) EnableCustomizedSNat(gateway *Gateway) error {
 
 	gateway.PolicyList = base64.StdEncoding.EncodeToString(b.Bytes())
 	gateway.Compress = true
+	// Reset the SnatPolicy field after encoding so we don't send both.
+	gateway.SnatPolicy = nil
 
 	return c.PostAPI(gateway.Action, gateway, BasicCheck)
 }


### PR DESCRIPTION
Previously we were sending both the encoded policy and the "raw" policy object. The raw object is not needed. Remove it so we optimize the payload size.