### PR TITLE
AVX-66795 increase timeout waiting for transit-peering API

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway_peering.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering.go
@@ -269,7 +269,7 @@ func resourceAviatrixTransitGatewayPeeringCreate(d *schema.ResourceData, meta in
 		}
 	}()
 
-	const timeoutDuration = 30 * time.Second
+	const timeoutDuration = 180 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
 	defer cancel()
 	err = client.CreateTransitGatewayPeering(ctx, transitGatewayPeering)


### PR DESCRIPTION
A recent change during refactor in 8.0 introduced 30s timeout for TransitGatewayPeering which typically takes around a min to complete. TF always gets "context deadline exceeded" error due to this.