### PR TITLE
AVX-65811: Add per connection BGP community resources for spoke gw.

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -1452,17 +1452,7 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 		}
 	}
 
-	if d.HasChange("connection_bgp_send_communities") || d.HasChange("connection_bgp_send_communities_additive") || d.HasChange("connection_bgp_send_communities_block") {
-		connName, ok := d.Get("connection_name").(string)
-		if !ok {
-			return fmt.Errorf("failed to assert connection_name as string")
-		}
-
-		gwName, ok := d.Get("gw_name").(string)
-		if !ok {
-			return fmt.Errorf("failed to assert gw_name as string")
-		}
-
+	if d.HasChanges("connection_bgp_send_communities", "connection_bgp_send_communities_additive", "connection_bgp_send_communities_block") {
 		// Detect whether the user wants to change the set of BGP communities sent on a given connection
 		// if so, update the connection with the new set of communities, either additively or as a replacement
 		// or block the communities entirely, depending on the user's choice

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -426,12 +426,34 @@ func resourceAviatrixSpokeExternalDeviceConn() *schema.Resource {
 				Default:     true,
 				Description: "Enable multihop on BGP connection.",
 			},
+			"connection_bgp_send_communities": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Connection based additional BGP communities to be sent",
+			},
+			"connection_bgp_send_communities_additive": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Do additive operation instead of replacement operation",
+			},
+			"connection_bgp_send_communities_block": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Block advertisement of any BGP communities on this connection",
+			},
 		},
 	}
 }
 
 func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
+
+	var bgpSendCommunities *goaviatrix.BgpSendCommunities
 
 	externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 		VpcID:                  d.Get("vpc_id").(string),
@@ -462,6 +484,41 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 		BackupBgpMd5Key:        d.Get("backup_bgp_md5_key").(string),
 		EnableJumboFrame:       d.Get("enable_jumbo_frame").(bool),
 		EnableBgpMultihop:      d.Get("enable_bgp_multihop").(bool),
+	}
+
+	sendComm, ok := d.Get("connection_bgp_send_communities").(string)
+	if !ok {
+		return fmt.Errorf("failed to assert connection_bgp_send_communities as string")
+	}
+	blockComm, ok := d.Get("connection_bgp_send_communities_block").(bool)
+	if !ok {
+		return fmt.Errorf("failed to assert connection_bgp_send_communities_block as bool")
+	}
+	setPerConnCommunity := false
+	if sendComm != "" || blockComm {
+		connName, ok := d.Get("connection_name").(string)
+		setPerConnCommunity = true
+		if !ok {
+			return fmt.Errorf("failed to assert connection_name as string")
+		}
+
+		gwName, ok := d.Get("gw_name").(string)
+		if !ok {
+			return fmt.Errorf("failed to assert gw_name as string")
+		}
+
+		sendAdditive, ok := d.Get("connection_bgp_send_communities_additive").(bool)
+		if !ok {
+			return fmt.Errorf("failed to assert connection_bgp_send_communities_additive as bool")
+		}
+
+		bgpSendCommunities = &goaviatrix.BgpSendCommunities{
+			ConnectionName:      connName,
+			GwName:              gwName,
+			ConnSendCommunities: sendComm,
+			ConnSendAdditive:    sendAdditive,
+			ConnSendBlock:       blockComm,
+		}
 	}
 
 	tunnelProtocol := strings.ToUpper(d.Get("tunnel_protocol").(string))
@@ -717,6 +774,13 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 	err = client.CreateExternalDeviceConn(externalDeviceConn)
 	if err != nil {
 		return fmt.Errorf("failed to create Aviatrix external device connection: %s", err)
+	}
+
+	if setPerConnCommunity {
+		err = client.ConnectionBGPSendCommunities(bgpSendCommunities)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to set/block BGP communities for connection %s: %w", externalDeviceConn.ConnectionName, err)
 	}
 
 	enableBFD, ok := d.Get("enable_bfd").(bool)
@@ -1072,6 +1136,19 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 		if err != nil {
 			return fmt.Errorf("could not set value for enable_bgp_multihop: %w", err)
 		}
+
+		err = d.Set("connection_bgp_send_communities", conn.BgpSendCommunities)
+		if err != nil {
+			return fmt.Errorf("could not set value for connection_bgp_send_communities: %w", err)
+		}
+		err = d.Set("connection_bgp_send_communities_additive", conn.BgpSendCommunitiesAdditive)
+		if err != nil {
+			return fmt.Errorf("could not set value for connection_bgp_send_communities: %w", err)
+		}
+		err = d.Set("connection_bgp_send_communities_block", conn.BgpSendCommunitiesBlock)
+		if err != nil {
+			return fmt.Errorf("could not set value for connection_bgp_send_communities: %w", err)
+		}
 	}
 
 	d.SetId(conn.ConnectionName + "~" + conn.VpcID)
@@ -1372,6 +1449,47 @@ func resourceAviatrixSpokeExternalDeviceConnUpdate(d *schema.ResourceData, meta 
 		err := client.EditSite2CloudPhase1LocalIdentifier(s2c)
 		if err != nil {
 			return fmt.Errorf("could not update phase1 local identificer for connection: %s: %v", s2c.ConnName, err)
+		}
+	}
+
+	if d.HasChange("connection_bgp_send_communities") || d.HasChange("connection_bgp_send_communities_additive") || d.HasChange("connection_bgp_send_communities_block") {
+		connName, ok := d.Get("connection_name").(string)
+		if !ok {
+			return fmt.Errorf("failed to assert connection_name as string")
+		}
+
+		gwName, ok := d.Get("gw_name").(string)
+		if !ok {
+			return fmt.Errorf("failed to assert gw_name as string")
+		}
+
+		// Detect whether the user wants to change the set of BGP communities sent on a given connection
+		// if so, update the connection with the new set of communities, either additively or as a replacement
+		// or block the communities entirely, depending on the user's choice
+		sendComm, ok := d.Get("connection_bgp_send_communities").(string)
+		if !ok {
+			return fmt.Errorf("failed to assert connection_bgp_send_communities as string")
+		}
+
+		sendAdditive, ok := d.Get("connection_bgp_send_communities_additive").(bool)
+		if !ok {
+			return fmt.Errorf("failed to assert connection_bgp_send_communities_additive as bool")
+		}
+
+		sendBlock, ok := d.Get("connection_bgp_send_communities_block").(bool)
+		if !ok {
+			return fmt.Errorf("failed to assert connection_bgp_send_communities_block as bool")
+		}
+
+		bgpSendCommunities := &goaviatrix.BgpSendCommunities{
+			ConnectionName:      connName,
+			GwName:              gwName,
+			ConnSendCommunities: sendComm,
+			ConnSendAdditive:    sendAdditive,
+			ConnSendBlock:       sendBlock,
+		}
+		if err := client.ConnectionBGPSendCommunities(bgpSendCommunities); err != nil {
+			return fmt.Errorf("failed to update bgp connection based communities for connection %q", bgpSendCommunities.ConnectionName)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -301,7 +301,7 @@ func resourceAviatrixSpokeExternalDeviceConn() *schema.Resource {
 				Optional: true,
 				Description: "Configure manual BGP advertised CIDRs for this connection. Only valid with 'connection_type'" +
 					" = 'bgp'.",
-				DiffSuppressFunc: func(k, oldStr, newStr string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, oldStr, newStr string, _ *schema.ResourceData) bool {
 					// Suppress diff if old is null ("" or "<nil>") and new is an empty set/list ("[]")
 					return (oldStr == "" || oldStr == "<nil>") && (newStr == "[]" || newStr == "")
 				},
@@ -433,7 +433,7 @@ func resourceAviatrixSpokeExternalDeviceConn() *schema.Resource {
 			"connection_bgp_send_communities": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Connection based additional BGP communities to be sent",
+				Description: "Connection based additional BGP communities to be sent. E.g. 111:111, 444:444",
 			},
 			"connection_bgp_send_communities_additive": {
 				Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -301,9 +301,9 @@ func resourceAviatrixSpokeExternalDeviceConn() *schema.Resource {
 				Optional: true,
 				Description: "Configure manual BGP advertised CIDRs for this connection. Only valid with 'connection_type'" +
 					" = 'bgp'.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(k, oldStr, newStr string, d *schema.ResourceData) bool {
 					// Suppress diff if old is null ("" or "<nil>") and new is an empty set/list ("[]")
-					return (old == "" || old == "<nil>") && (new == "[]" || new == "")
+					return (oldStr == "" || oldStr == "<nil>") && (newStr == "[]" || newStr == "")
 				},
 			},
 			"remote_vpc_name": {

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -301,6 +301,10 @@ func resourceAviatrixSpokeExternalDeviceConn() *schema.Resource {
 				Optional: true,
 				Description: "Configure manual BGP advertised CIDRs for this connection. Only valid with 'connection_type'" +
 					" = 'bgp'.",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Suppress diff if old is null ("" or "<nil>") and new is an empty set/list ("[]")
+					return (old == "" || old == "<nil>") && (new == "[]" || new == "")
+				},
 			},
 			"remote_vpc_name": {
 				Type:     schema.TypeString,
@@ -429,21 +433,18 @@ func resourceAviatrixSpokeExternalDeviceConn() *schema.Resource {
 			"connection_bgp_send_communities": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Connection based additional BGP communities to be sent",
 			},
 			"connection_bgp_send_communities_additive": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				ForceNew:    true,
 				Description: "Do additive operation instead of replacement operation",
 			},
 			"connection_bgp_send_communities_block": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				ForceNew:    true,
 				Description: "Block advertisement of any BGP communities on this connection",
 			},
 		},

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
@@ -45,6 +45,9 @@ func TestAccAviatrixSpokeExternalDeviceConn_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bgp_bfd.0.transmit_interval", "400"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_bfd.0.receive_interval", "400"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_bfd.0.multiplier", "5"),
+					resource.TestCheckResourceAttr(resourceName, "connection_bgp_send_communities", "444:444"),
+					resource.TestCheckResourceAttr(resourceName, "connection_bgp_send_communities_additive", "true"),
+					resource.TestCheckResourceAttr(resourceName, "connection_bgp_send_communities_block", "false"),
 				),
 			},
 			{
@@ -90,6 +93,9 @@ resource "aviatrix_spoke_external_device_conn" "test" {
 		receive_interval = 400
 		multiplier = 5
 	}
+	connection_bgp_send_communities           = "444:444"
+	connection_bgp_send_communities_additive  = true
+	connection_bgp_send_communities_block     = false
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		rName, os.Getenv("AWS_VPC_ID"), os.Getenv("AWS_REGION"), os.Getenv("AWS_SUBNET"), rName)

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -323,7 +323,7 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Optional: true,
 				Description: "Configure manual BGP advertised CIDRs for this connection. Only valid with 'connection_type'" +
 					" = 'bgp'. Available as of provider version R2.18+.",
-				DiffSuppressFunc: func(k, oldStr, newStr string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, oldStr, newStr string, _ *schema.ResourceData) bool {
 					// Suppress diff if old is null ("" or "<nil>") and new is an empty set/list ("[]")
 					return (oldStr == "" || oldStr == "<nil>") && (newStr == "[]" || newStr == "")
 				},
@@ -473,7 +473,7 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 			"connection_bgp_send_communities": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Connection based additional BGP communities to be sent",
+				Description: "Connection based additional BGP communities to be sent. E.g. 111:111, 444:444",
 			},
 			"connection_bgp_send_communities_additive": {
 				Type:        schema.TypeBool,

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -323,9 +323,9 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				Optional: true,
 				Description: "Configure manual BGP advertised CIDRs for this connection. Only valid with 'connection_type'" +
 					" = 'bgp'. Available as of provider version R2.18+.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(k, oldStr, newStr string, d *schema.ResourceData) bool {
 					// Suppress diff if old is null ("" or "<nil>") and new is an empty set/list ("[]")
-					return (old == "" || old == "<nil>") && (new == "[]" || new == "")
+					return (oldStr == "" || oldStr == "<nil>") && (newStr == "[]" || newStr == "")
 				},
 			},
 			"remote_vpc_name": {

--- a/docs/resources/aviatrix_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_spoke_external_device_conn.md
@@ -125,6 +125,24 @@ resource "aviatrix_spoke_external_device_conn" "ex-conn" {
   backup_local_lan_ip      = "172.12.13.17"
 }
 ```
+```hcl
+# Create a BGP over LAN Aviatrix Spoke External Device Connection with BGP Communities
+resource "aviatrix_spoke_external_device_conn" "conn-1" {
+  vpc_id                                    = aviatrix_spoke_gateway.spoke-gateway.vpc_id
+  connection_name                           = "my_conn"
+  gw_name                                   = aviatrix_spoke_gateway.spoke-gateway.gw_name
+  connection_bgp_send_communities           = "444:444 111:111"
+  connection_bgp_send_communities_additive  = true
+  connection_bgp_send_communities_block     = false
+  backup_bgp_remote_as_num                  = "123"
+  remote_lan_ip                             = "172.12.13.14"
+  backup_remote_lan_ip                      = "172.12.13.16"
+  bgp_local_as_num                          = "456"
+  bgp_remote_as_num                         = "789"
+  ha_enabled                                = true
+  tunnel_protocol                           = "LAN"
+}
+```
 
 ## Argument Reference
 
@@ -181,6 +199,9 @@ The following arguments are supported:
 * `backup_remote_lan_ip` - (Optional) Backup Remote LAN IP. Required for HA BGP over LAN connection.
 * `backup_local_lan_ip` - (Optional) Backup Local LAN IP. Required for GCP HA BGP over LAN connection.
 * `enable_bgp_lan_activemesh` - (Optional) Switch to enable BGP LAN ActiveMesh mode. Only valid for GCP and Azure with Remote Gateway HA enabled. Requires Azure Remote Gateway insane mode enabled. Valid values: true, false. Default: false. Available as of provider version R3.0.2+.
+* `connection_bgp_send_communities` - (Optional) Extra BGP communities to send over this connection.
+* `connection_bgp_send_communities_additive` - (Optional) Whether the BGP communities should be sent additively or as a replacement (true/false).
+* `connection_bgp_send_communities_block` - (Optional) If set to true, block all BGP communities over this connection.
 
 ### BGP MD5 Authentication (Available as of provider version R2.21.1+)
 ~> **NOTE:** BGP MD5 Authentication is only valid with `connection_type` = 'bgp'.

--- a/docs/resources/aviatrix_transit_external_device_conn.md
+++ b/docs/resources/aviatrix_transit_external_device_conn.md
@@ -123,6 +123,24 @@ resource "aviatrix_transit_external_device_conn" "ex-conn" {
   }
 }
 ```
+```hcl
+# Create a BGP over LAN Aviatrix Transit External Device Connection with BGP Communities
+resource "aviatrix_transit_external_device_conn" "conn-1" {
+  vpc_id                                    = aviatrix_spoke_gateway.spoke-gateway.vpc_id
+  connection_name                           = "my_conn"
+  gw_name                                   = aviatrix_spoke_gateway.spoke-gateway.gw_name
+  connection_bgp_send_communities           = "444:444 111:111"
+  connection_bgp_send_communities_additive  = true
+  connection_bgp_send_communities_block     = false
+  backup_bgp_remote_as_num                  = "123"
+  remote_lan_ip                             = "172.12.13.14"
+  backup_remote_lan_ip                      = "172.12.13.16"
+  bgp_local_as_num                          = "456"
+  bgp_remote_as_num                         = "789"
+  ha_enabled                                = true
+  tunnel_protocol                           = "LAN"
+}
+```
 
 ## Argument Reference
 
@@ -178,6 +196,9 @@ The following arguments are supported:
 * `backup_remote_lan_ip` - (Optional) Backup Remote LAN IP. Required for HA BGP over LAN connection.
 * `backup_local_lan_ip` - (Optional) Backup Local LAN IP. Required for GCP HA BGP over LAN connection.
 * `enable_bgp_lan_activemesh` - (Optional) Switch to enable BGP LAN ActiveMesh mode. Only valid for GCP and Azure with Remote Gateway HA enabled. Requires Azure Remote Gateway insane mode enabled. Valid values: true, false. Default: false. Available as of provider version R2.21+.
+* `connection_bgp_send_communities` - (Optional) Extra BGP communities to send over this connection.
+* `connection_bgp_send_communities_additive` - (Optional) Whether the BGP communities should be sent additively or as a replacement (true/false).
+* `connection_bgp_send_communities_block` - (Optional) If set to true, block all BGP communities over this connection.
 
 ### BGP MD5 Authentication (Available as of provider version R2.21.1+)
 ~> **NOTE:** BGP MD5 Authentication is only valid with `connection_type` = 'bgp'.

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -266,6 +266,21 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 			backupBgpRemoteAsNumber = backupBgpRemoteAsNumberRead
 		}
 
+		// get_site2cloud_conn_detail API returns one field for communities, namely, conn_bgp_send_communities
+		// Example1: "conn_bgp_send_communities": "additive 444:444"
+		// Example2: "conn_bgp_send_communities": "block"
+		// We need to parse this field to set the BgpSendCommunities, BgpSendCommunitiesAdditive and BgpSendCommunitiesBlock fields
+		if externalDeviceConnDetail.BgpSendCommunities != "" {
+			commList := strings.Split(externalDeviceConnDetail.BgpSendCommunities, " ")
+			if len(commList) > 0 && commList[0] == "block" {
+				externalDeviceConn.BgpSendCommunitiesBlock = true
+			} else if len(commList) > 0 && commList[0] == "additive" {
+				externalDeviceConn.BgpSendCommunitiesAdditive = true
+				commList = commList[1:]
+				externalDeviceConn.BgpSendCommunities = strings.Join(commList, " ")
+			}
+		}
+
 		if externalDeviceConn.TunnelProtocol != "LAN" {
 			externalDeviceConn.DisableActivemesh = externalDeviceConnDetail.DisableActivemesh
 			externalDeviceConn.TunnelSrcIP = externalDeviceConnDetail.TunnelSrcIP


### PR DESCRIPTION
Spoke gateway communities resources were missing. These changes are similar to transit gateway changes in `aviatrix/resource_aviatrix_transit_external_device_conn.go`