### PR TITLE
AVX-67970: EaT should support downloading the cloud_init using iso format

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -118,6 +118,13 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				},
 				Description: "The location where the ZTP file will be stored locally.",
 			},
+			"ztp_file_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "ZTP file type.",
+				ValidateFunc: validation.StringInSlice([]string{"iso", "cloud-init"}, false),
+			},
 			"allocate_new_eip": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -3968,7 +3975,7 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 			// Double the backoff time after each failed try
 			backoff *= 2
 		}
-		if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGEEQUINIX|goaviatrix.EDGEMEGAPORT) {
+		if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGEEQUINIX|goaviatrix.EDGEMEGAPORT|goaviatrix.EDGESELFMANAGED) {
 			vpcID, ok := d.Get("vpc_id").(string)
 			if !ok {
 				return fmt.Errorf("vpc_id is not a string")
@@ -3988,7 +3995,7 @@ func resourceAviatrixTransitGatewayDelete(d *schema.ResourceData, meta interface
 	if err != nil {
 		return fmt.Errorf("failed to delete Aviatrix Edge Transit Gateway: %s", err)
 	}
-	if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGEEQUINIX|goaviatrix.EDGEMEGAPORT) {
+	if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGEEQUINIX|goaviatrix.EDGEMEGAPORT|goaviatrix.EDGESELFMANAGED) {
 		vpcID, ok := d.Get("vpc_id").(string)
 		if !ok {
 			return fmt.Errorf("vpc_id is not a string")
@@ -4062,6 +4069,13 @@ func createEdgeTransitGateway(d *schema.ResourceData, client *goaviatrix.Client,
 		gateway.ZtpFileDownloadPath, ok = d.Get("ztp_file_download_path").(string)
 		if !ok {
 			return fmt.Errorf("ztp_file_download_path attribute is required for Edge Transit Gateway")
+		}
+		if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGESELFMANAGED) {
+			gateway.ZtpFileType, ok = d.Get("ztp_file_type").(string)
+			if !ok {
+				return fmt.Errorf("ztp_file_type attribute is required for Selfmanaged Edge Transit Gateway")
+			}
+			gateway.GatewayRegistrationMethod = gateway.ZtpFileType
 		}
 		managementEgressIPPrefixList := getStringSet(d, "management_egress_ip_prefix_list")
 		if len(managementEgressIPPrefixList) > 0 {
@@ -4412,6 +4426,15 @@ func getTransitHaGatewayDetails(d *schema.ResourceData, wanCount int, cloudType 
 	haManagementEgressIPPrefixList := getStringSet(d, "ha_management_egress_ip_prefix_list")
 	if len(haManagementEgressIPPrefixList) > 0 {
 		transitHaGw.ManagementEgressIPPrefix = strings.Join(haManagementEgressIPPrefixList, ",")
+	}
+
+	// ztp file type and registration method is only required for self-managed edge
+	if goaviatrix.IsCloudType(cloudType, goaviatrix.EDGESELFMANAGED) {
+		transitHaGw.ZtpFileType, ok = d.Get("ztp_file_type").(string)
+		if !ok {
+			return nil, fmt.Errorf("ztp_file_type is required for HA Edge Transit Gateway")
+		}
+		transitHaGw.GatewayRegistrationMethod = transitHaGw.ZtpFileType
 	}
 	return transitHaGw, nil
 }

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -4018,6 +4018,11 @@ func deleteZtpFile(gatewayName, vpcID, ztpFileDownloadPath string) error {
 	if err := os.Remove(fileName); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("could not remove the ztp file: %w", err)
 	}
+	// remove iso file
+	isoFileName := ztpFileDownloadPath + "/" + gatewayName + "-" + vpcID + ".iso"
+	if err := os.Remove(isoFileName); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("could not remove the iso file: %w", err)
+	}
 	return nil
 }
 

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -379,6 +379,7 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceNameSelfManaged, "interfaces.0.gateway_ip", "192.168.20.1"),
 						resource.TestCheckResourceAttr(resourceNameSelfManaged, "interfaces.0.ip_address", "192.168.20.11/24"),
 						resource.TestCheckResourceAttr(resourceNameSelfManaged, "interfaces.0.logical_ifname", "wan0"),
+						resource.TestCheckResourceAttr(resourceNameSelfManaged, "ztp_file_type", "iso"),
 					),
 				},
 				{
@@ -692,6 +693,7 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_selfmanaged" {
 	vpc_id       = "%[2]s"
 	gw_size      = ""
 	ztp_file_download_path = "/tmp"
+	ztp_file_type = "iso"
 	interfaces {
         gateway_ip     = "192.168.20.1"
         ip_address     = "192.168.20.11/24"

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -422,7 +422,8 @@ The following arguments are supported:
 * `subnet` - (Required) A VPC Network address range selected from one of the available network ranges. Example: "172.31.0.0/20". **NOTE: If using `insane_mode`, please see notes [here](#insane_mode).**
 * `availability_domain` - (Optional) Availability domain. Required and valid only for OCI. Available as of provider version R2.19.3.
 * `fault_domain` - (Optional) Fault domain. Required and valid only for OCI. Available as of provider version R2.19.3.
-* `ztp_file_download_path` - (Optional) Ztp file download path where the cloud init file will be stored locally. Required only for Equinix EAT gateway.
+* `ztp_file_download_path` - (Optional) Ztp file download path where the cloud init file will be stored locally. Required only for Equinix, Megaport and Selfmanaged EAT gateway.
+* `ztp_file_type` - (Optional) ZTP file type. Valid values: "iso", "cloud-init". Required only for Selfmanaged EAT gateway.
 * `device_id` - (Optional) Device ID for AEP EAT gateway. Required only for AEP gateway.
 * `interfaces` - (Optional) A list of WAN/Management interfaces, each represented as a map. Required and valid only for edge transit gateways AEP and Equinix. Each interface has the following attributes:
   * `logical_ifname` - (Required) Logical interface name e.g., wan0, mgmt0.

--- a/goaviatrix/transit_ha_gateway.go
+++ b/goaviatrix/transit_ha_gateway.go
@@ -5,34 +5,36 @@ import (
 )
 
 type TransitHaGateway struct {
-	Action                   string `json:"action"`
-	CID                      string `json:"CID"`
-	AccountName              string `json:"account_name"`
-	CloudType                int    `json:"cloud_type"`
-	VpcID                    string `json:"vpc_id,omitempty"`
-	VNetNameResourceGroup    string `json:"vnet_and_resource_group_names"`
-	PrimaryGwName            string `json:"primary_gw_name"`
-	GwName                   string `json:"ha_gw_name"`
-	GwSize                   string `json:"gw_size"`
-	Subnet                   string `json:"gw_subnet"`
-	VpcRegion                string `json:"region"`
-	Zone                     string `json:"zone"`
-	AvailabilityDomain       string `json:"availability_domain"`
-	FaultDomain              string `json:"fault_domain"`
-	BgpLanVpcID              string `json:"bgp_lan_vpc"`
-	BgpLanSubnet             string `json:"bgp_lan_specify_subnet"`
-	Eip                      string `json:"eip,omitempty"`
-	InsaneMode               string `json:"insane_mode"`
-	TagList                  string `json:"tag_string"`
-	TagJSON                  string `json:"tag_json"`
-	AutoGenHaGwName          string `json:"autogen_hagw_name"`
-	BackupLinkList           []BackupLinkInterface
-	BackupLinkConfig         string `json:"backup_link_config,omitempty"`
-	InterfaceMapping         string `json:"interface_mapping,omitempty"`
-	Interfaces               string `json:"interfaces,omitempty"`
-	DeviceID                 string `json:"device_id,omitempty"`
-	ZtpFileDownloadPath      string `json:"-"`
-	ManagementEgressIPPrefix string `json:"mgmt_egress_ip,omitempty"`
+	Action                    string `json:"action"`
+	CID                       string `json:"CID"`
+	AccountName               string `json:"account_name"`
+	CloudType                 int    `json:"cloud_type"`
+	VpcID                     string `json:"vpc_id,omitempty"`
+	VNetNameResourceGroup     string `json:"vnet_and_resource_group_names"`
+	PrimaryGwName             string `json:"primary_gw_name"`
+	GwName                    string `json:"ha_gw_name"`
+	GwSize                    string `json:"gw_size"`
+	Subnet                    string `json:"gw_subnet"`
+	VpcRegion                 string `json:"region"`
+	Zone                      string `json:"zone"`
+	AvailabilityDomain        string `json:"availability_domain"`
+	FaultDomain               string `json:"fault_domain"`
+	BgpLanVpcID               string `json:"bgp_lan_vpc"`
+	BgpLanSubnet              string `json:"bgp_lan_specify_subnet"`
+	Eip                       string `json:"eip,omitempty"`
+	InsaneMode                string `json:"insane_mode"`
+	TagList                   string `json:"tag_string"`
+	TagJSON                   string `json:"tag_json"`
+	AutoGenHaGwName           string `json:"autogen_hagw_name"`
+	BackupLinkList            []BackupLinkInterface
+	BackupLinkConfig          string `json:"backup_link_config,omitempty"`
+	InterfaceMapping          string `json:"interface_mapping,omitempty"`
+	Interfaces                string `json:"interfaces,omitempty"`
+	DeviceID                  string `json:"device_id,omitempty"`
+	ZtpFileDownloadPath       string `json:"-"`
+	ZtpFileType               string `json:"ztp_file_type,omitempty"`
+	GatewayRegistrationMethod string `json:"gw_registration_method,omitempty"`
+	ManagementEgressIPPrefix  string `json:"mgmt_egress_ip,omitempty"`
 }
 
 type BackupLinkInterface struct {
@@ -58,6 +60,29 @@ func (c *Client) CreateTransitHaGw(transitHaGateway *TransitHaGateway) (string, 
 		err = createZtpFile(fileName, data.Result)
 		if err != nil {
 			return "", err
+		}
+	}
+
+	if IsCloudType(transitHaGateway.CloudType, EDGESELFMANAGED) {
+		// log the ztp file type
+		var fileName string
+		if transitHaGateway.ZtpFileType == "iso" {
+			fileName = transitHaGateway.ZtpFileDownloadPath + "/" + transitHaGateway.GwName + "-" + transitHaGateway.VpcID + ".iso"
+			// For ISO files, handle binary content differently
+			err = createZtpFileISO(fileName, data.Result)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			fileName = getFileName(transitHaGateway.ZtpFileDownloadPath, transitHaGateway.GwName, transitHaGateway.VpcID)
+			fileContent, err := processZtpFileContent(data.Result)
+			if err != nil {
+				return "", err
+			}
+			err = createZtpFile(fileName, fileContent)
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 	return resp, nil


### PR DESCRIPTION
Right now, EAT created via TF will only output cloud init in regular text mode.
For ESXI edges, it needs to support this config in iso format as well.
This Jira is to track that work, which is missing for EaT.

TF should support something like:

ztp_file_type          = "iso"
 ztp_file_download_path = "/ztp/download/path"
This functionality exists for EaS, but is missing for EAT, just to be clear.