### PR TITLE
AVX-68228 terraform support for IPv6 AWS and Azure VPC and Gateway

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -2743,12 +2743,12 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 		if d.Get("enable_ipv6").(bool) {
 			err := client.EnableIPv6(gateway)
 			if err != nil {
-				return fmt.Errorf("couldn't enable IPv6 on spoke gateway when updating: %s", err)
+				return fmt.Errorf("couldn't enable IPv6 on spoke gateway when updating: %w", err)
 			}
 		} else {
 			err := client.DisableIPv6(gateway)
 			if err != nil {
-				return fmt.Errorf("couldn't disable IPv6 on spoke gateway when updating: %s", err)
+				return fmt.Errorf("couldn't disable IPv6 on spoke gateway when updating: %w", err)
 			}
 		}
 	}

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -626,6 +626,12 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description: "BGP communities gateway accept configuration.",
 				Default:     false,
 			},
+			"enable_ipv6": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable IPv6 for the gateway. Only supported for AWS (1), Azure (8).",
+			},
 		},
 	}
 }
@@ -1011,6 +1017,14 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 
 	if gateway.EnableGlobalVpc && !goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.GCPRelatedCloudTypes) {
 		return fmt.Errorf("'enable_global_vpc' is only valid for GCP")
+	}
+
+	enableIpv6 := d.Get("enable_ipv6").(bool)
+	if enableIpv6 {
+		if !goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes|goaviatrix.AWSRelatedCloudTypes) {
+			return fmt.Errorf("error creating gateway: enable_ipv6 is only supported for AWS (1), Azure (8)")
+		}
+		gateway.EnableIPv6 = true
 	}
 
 	log.Printf("[INFO] Creating Aviatrix Spoke Gateway: %#v", gateway)
@@ -1471,6 +1485,8 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("enable_jumbo_frame", gw.JumboFrame)
 	d.Set("enable_bgp", gw.EnableBgp)
 	d.Set("enable_bgp_over_lan", goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) && gw.EnableBgpOverLan)
+	d.Set("enable_ipv6", gw.EnableIPv6)
+
 	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) && gw.EnableBgpOverLan {
 		bgpLanIpInfo, err := client.GetBgpLanIPList(&goaviatrix.TransitVpc{GwName: gateway.GwName})
 		if err != nil {
@@ -2719,6 +2735,20 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 			err := client.DisableGlobalVpc(gateway)
 			if err != nil {
 				return fmt.Errorf("could not disable global vpc during spoke gateway update: %w", err)
+			}
+		}
+	}
+
+	if d.HasChange("enable_ipv6") {
+		if d.Get("enable_ipv6").(bool) {
+			err := client.EnableIPv6(gateway)
+			if err != nil {
+				return fmt.Errorf("couldn't enable IPv6 on spoke gateway when updating: %s", err)
+			}
+		} else {
+			err := client.DisableIPv6(gateway)
+			if err != nil {
+				return fmt.Errorf("couldn't disable IPv6 on spoke gateway when updating: %s", err)
 			}
 		}
 	}

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -3904,12 +3904,12 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 		if d.Get("enable_ipv6").(bool) {
 			err := client.EnableIPv6(gateway)
 			if err != nil {
-				return fmt.Errorf("couldn't enable IPv6 on spoke gateway when updating: %s", err)
+				return fmt.Errorf("couldn't enable IPv6 on spoke gateway when updating: %w", err)
 			}
 		} else {
 			err := client.DisableIPv6(gateway)
 			if err != nil {
-				return fmt.Errorf("couldn't disable IPv6 on spoke gateway when updating: %s", err)
+				return fmt.Errorf("couldn't disable IPv6 on spoke gateway when updating: %w", err)
 			}
 		}
 	}

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -930,6 +930,12 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				Description: "BGP communities gateway accept configuration.",
 				Default:     false,
 			},
+			"enable_ipv6": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable IPv6 for the gateway. Only supported for AWS (1), Azure (8).",
+			},
 		},
 	}
 }
@@ -1395,6 +1401,14 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 			if _, ok := d.GetOk("private_mode_lb_vpc_id"); ok {
 				return fmt.Errorf("%q is only valid on when Private Mode is enabled", "private_mode_lb_vpc_id")
 			}
+		}
+
+		enableIpv6 := d.Get("enable_ipv6").(bool)
+		if enableIpv6 {
+			if !goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes|goaviatrix.AWSRelatedCloudTypes) {
+				return fmt.Errorf("error creating gateway: enable_ipv6 is only supported for AWS (1), Azure (8)")
+			}
+			gateway.EnableIPv6 = true
 		}
 
 		log.Printf("[INFO] Creating Aviatrix Transit Gateway: %#v", gateway)
@@ -1910,6 +1924,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 	d.Set("account_name", gw.AccountName)
 	d.Set("gw_name", gw.GwName)
 	d.Set("gw_size", gw.GwSize)
+	d.Set("enable_ipv6", gw.EnableIPv6)
 
 	// gateway bgp communities should be set only after the gateway is created and the gateway size is known.
 	// This will allow the AEP EAT gateways to be created before setting the communities.
@@ -3881,6 +3896,20 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 			err := client.ChangeBgpOverLanIntfCnt(haGw)
 			if err != nil {
 				return fmt.Errorf("could not modify BGP over LAN interface count for transit ha: %s during gateway update: %v", haGw.GwName, err)
+			}
+		}
+	}
+
+	if d.HasChange("enable_ipv6") {
+		if d.Get("enable_ipv6").(bool) {
+			err := client.EnableIPv6(gateway)
+			if err != nil {
+				return fmt.Errorf("couldn't enable IPv6 on spoke gateway when updating: %s", err)
+			}
+		} else {
+			err := client.DisableIPv6(gateway)
+			if err != nil {
+				return fmt.Errorf("couldn't disable IPv6 on spoke gateway when updating: %s", err)
 			}
 		}
 	}

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -254,6 +254,19 @@ resource "aviatrix_spoke_gateway" "test_spoke_gateway_azure" {
   bgp_lan_interfaces_count = 2
 }
 ```
+```hcl
+# Create an Aviatrix IPv6 Spoke Gateway
+resource "aviatrix_spoke_gateway" "test_spoke_gateway_aws" {
+  cloud_type        = 1
+  account_name      = "my-aws"
+  gw_name           = "spoke-gw-aws"
+  vpc_id            = "vpc-abcd123"
+  vpc_reg           = "us-west-1"
+  gw_size           = "t2.micro"
+  subnet            = "10.11.0.0/24"
+  enable_ipv6       = true
+}
+```
 
 ## Argument Reference
 
@@ -381,6 +394,7 @@ The following arguments are supported:
 * `private_mode_lb_vpc_id` - (Optional) VPC ID of Private Mode load balancer. Required when Private Mode is enabled on the Controller. Available in provider version R2.23+.
 * `private_mode_subnet_zone` - (Optional) Availability Zone of the subnet. Required when Private Mode is enabled on the Controller and `cloud_type` is AWS or AWSGov. Available in Provider version R2.23+.
 * `ha_private_mode_subnet_zone` - (Optional) Availability Zone of the HA subnet. Required when Private Mode is enabled on the Controller and `cloud_type` is AWS or AWSGov with HA. Available in Provider version R2.23+.
+* `enable_ipv6` - (Optional) To enable IPv6 CIDR in Spoke Gateway. Only AWS, Azure, AzureGov and AWSGov are supported.
 
 !> **WARNING:** Aviatrix released the Global VPC feature in Preview mode. Preview features are not safe for deployment in production environments.
 * `enable_global_vpc` - (Optional) Enable global VPC. Only supported for GCP spoke gateways. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -401,6 +401,26 @@ resource "aviatrix_transit_gateway" "edge-transit-test" {
     }
 }
 ```
+```hcl
+# Create an Aviatrix IPv6 Transit Network Gateway
+resource "aviatrix_transit_gateway" "test_transit_gateway_aws" {
+  cloud_type               = 1
+  account_name             = "devops_aws"
+  gw_name                  = "transit"
+  vpc_id                   = "vpc-abcd1234"
+  vpc_reg                  = "us-east-1"
+  gw_size                  = "t2.micro"
+  subnet                   = "10.1.0.0/24"
+  ha_subnet                = "10.1.0.0/24"
+  ha_gw_size               = "t2.micro"
+  tags                     = {
+    name = "value"
+  }
+  enable_hybrid_connection = true
+  connected_transit        = true
+  enable_ipv6 = true
+}
+```
 
 ## Argument Reference
 
@@ -491,6 +511,7 @@ The following arguments are supported:
 * `enable_multi_tier_transit` - (Optional) Enable Multi-tier Transit mode on transit gateway. When enabled, transit gateway will propagate routes it receives from its transit peering peer to other transit peering peers. `local_as_number` is required. Default value: false. Available as of provider version R2.19+.
 * `enable_s2c_rx_balancing` - (Optional) Enable S2C receive packet CPU re-balancing on transit gateway. Valid values: true, false. Default value: false. Available in provider version R2.21.2+.
 * `enable_preserve_as_path` - (Optional) Enable preserve as_path when advertising manual summary cidrs on transit gateway. Valid values: true, false. Default value: false. Available as of provider version R.2.22.1+.
+* `enable_ipv6` - (Optional) To enable IPv6 CIDR in Transit Gateway. Only AWS, Azure, AzureGov and AWSGov are supported.
 
 -> **NOTE:** Enabling FireNet will automatically enable hybrid connection. If `enable_firenet` is set to true, please set `enable_hybrid_connection` to true in the respective **aviatrix_transit_gateway** as well.
 

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -22,7 +22,7 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_aws" {
   vpc_reg                  = "us-east-1"
   gw_size                  = "t2.micro"
   subnet                   = "10.1.0.0/24"
-  ha_subnet                = "10.1.0.0/24"
+  ha_subnet                = "10.1.1.0/24"
   ha_gw_size               = "t2.micro"
   tags                     = {
     name = "value"
@@ -411,12 +411,6 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_aws" {
   vpc_reg                  = "us-east-1"
   gw_size                  = "t2.micro"
   subnet                   = "10.1.0.0/24"
-  ha_subnet                = "10.1.0.0/24"
-  ha_gw_size               = "t2.micro"
-  tags                     = {
-    name = "value"
-  }
-  enable_hybrid_connection = true
   connected_transit        = true
   enable_ipv6 = true
 }

--- a/docs/resources/aviatrix_vpc.md
+++ b/docs/resources/aviatrix_vpc.md
@@ -166,7 +166,7 @@ The following arguments are supported:
 * `enable_private_oob_subnet` - (Optional) Switch to enable private oob subnet. Only supported for AWS, AWSGov and AWSChina providers. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
 * `resource_group` - (Optional) The name of an existing resource group or a new resource group to be created for the Azure VNet.  A new resource group will be created if left blank. Only available for Azure, AzureGov and AzureChina providers. Available as of provider version R2.19+.
 * `enable_ipv6` - (Optional) To enable IPv6 CIDR in VPC. Only AWS, Azure, AzureGov and AWSGov are supported.
-* `vpc_ipv6_cidr` - (Optional) To configure IPv6 CIDR in Azure VPC. Only Azure, AzureGov are supported.
+* `vpc_ipv6_cidr` - (Optional) To configure IPv6 CIDR in Azure VPC. Only Azure, AzureGov are supported. On AWS/AWSGov, the IPv6 CIDR is automatically assigned and this field is ignored.
 
 ### Misc.
 * `aviatrix_transit_vpc` - (Optional) Specify whether it is an [Aviatrix Transit VPC](https://docs.aviatrix.com/HowTos/create_vpc.html#aviatrix-transit-vpc) to be used for [Transit Network](https://docs.aviatrix.com/HowTos/transitvpc_faq.html) or [TGW](https://docs.aviatrix.com/HowTos/tgw_faq.html) solutions. **Only AWS, AWSGov, AWSChina, and Alibaba Cloud are supported. Required to be false for other providers.** Valid values: true, false. Default: false.

--- a/docs/resources/aviatrix_vpc.md
+++ b/docs/resources/aviatrix_vpc.md
@@ -119,6 +119,29 @@ resource "aviatrix_vpc" "aliyun_vpc" {
   cidr         = "10.0.0.0/20"
 }
 ```
+```hcl
+# Create an AWS IPv6 Cloud VPC
+resource "aviatrix_vpc" "aws_vpc" {
+  cloud_type   = 1
+  account_name = "devops"
+  region       = "acs-us-west-1 (Silicon Valley)"
+  name         = "aws-vpc"
+  cidr         = "10.0.0.0/20"
+  enable_ipv6 = true
+}
+```
+```hcl
+# Create an Azure IPv6 Cloud VPC
+resource "aviatrix_vpc" "azure_vpc" {
+  cloud_type   = 8
+  account_name = "devops"
+  region       = "Central US"
+  name         = "azure-vpc"
+  cidr         = "10.0.0.0/20"
+  enable_ipv6  = true
+  vpc_ipv6_cidr = "2607:c000:1234::/56"
+}
+```
 
 ## Argument Reference
 
@@ -142,6 +165,8 @@ The following arguments are supported:
 * `num_of_subnet_pairs` - (Optional) Number of public subnet and private subnet pair created. Only supported for AWS, Azure provider. Example: 1. Available in provider version R2.17+.
 * `enable_private_oob_subnet` - (Optional) Switch to enable private oob subnet. Only supported for AWS, AWSGov and AWSChina providers. Valid values: true, false. Default value: false. Available as of provider version R2.18+.
 * `resource_group` - (Optional) The name of an existing resource group or a new resource group to be created for the Azure VNet.  A new resource group will be created if left blank. Only available for Azure, AzureGov and AzureChina providers. Available as of provider version R2.19+.
+* `enable_ipv6` - (Optional) To enable IPv6 CIDR in VPC. Only AWS, Azure, AzureGov and AWSGov are supported.
+* `vpc_ipv6_cidr` - (Optional) To configure IPv6 CIDR in Azure VPC. Only Azure, AzureGov are supported.
 
 ### Misc.
 * `aviatrix_transit_vpc` - (Optional) Specify whether it is an [Aviatrix Transit VPC](https://docs.aviatrix.com/HowTos/create_vpc.html#aviatrix-transit-vpc) to be used for [Transit Network](https://docs.aviatrix.com/HowTos/transitvpc_faq.html) or [TGW](https://docs.aviatrix.com/HowTos/tgw_faq.html) solutions. **Only AWS, AWSGov, AWSChina, and Alibaba Cloud are supported. Required to be false for other providers.** Valid values: true, false. Default: false.

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -228,6 +228,7 @@ type Gateway struct {
 	LogicalEipMap                   map[string][]EipMap                 `json:"logical_intf_eip_map,omitempty"`
 	IfNamesTranslation              map[string]string                   `json:"ifnames_translation,omitempty"`
 	ManagementEgressIPPrefix        string                              `json:"mgmt_egress_ip,omitempty"`
+	EnableIPv6                      bool                                `json:"enable_ipv6,omitempty"`
 }
 
 type HaGateway struct {
@@ -1458,4 +1459,24 @@ func (c *Client) GetGroGsoStatus(gateway *Gateway) (bool, error) {
 		return false, err
 	}
 	return strings.Contains(resp.Results, "GRO/GSO is enabled"), nil
+}
+
+func (c *Client) EnableIPv6(gateway *Gateway) error {
+	action := "enable_ipv6"
+	form := map[string]string{
+		"CID":          c.CID,
+		"action":       action,
+		"gateway_name": gateway.GwName,
+	}
+	return c.PostAPI(action, form, BasicCheck)
+}
+
+func (c *Client) DisableIPv6(gateway *Gateway) error {
+	action := "disable_ipv6"
+	form := map[string]string{
+		"CID":          c.CID,
+		"action":       action,
+		"gateway_name": gateway.GwName,
+	}
+	return c.PostAPI(action, form, BasicCheck)
 }

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -51,6 +51,7 @@ type SpokeVpc struct {
 	BgpLanInterfacesCount        int      `form:"bgp_lan_intf_count,omitempty"`
 	LbVpcId                      string   `form:"lb_vpc_id,omitempty"`
 	EnableGlobalVpc              bool     `form:"global_vpc"`
+	EnableIPv6                   bool     `json:"enable_ipv6,omitempty"`
 }
 
 type SpokeGatewayAdvancedConfig struct {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -77,6 +77,7 @@ type TransitVpc struct {
 	GatewayRegistrationMethod    string              `json:"gw_registration_method,omitempty"`
 	ManagementEgressIPPrefix     string              `json:"mgmt_egress_ip,omitempty"`
 	JumboFrame                   bool                `json:"jumbo_frame,omitempty"`
+	EnableIPv6                   bool                `json:"enable_ipv6,omitempty"`
 }
 
 type TransitGatewayAdvancedConfig struct {

--- a/goaviatrix/vpc.go
+++ b/goaviatrix/vpc.go
@@ -25,6 +25,8 @@ type Vpc struct {
 	PublicRoutesOnly       bool
 	ResourceGroup          string `json:"resource_group,omitempty"`
 	PrivateModeSubnets     bool
+	EnableIpv6             bool   `form:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
+	VpcIpv6Cidr            string `form:"vpc_ipv6_cidr,omitempty" json:"vpc_ipv6_cidr,omitempty"`
 }
 
 type VpcEdit struct {
@@ -43,6 +45,8 @@ type VpcEdit struct {
 	PublicSubnets          []SubnetInfo `json:"public_subnets,omitempty"`
 	PrivateSubnets         []SubnetInfo `json:"private_subnets,omitempty"`
 	PrivateModeSubnets     bool         `json:"private_mode_subnets"`
+	EnableIpv6             bool         `form:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
+	VpcIpv6Cidr            string       `form:"vpc_ipv6_cidr,omitempty" json:"vpc_ipv6_cidr,omitempty"`
 }
 
 type VpcResp struct {
@@ -110,6 +114,14 @@ func (c *Client) CreateVpc(vpc *Vpc) error {
 
 	if vpc.PrivateModeSubnets {
 		form["private_mode_subnets"] = "true"
+	}
+
+	if vpc.EnableIpv6 {
+		form["enable_ipv6"] = "true"
+	}
+
+	if vpc.EnableIpv6 && IsCloudType(vpc.CloudType, AzureArmRelatedCloudTypes) {
+		form["vpc_ipv6_cidr"] = vpc.VpcIpv6Cidr
 	}
 
 	return c.PostAPI(action, form, BasicCheck)
@@ -203,6 +215,8 @@ func (c *Client) GetVpc(vpc *Vpc) (*Vpc, error) {
 	vpc.NumOfSubnetPairs = data.Results.NumOfSubnetPairs
 	vpc.EnablePrivateOobSubnet = data.Results.EnablePrivateOobSubnet
 	vpc.PrivateModeSubnets = data.Results.PrivateModeSubnets
+	vpc.EnableIpv6 = data.Results.EnableIpv6
+	vpc.VpcIpv6Cidr = data.Results.VpcIpv6Cidr
 	return vpc, nil
 }
 


### PR DESCRIPTION
AVX-68228 terraform support for IPv6 AWS and Azure VPC and Multi cloud Gateway

Added support for IPv6 VPC for AWS and Azure.
Added support for IPv6 spoke/transit Gateway for AWS and Azure.