### PR TITLE
AVX-66122 terraform support for VPC creation

### DIFF
--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var supportedVersions = []string{"8.0"}
+var supportedVersions = []string{"8.0", "8.2"}
 
 // Provider returns a schema.Provider for Aviatrix.
 func Provider() *schema.Provider {

--- a/aviatrix/resource_aviatrix_vpc_test.go
+++ b/aviatrix/resource_aviatrix_vpc_test.go
@@ -129,10 +129,204 @@ func TestAccAviatrixVpc_basic(t *testing.T) {
 	}
 }
 
+func TestAccAviatrixVpc_ipv6_aws(t *testing.T) {
+	var vpc goaviatrix.Vpc
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_vpc.test_vpc_ipv6"
+
+	skipAcc := os.Getenv("SKIP_VPC")
+	if skipAcc == "yes" {
+		t.Skip("Skipping VPC tests as 'SKIP_VPC' is set")
+	}
+
+	skipAccAWS := os.Getenv("SKIP_VPC_AWS")
+	if skipAccAWS != "yes" {
+		msgCommon := ". Set 'SKIP_VPC_AWS' to 'yes' to skip VPC tests in AWS"
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preAccountCheck(t, msgCommon)
+			},
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckVpcDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccVpcConfigIPv6AWS(rName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckVpcExists(resourceName, &vpc),
+						resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tfg-%s-ipv6", rName)),
+						resource.TestCheckResourceAttr(resourceName, "account_name", ""),
+						resource.TestCheckResourceAttr(resourceName, "cloud_type", "1"),
+						resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+						resource.TestCheckResourceAttr(resourceName, "aviatrix_transit_vpc", "false"),
+						resource.TestCheckResourceAttr(resourceName, "region", os.Getenv("AWS_REGION")),
+						resource.TestCheckResourceAttr(resourceName, "cidr", "10.0.0.0/16"),
+					),
+				},
+				{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	} else {
+		t.Log("Skipping IPv6 VPC tests in AWS as 'SKIP_VPC_AWS' is set")
+	}
+}
+
+func TestAccAviatrixVpc_ipv6_azure(t *testing.T) {
+	var vpc goaviatrix.Vpc
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_vpc.test_vpc_ipv6_azure"
+
+	skipAcc := os.Getenv("SKIP_VPC")
+	if skipAcc == "yes" {
+		t.Skip("Skipping VPC tests as 'SKIP_VPC' is set")
+	}
+
+	skipAccAZURE := os.Getenv("SKIP_VPC_AZURE")
+	if skipAccAZURE != "yes" {
+		msgCommon := ". Set 'SKIP_VPC_AZURE' to 'yes' to skip VPC tests in Azure"
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preAccountCheck(t, msgCommon)
+			},
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckVpcDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccVpcConfigIPv6Azure(rName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckVpcExists(resourceName, &vpc),
+						resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tfg-%s-ipv6", rName)),
+						resource.TestCheckResourceAttr(resourceName, "account_name", ""),
+						resource.TestCheckResourceAttr(resourceName, "cloud_type", "8"),
+						resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+						resource.TestCheckResourceAttr(resourceName, "vpc_ipv6_cidr", "2001:db8::/48"),
+						resource.TestCheckResourceAttr(resourceName, "aviatrix_transit_vpc", "false"),
+						resource.TestCheckResourceAttr(resourceName, "region", os.Getenv("AZURE_REGION")),
+						resource.TestCheckResourceAttr(resourceName, "cidr", "10.0.0.0/16"),
+					),
+				},
+				{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	} else {
+		t.Log("Skipping IPv6 VPC tests in Azure as 'SKIP_VPC_AZURE' is set")
+	}
+}
+
+func TestAccAviatrixVpc_ipv6_gcp(t *testing.T) {
+	var vpc goaviatrix.Vpc
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_vpc.test_vpc_ipv6_gcp"
+
+	skipAcc := os.Getenv("SKIP_VPC")
+	if skipAcc == "yes" {
+		t.Skip("Skipping VPC tests as 'SKIP_VPC' is set")
+	}
+
+	skipAccGCP := os.Getenv("SKIP_VPC_GCP")
+	if skipAccGCP != "yes" {
+		msgCommon := ". Set 'SKIP_VPC_GCP' to 'yes' to skip VPC tests in GCP"
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preAccountCheck(t, msgCommon)
+			},
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckVpcDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccVpcConfigIPv6GCP(rName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckVpcExists(resourceName, &vpc),
+						resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tfg-%s-ipv6", rName)),
+						resource.TestCheckResourceAttr(resourceName, "account_name", ""),
+						resource.TestCheckResourceAttr(resourceName, "cloud_type", "4"),
+						resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+						resource.TestCheckResourceAttr(resourceName, "ipv6_access_type", "EXTERNAL"),
+						resource.TestCheckResourceAttr(resourceName, "subnets.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "subnets.0.region", "us-east1"),
+						resource.TestCheckResourceAttr(resourceName, "subnets.0.name", "us-east1-subnet-new"),
+						resource.TestCheckResourceAttr(resourceName, "subnets.0.cidr", "10.0.0.0/16"),
+					),
+				},
+				{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	} else {
+		t.Log("Skipping IPv6 VPC tests in GCP as 'SKIP_VPC_GCP' is set")
+	}
+}
+
+func TestAccAviatrixVpc_ipv6_gcp_internal(t *testing.T) {
+	var vpc goaviatrix.Vpc
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_vpc.test_vpc_ipv6_gcp_internal"
+
+	skipAcc := os.Getenv("SKIP_VPC")
+	if skipAcc == "yes" {
+		t.Skip("Skipping VPC tests as 'SKIP_VPC' is set")
+	}
+
+	skipAccGCP := os.Getenv("SKIP_VPC_GCP")
+	if skipAccGCP != "yes" {
+		msgCommon := ". Set 'SKIP_VPC_GCP' to 'yes' to skip VPC tests in GCP"
+		resource.Test(t, resource.TestCase{
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preAccountCheck(t, msgCommon)
+			},
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckVpcDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccVpcConfigIPv6GCPInternal(rName),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckVpcExists(resourceName, &vpc),
+						resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("tfg-%s-ipv6-internal", rName)),
+						resource.TestCheckResourceAttr(resourceName, "account_name", ""),
+						resource.TestCheckResourceAttr(resourceName, "cloud_type", "4"),
+						resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+						resource.TestCheckResourceAttr(resourceName, "ipv6_access_type", "INTERNAL"),
+						resource.TestCheckResourceAttr(resourceName, "vpc_ipv6_cidr", "fd20:cbe::/48"),
+						resource.TestCheckResourceAttr(resourceName, "subnets.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "subnets.0.region", "us-east1"),
+						resource.TestCheckResourceAttr(resourceName, "subnets.0.name", "us-east1-subnet-new-internal"),
+						resource.TestCheckResourceAttr(resourceName, "subnets.0.cidr", "10.0.0.0/16"),
+					),
+				},
+				{
+					ResourceName:      resourceName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	} else {
+		t.Log("Skipping IPv6 VPC tests in GCP as 'SKIP_VPC_GCP' is set")
+	}
+}
+
 func testAccVpcConfigBasicAWS(rName string) string {
 	return fmt.Sprintf(`
 resource "aviatrix_account" "test_acc" {
-	account_name       = "tfa-%s"
+	account_name       = ""
 	cloud_type         = 1
 	aws_account_number = "%s"
 	aws_iam            = false
@@ -146,7 +340,7 @@ resource "aviatrix_vpc" "test_vpc" {
 	region       = "%s"
 	cidr         = "10.0.0.0/16"
 }
-`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
+`, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		rName, os.Getenv("AWS_REGION"))
 }
 
@@ -192,6 +386,79 @@ resource "aviatrix_vpc" "test_vpc" {
 `, rName, os.Getenv("ARM_SUBSCRIPTION_ID"), os.Getenv("ARM_DIRECTORY_ID"),
 		os.Getenv("ARM_APPLICATION_ID"), os.Getenv("ARM_APPLICATION_KEY"),
 		rName, os.Getenv("AZURE_REGION"))
+}
+
+func testAccVpcConfigIPv6AWS(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_vpc" "test_vpc_ipv6" {
+	cloud_type   = 1
+	account_name = ""
+	name         = "tfg-%s-ipv6"
+	region       = "%s"
+	cidr         = "10.0.0.0/16"
+	
+	enable_ipv6 = true
+	
+	aviatrix_transit_vpc = false
+	aviatrix_firenet_vpc = false
+}
+`, rName, os.Getenv("AWS_REGION"))
+}
+
+func testAccVpcConfigIPv6Azure(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_vpc" "test_vpc_ipv6_azure" {
+	cloud_type   = 8
+	account_name = "test-account"
+	name         = "tfg-%s-ipv6"
+	region       = "%s"
+	cidr         = "10.0.0.0/16"
+	enable_ipv6 = true
+	vpc_ipv6_cidr = "2001:db8::/48"
+	
+	aviatrix_transit_vpc = false
+	aviatrix_firenet_vpc = false
+}
+`, rName, os.Getenv("AZURE_REGION"))
+}
+
+func testAccVpcConfigIPv6GCP(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_vpc" "test_vpc_ipv6_gcp" {
+	cloud_type   = 4
+	account_name = ""
+	name         = "tfg-%s-ipv6"
+	
+	subnets {
+		name   = "us-east1-subnet-new"
+		region = "us-east1"
+		cidr   = "10.0.0.0/16"
+	}
+	
+	enable_ipv6 = true
+	ipv6_access_type = "EXTERNAL"
+}
+`, rName)
+}
+
+func testAccVpcConfigIPv6GCPInternal(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_vpc" "test_vpc_ipv6_gcp_internal" {
+	cloud_type   = 4
+	account_name = ""
+	name         = "tfg-%s-ipv6-internal"
+	
+	subnets {
+		name   = "us-east1-subnet-new-internal"
+		region = "us-east1"
+		cidr   = "10.0.0.0/16"
+	}
+	
+	enable_ipv6 = true
+	ipv6_access_type = "INTERNAL"
+	vpc_ipv6_cidr =  "fd20:cbe::/48"
+}
+`, rName)
 }
 
 func testAccCheckVpcExists(n string, vpc *goaviatrix.Vpc) resource.TestCheckFunc {

--- a/goaviatrix/vpc.go
+++ b/goaviatrix/vpc.go
@@ -25,10 +25,9 @@ type Vpc struct {
 	PublicRoutesOnly       bool
 	ResourceGroup          string `json:"resource_group,omitempty"`
 	PrivateModeSubnets     bool
-	EnableIpv6             bool     `form:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
-	VpcIpv6Cidr            string   `form:"vpc_ipv6_cidr,omitempty" json:"vpc_ipv6_cidr,omitempty"`
-	Ipv6AccessType         string   `form:"ipv6_access_type,omitempty" json:"ipv6_access_type,omitempty"`
-	VpcIpv6CidrList        []string `form:"vpc_ipv6_cidr_list,omitempty" json:"vpc_ipv6_cidr_list,omitempty"`
+	EnableIpv6             bool   `form:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
+	VpcIpv6Cidr            string `form:"vpc_ipv6_cidr,omitempty" json:"vpc_ipv6_cidr,omitempty"`
+	Ipv6AccessType         string `form:"ipv6_access_type,omitempty" json:"ipv6_access_type,omitempty"`
 }
 
 type VpcEdit struct {
@@ -50,7 +49,6 @@ type VpcEdit struct {
 	EnableIpv6             bool         `form:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
 	VpcIpv6Cidr            string       `form:"vpc_ipv6_cidr,omitempty" json:"vpc_ipv6_cidr,omitempty"`
 	Ipv6AccessType         string       `form:"ipv6_access_type,omitempty" json:"ipv6_access_type,omitempty"`
-	VpcIpv6CidrList        []string     `form:"vpc_ipv6_cidr_list,omitempty" json:"vpc_ipv6_cidr_list,omitempty"`
 }
 
 type VpcResp struct {
@@ -227,7 +225,6 @@ func (c *Client) GetVpc(vpc *Vpc) (*Vpc, error) {
 	vpc.EnableIpv6 = data.Results.EnableIpv6
 	vpc.VpcIpv6Cidr = data.Results.VpcIpv6Cidr
 	vpc.Ipv6AccessType = data.Results.Ipv6AccessType
-	vpc.VpcIpv6CidrList = data.Results.VpcIpv6CidrList
 	return vpc, nil
 }
 

--- a/goaviatrix/vpc.go
+++ b/goaviatrix/vpc.go
@@ -225,6 +225,7 @@ func (c *Client) GetVpc(vpc *Vpc) (*Vpc, error) {
 	vpc.EnableIpv6 = data.Results.EnableIpv6
 	vpc.VpcIpv6Cidr = data.Results.VpcIpv6Cidr
 	vpc.Ipv6AccessType = data.Results.Ipv6AccessType
+	
 	return vpc, nil
 }
 

--- a/goaviatrix/vpc.go
+++ b/goaviatrix/vpc.go
@@ -25,6 +25,10 @@ type Vpc struct {
 	PublicRoutesOnly       bool
 	ResourceGroup          string `json:"resource_group,omitempty"`
 	PrivateModeSubnets     bool
+	EnableIpv6             bool     `form:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
+	VpcIpv6Cidr            string   `form:"vpc_ipv6_cidr,omitempty" json:"vpc_ipv6_cidr,omitempty"`
+	Ipv6AccessType         string   `form:"ipv6_access_type,omitempty" json:"ipv6_access_type,omitempty"`
+	VpcIpv6CidrList        []string `form:"vpc_ipv6_cidr_list,omitempty" json:"vpc_ipv6_cidr_list,omitempty"`
 }
 
 type VpcEdit struct {
@@ -43,6 +47,10 @@ type VpcEdit struct {
 	PublicSubnets          []SubnetInfo `json:"public_subnets,omitempty"`
 	PrivateSubnets         []SubnetInfo `json:"private_subnets,omitempty"`
 	PrivateModeSubnets     bool         `json:"private_mode_subnets"`
+	EnableIpv6             bool         `form:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
+	VpcIpv6Cidr            string       `form:"vpc_ipv6_cidr,omitempty" json:"vpc_ipv6_cidr,omitempty"`
+	Ipv6AccessType         string       `form:"ipv6_access_type,omitempty" json:"ipv6_access_type,omitempty"`
+	VpcIpv6CidrList        []string     `form:"vpc_ipv6_cidr_list,omitempty" json:"vpc_ipv6_cidr_list,omitempty"`
 }
 
 type VpcResp struct {
@@ -77,6 +85,12 @@ func (c *Client) CreateVpc(vpc *Vpc) error {
 		"account_name": vpc.AccountName,
 		"pool_name":    vpc.Name,
 	}
+	if vpc.EnableIpv6 {
+		form["enable_ipv6"] = "true"
+	}
+	if vpc.CloudType == Azure && vpc.EnableIpv6 {
+		form["vpc_ipv6_cidr"] = vpc.VpcIpv6Cidr
+	}
 	if vpc.CloudType != GCP {
 		form["region"] = vpc.Region
 		form["vpc_cidr"] = vpc.Cidr
@@ -89,6 +103,13 @@ func (c *Client) CreateVpc(vpc *Vpc) error {
 				return err
 			}
 			form["subnet_list"] = string(args)
+		}
+
+		if vpc.EnableIpv6 {
+			form["ipv6_access_type"] = vpc.Ipv6AccessType
+			if vpc.Ipv6AccessType == "INTERNAL" {
+				form["vpc_ipv6_cidr"] = vpc.VpcIpv6Cidr
+			}
 		}
 	}
 	if vpc.SubnetSize != 0 {
@@ -203,6 +224,10 @@ func (c *Client) GetVpc(vpc *Vpc) (*Vpc, error) {
 	vpc.NumOfSubnetPairs = data.Results.NumOfSubnetPairs
 	vpc.EnablePrivateOobSubnet = data.Results.EnablePrivateOobSubnet
 	vpc.PrivateModeSubnets = data.Results.PrivateModeSubnets
+	vpc.EnableIpv6 = data.Results.EnableIpv6
+	vpc.VpcIpv6Cidr = data.Results.VpcIpv6Cidr
+	vpc.Ipv6AccessType = data.Results.Ipv6AccessType
+	vpc.VpcIpv6CidrList = data.Results.VpcIpv6CidrList
 	return vpc, nil
 }
 


### PR DESCRIPTION
This PR adds IPv6 support for VPC creation in the Aviatrix Terraform provider.

## Changes Made:

### goaviatrix/vpc.go:
- Added IPv6 fields to Vpc struct:
  - EnableIpv6 (bool) - Flag to enable IPv6
  - VpcIpv6Cidr (string) - Single IPv6 CIDR for Azure
  - Ipv6AccessType (string) - Access type for GCP (INTERNAL/EXTERNAL)

- Updated CreateVpc function to handle IPv6 parameters
- Added conditional logic for different cloud providers (Azure vs GCP)

### aviatrix/resource_aviatrix_vpc.go:
- Added IPv6 schema fields:
  - enable_ipv6 (bool)
  - vpc_ipv6_cidr (string)
  - ipv6_access_type (string)
- Added validation for IPv6 CIDR blocks
-  Support for AWS,AZURE,GCP
- Updated Create, Read, and Update functions to handle IPv6 fields
- Added proper error handling for unsupported configurations
