### PR TITLE
AVX-66693 Adding the interface tag to terraform state for megaport EAS

### DIFF
--- a/aviatrix/resource_aviatrix_edge_megaport.go
+++ b/aviatrix/resource_aviatrix_edge_megaport.go
@@ -806,6 +806,10 @@ func resourceAviatrixEdgeMegaportRead(ctx context.Context, d *schema.ResourceDat
 			interface1["vrrp_virtual_ip"] = interface0.VirtualIP
 		}
 
+		if interface0.Tag != "" {
+			interface1["tag"] = interface0.Tag
+		}
+
 		if strings.HasPrefix(interface0.LogicalInterfaceName, "lan") && interface0.SubInterfaces != nil {
 			for _, vlan0 := range interface0.SubInterfaces {
 				vlan1 := make(map[string]interface{})

--- a/aviatrix/resource_aviatrix_edge_megaport_test.go
+++ b/aviatrix/resource_aviatrix_edge_megaport_test.go
@@ -38,8 +38,10 @@ func TestAccAviatrixEdgeMegaport_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "site_id", siteId),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "10.220.14.10/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.logical_ifname", "lan0"),
+					resource.TestCheckResourceAttr(resourceName, "interfaces.0.tag", "LAN"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "192.168.99.14/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.logical_ifname", "wan0"),
+					resource.TestCheckResourceAttr(resourceName, "interfaces.1.tag", "WAN"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "192.168.88.14/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.logical_ifname", "wan1"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.3.ip_address", "192.168.77.14/24"),
@@ -86,6 +88,7 @@ func testAccEdgeMegaportBasic(accountName, gwName, siteId, path string) string {
 			gateway_ip     = "10.220.14.1"
 			ip_address     = "10.220.14.10/24"
 			logical_ifname = "lan0"
+			tag            = "LAN"
 		}
 
 		interfaces {
@@ -93,6 +96,7 @@ func testAccEdgeMegaportBasic(accountName, gwName, siteId, path string) string {
 			ip_address     = "192.168.99.14/24"
 			logical_ifname = "wan0"
 			wan_public_ip  = "67.207.104.19"
+			tag            = "WAN"
 		}
 
 		interfaces {


### PR DESCRIPTION
Adding the interface config `tag` to terraform state file for Megaport

```
resource "aviatrix_edge_megaport" "edge_megaport_1" {
    gw_name = "eas-megaport-1"
    ztp_file_download_path = "ztp"
    account_name = "edge_megaport"
    site_id = "eas-site-1"
    management_egress_ip_prefix_list = [ 
        "162.43.140.85/31"
    ]
    local_as_number = "65214"
    interfaces {
        logical_ifname = "wan0"
        ip_address = "192.168.16.10/24"
        gateway_ip = "192.168.16.1"
        tag = "WAN"
    }

    interfaces {
        logical_ifname = "wan1"
        ip_address = "192.168.17.10/24"
        gateway_ip = "192.168.17.1"
        tag = "WAN"
    }

    interfaces {
        logical_ifname = "wan2"
        ip_address = "192.168.18.10/24"
        gateway_ip = "192.168.18.1"
        tag = "WAN"
    }

    interfaces {
        logical_ifname = "lan0"
        ip_address = "192.168.19.10/24"
        tag = "LAN"
    }

    interfaces {
        logical_ifname = "mgmt0"
        enable_dhcp = true
        tag = "MGMT"
    }

    vlan {
        parent_logical_interface_name = "lan0"
        vlan_id = 100
        ip_address = "192.168.20.10/24"
    }
}
```