### PR TITLE
AVX-52106: Update function missing fields for edge spoke ext connection

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -620,6 +620,18 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 	if externalDeviceConn.EnableEdgeUnderlay && d.HasChanges("bgp_md5_key", "backup_bgp_md5_key") {
 		edgeExternalDeviceConn := goaviatrix.EdgeExternalDeviceConn(*externalDeviceConn)
 
+		bgpMD5Key, ok := d.Get("bgp_md5_key").(string)
+		if !ok {
+			return diag.Errorf("failed to assert bgp_md5_key as string")
+		}
+		edgeExternalDeviceConn.BgpMd5Key = bgpMD5Key
+
+		backupBGPMD5Key, ok := d.Get("backup_bgp_md5_key").(string)
+		if !ok {
+			return diag.Errorf("failed to assert backup_bgp_md5_key as string")
+		}
+		edgeExternalDeviceConn.BackupBgpMd5Key = backupBGPMD5Key
+
 		edgeExternalDeviceConn.BgpMd5KeyChanged = true
 
 		_, err := client.CreateEdgeExternalDeviceConn(&edgeExternalDeviceConn)

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -622,13 +622,13 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnUpdate(ctx context.Context, d *s
 
 		bgpMD5Key, ok := d.Get("bgp_md5_key").(string)
 		if !ok {
-			return diag.Errorf("failed to assert bgp_md5_key as string")
+			return diag.Errorf("invalid value for 'bgp_md5_key': expected a string, but got a %T (value: %v)", bgpMD5Key, bgpMD5Key)
 		}
 		edgeExternalDeviceConn.BgpMd5Key = bgpMD5Key
 
 		backupBGPMD5Key, ok := d.Get("backup_bgp_md5_key").(string)
 		if !ok {
-			return diag.Errorf("failed to assert backup_bgp_md5_key as string")
+			return diag.Errorf("invalid value for 'backup_bgp_md5_key': expected a string, but got a %T (value: %v)", backupBGPMD5Key, backupBGPMD5Key)
 		}
 		edgeExternalDeviceConn.BackupBgpMd5Key = backupBGPMD5Key
 


### PR DESCRIPTION
Testing: verified with edge spoke gateway that BGP session gets established after providing the MD5 key either in the beginning or while updating the terraform. 