### PR TITLE
Fixing the enable_ha change for external device connection

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -458,7 +458,12 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 		GwName:         d.Get("gw_name").(string),
 	}
 
-	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+	if err != nil {
+		return diag.Errorf("could not get local gateway details: %v", err)
+	}
+
+	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 	if err != nil {
 		if err == goaviatrix.ErrNotFound {
 			d.SetId("")

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -154,9 +154,15 @@ func testAccCheckEdgeSpokeExternalDeviceConnExists(resourceName string) resource
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["site_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
 
-		conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+		localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+
+		conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 		if err != nil {
 			return err
 		}
@@ -180,9 +186,15 @@ func testAccCheckEdgeSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["site_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
 
-		_, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+		localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+
+		_, err = client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 		if err != goaviatrix.ErrNotFound {
 			return fmt.Errorf("edge as a spoke external device conn still exists %s", err.Error())
 		}

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -159,7 +159,7 @@ func testAccCheckEdgeSpokeExternalDeviceConnExists(resourceName string) resource
 
 		localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 
 		conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
@@ -191,7 +191,7 @@ func testAccCheckEdgeSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 
 		localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 
 		_, err = client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -970,7 +970,7 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 
 	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
 	if err != nil {
-		return fmt.Errorf("could not get local gateway details: %v", err)
+		return fmt.Errorf("could not get local gateway details: %w", err)
 	}
 
 	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -965,9 +965,15 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 	externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 		VpcID:          d.Get("vpc_id").(string),
 		ConnectionName: d.Get("connection_name").(string),
+		GwName:         d.Get("gw_name").(string),
 	}
 
-	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+	if err != nil {
+		return fmt.Errorf("could not get local gateway details: %v", err)
+	}
+
+	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 	log.Printf("[TRACE] Reading Aviatrix external device conn: %s : %#v", d.Get("connection_name").(string), externalDeviceConn)
 
 	if err != nil {

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
@@ -120,7 +120,7 @@ func testAccCheckSpokeExternalDeviceConnExists(n string, externalDeviceConn *goa
 		}
 		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != nil {
@@ -150,12 +150,12 @@ func testAccCheckSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 		}
 		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 
 		_, err = client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != goaviatrix.ErrNotFound {
-			return fmt.Errorf("site2cloud still exists %s", err.Error())
+			return fmt.Errorf("site2cloud still exists: %w", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
@@ -116,8 +116,13 @@ func testAccCheckSpokeExternalDeviceConnExists(n string, externalDeviceConn *goa
 		foundExternalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["vpc_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
-		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn)
+		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != nil {
 			return err
 		}
@@ -141,9 +146,14 @@ func testAccCheckSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 		foundExternalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["vpc_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
+		}
+		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
 		}
 
-		_, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn)
+		_, err = client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != goaviatrix.ErrNotFound {
 			return fmt.Errorf("site2cloud still exists %s", err.Error())
 		}

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -1060,7 +1060,7 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 
 	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
 	if err != nil {
-		return fmt.Errorf("could not get local gateway details: %v", err)
+		return fmt.Errorf("could not get local gateway details: %w", err)
 	}
 
 	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -1055,9 +1055,15 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 	externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 		VpcID:          d.Get("vpc_id").(string),
 		ConnectionName: d.Get("connection_name").(string),
+		GwName:         d.Get("gw_name").(string),
 	}
 
-	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+	if err != nil {
+		return fmt.Errorf("could not get local gateway details: %v", err)
+	}
+
+	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 	log.Printf("[TRACE] Reading Aviatrix external device conn: %s : %#v", d.Get("connection_name").(string), externalDeviceConn)
 
 	if err != nil {

--- a/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
@@ -261,8 +261,13 @@ func testAccCheckTransitExternalDeviceConnExists(n string, externalDeviceConn *g
 		foundExternalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["vpc_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
-		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn)
+		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != nil {
 			return err
 		}
@@ -286,9 +291,15 @@ func testAccCheckTransitExternalDeviceConnDestroy(s *terraform.State) error {
 		foundExternalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["vpc_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
 
-		_, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn)
+		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+
+		_, err = client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != goaviatrix.ErrNotFound {
 			return fmt.Errorf("site2cloud still exists %s", err.Error())
 		}

--- a/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
@@ -265,7 +265,7 @@ func testAccCheckTransitExternalDeviceConnExists(n string, externalDeviceConn *g
 		}
 		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != nil {
@@ -296,7 +296,7 @@ func testAccCheckTransitExternalDeviceConnDestroy(s *terraform.State) error {
 
 		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 
 		_, err = client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -228,6 +228,7 @@ type Gateway struct {
 	LogicalEipMap                   map[string][]EipMap                 `json:"logical_intf_eip_map,omitempty"`
 	IfNamesTranslation              map[string]string                   `json:"ifnames_translation,omitempty"`
 	ManagementEgressIPPrefix        string                              `json:"mgmt_egress_ip,omitempty"`
+	EdgeGateway                     bool                                `json:"edge_gateway,omitempty"`
 }
 
 type HaGateway struct {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -176,7 +176,7 @@ func (c *Client) CreateExternalDeviceConn(externalDeviceConn *ExternalDeviceConn
 	return c.PostAPI(externalDeviceConn.Action, externalDeviceConn, BasicCheck)
 }
 
-func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceConn) (*ExternalDeviceConn, error) {
+func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceConn, localGateway *Gateway) (*ExternalDeviceConn, error) {
 	params := map[string]string{
 		"CID":       c.CID,
 		"action":    "get_site2cloud_conn_detail",
@@ -300,7 +300,7 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 						} else {
 							// two external devices, remote has HA
 							// activemesh is disabled, 2 straight tunnels only
-							if strings.HasPrefix(externalDeviceConnDetail.TunnelType, "Transit") {
+							if localGateway != nil && localGateway.EdgeGateway && localGateway.TransitVpc == "yes" {
 								externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
 								externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
 								externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -299,13 +299,10 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 						} else {
 							// two external devices, remote has HA
 							// activemesh is disabled, 2 straight tunnels only
-							externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
-							externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
-							externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
-							externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
-							externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
-							externalDeviceConn.HAEnabled = "enabled"
-							externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
+							externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
+							externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
+							externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
+							externalDeviceConn.HAEnabled = "disabled"
 						}
 					} else if len(remoteIP) == 4 {
 						if remoteIP[0] == remoteIP[2] && remoteIP[1] == remoteIP[3] {


### PR DESCRIPTION
Enable HA value was enabled when there were two remote connections. This logic is only applicable for EAT external device connection. 
PR - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2167/files#diff-a74471d814210d0b5fa34660c7cedc4422bccbfc1ddd00cc8b2e24d0c7796db6R268-R276

For spoke external device connection, enable HA is disabled for 2 remote connections. Updating the `get_site2cloud_conn_detail` to handle the logic for spoke and EAT device connections differently
