### PR TITLE
AVX-68132 Fixing the enable_ha change for external device connection [Backport rc-8.0]

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn.go
@@ -458,7 +458,12 @@ func resourceAviatrixEdgeSpokeExternalDeviceConnRead(ctx context.Context, d *sch
 		GwName:         d.Get("gw_name").(string),
 	}
 
-	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+	if err != nil {
+		return diag.Errorf("could not get local gateway details: %v", err)
+	}
+
+	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 	if err != nil {
 		if err == goaviatrix.ErrNotFound {
 			d.SetId("")

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -154,9 +154,15 @@ func testAccCheckEdgeSpokeExternalDeviceConnExists(resourceName string) resource
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["site_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
 
-		conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+		localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+
+		conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 		if err != nil {
 			return err
 		}
@@ -180,9 +186,15 @@ func testAccCheckEdgeSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 		externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["site_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
 
-		_, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+		localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+
+		_, err = client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 		if err != goaviatrix.ErrNotFound {
 			return fmt.Errorf("edge as a spoke external device conn still exists %s", err.Error())
 		}

--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -159,7 +159,7 @@ func testAccCheckEdgeSpokeExternalDeviceConnExists(resourceName string) resource
 
 		localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 
 		conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
@@ -191,7 +191,7 @@ func testAccCheckEdgeSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 
 		localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 
 		_, err = client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -905,7 +905,7 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 
 	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
 	if err != nil {
-		return fmt.Errorf("could not get local gateway details: %v", err)
+		return fmt.Errorf("could not get local gateway details: %w", err)
 	}
 
 	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -900,9 +900,15 @@ func resourceAviatrixSpokeExternalDeviceConnRead(d *schema.ResourceData, meta in
 	externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 		VpcID:          d.Get("vpc_id").(string),
 		ConnectionName: d.Get("connection_name").(string),
+		GwName:         d.Get("gw_name").(string),
 	}
 
-	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+	if err != nil {
+		return fmt.Errorf("could not get local gateway details: %v", err)
+	}
+
+	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 	log.Printf("[TRACE] Reading Aviatrix external device conn: %s : %#v", d.Get("connection_name").(string), externalDeviceConn)
 
 	if err != nil {

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
@@ -110,8 +110,13 @@ func testAccCheckSpokeExternalDeviceConnExists(n string, externalDeviceConn *goa
 		foundExternalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["vpc_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
-		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn)
+		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != nil {
 			return err
 		}
@@ -135,9 +140,14 @@ func testAccCheckSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 		foundExternalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["vpc_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
+		}
+		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
 		}
 
-		_, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn)
+		_, err = client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != goaviatrix.ErrNotFound {
 			return fmt.Errorf("site2cloud still exists %s", err.Error())
 		}

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
@@ -114,7 +114,7 @@ func testAccCheckSpokeExternalDeviceConnExists(n string, externalDeviceConn *goa
 		}
 		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != nil {
@@ -144,12 +144,12 @@ func testAccCheckSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 		}
 		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 
 		_, err = client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != goaviatrix.ErrNotFound {
-			return fmt.Errorf("site2cloud still exists %s", err.Error())
+			return fmt.Errorf("site2cloud still exists: %w", err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -996,7 +996,7 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 
 	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
 	if err != nil {
-		return fmt.Errorf("could not get local gateway details: %v", err)
+		return fmt.Errorf("could not get local gateway details: %w", err)
 	}
 
 	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -991,9 +991,15 @@ func resourceAviatrixTransitExternalDeviceConnRead(d *schema.ResourceData, meta 
 	externalDeviceConn := &goaviatrix.ExternalDeviceConn{
 		VpcID:          d.Get("vpc_id").(string),
 		ConnectionName: d.Get("connection_name").(string),
+		GwName:         d.Get("gw_name").(string),
 	}
 
-	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn)
+	localGateway, err := getGatewayDetails(client, externalDeviceConn.GwName)
+	if err != nil {
+		return fmt.Errorf("could not get local gateway details: %v", err)
+	}
+
+	conn, err := client.GetExternalDeviceConnDetail(externalDeviceConn, localGateway)
 	log.Printf("[TRACE] Reading Aviatrix external device conn: %s : %#v", d.Get("connection_name").(string), externalDeviceConn)
 
 	if err != nil {

--- a/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
@@ -261,8 +261,13 @@ func testAccCheckTransitExternalDeviceConnExists(n string, externalDeviceConn *g
 		foundExternalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["vpc_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
-		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn)
+		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != nil {
 			return err
 		}
@@ -286,9 +291,15 @@ func testAccCheckTransitExternalDeviceConnDestroy(s *terraform.State) error {
 		foundExternalDeviceConn := &goaviatrix.ExternalDeviceConn{
 			VpcID:          rs.Primary.Attributes["vpc_id"],
 			ConnectionName: rs.Primary.Attributes["connection_name"],
+			GwName:         rs.Primary.Attributes["gw_name"],
 		}
 
-		_, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn)
+		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
+		if err != nil {
+			return fmt.Errorf("could not get local gateway details: %v", err)
+		}
+
+		_, err = client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != goaviatrix.ErrNotFound {
 			return fmt.Errorf("site2cloud still exists %s", err.Error())
 		}

--- a/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
@@ -265,7 +265,7 @@ func testAccCheckTransitExternalDeviceConnExists(n string, externalDeviceConn *g
 		}
 		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 		foundExternalDeviceConn2, err := client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)
 		if err != nil {
@@ -296,7 +296,7 @@ func testAccCheckTransitExternalDeviceConnDestroy(s *terraform.State) error {
 
 		localGateway, err := getGatewayDetails(client, foundExternalDeviceConn.GwName)
 		if err != nil {
-			return fmt.Errorf("could not get local gateway details: %v", err)
+			return fmt.Errorf("could not get local gateway details: %w", err)
 		}
 
 		_, err = client.GetExternalDeviceConnDetail(foundExternalDeviceConn, localGateway)

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -228,6 +228,7 @@ type Gateway struct {
 	LogicalEipMap                   map[string][]EipMap                 `json:"logical_intf_eip_map,omitempty"`
 	IfNamesTranslation              map[string]string                   `json:"ifnames_translation,omitempty"`
 	ManagementEgressIPPrefix        string                              `json:"mgmt_egress_ip,omitempty"`
+	EdgeGateway                     bool                                `json:"edge_gateway,omitempty"`
 }
 
 type HaGateway struct {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -82,49 +82,53 @@ type ExternalDeviceConn struct {
 }
 
 type EditExternalDeviceConnDetail struct {
-	VpcID                  []string      `json:"vpc_id,omitempty"`
-	ConnectionName         []string      `json:"name,omitempty"`
-	GwName                 string        `json:"gw_name,omitempty"`
-	BgpLocalAsNum          string        `json:"bgp_local_asn_number,omitempty"`
-	BgpRemoteAsNum         string        `json:"bgp_remote_asn_number,omitempty"`
-	BgpStatus              string        `json:"bgp_status,omitempty"`
-	EnableBgpLanActiveMesh bool          `json:"bgp_lan_activemesh,omitempty"`
-	RemoteGatewayIP        string        `json:"peer_ip,omitempty"`
-	RemoteSubnet           string        `json:"remote_cidr,omitempty"`
-	DirectConnect          bool          `json:"direct_connect_primary,omitempty"`
-	LocalTunnelCidr        string        `json:"bgp_local_ip,omitempty"`
-	RemoteTunnelCidr       string        `json:"bgp_remote_ip,omitempty"`
-	Algorithm              AlgorithmInfo `json:"algorithm,omitempty"`
-	HAEnabled              string        `json:"ha_status,omitempty"`
-	BackupBgpRemoteAsNum   string        `json:"bgp_remote_backup_asn_number,omitempty"`
-	BackupLocalTunnelCidr  string        `json:"bgp_backup_local_ip,omitempty"`
-	BackupRemoteTunnelCidr string        `json:"bgp_backup_remote_ip,omitempty"`
-	BackupDirectConnect    bool          `json:"direct_connect_backup,omitempty"`
-	EnableEdgeSegmentation bool          `json:"enable_edge_segmentation,omitempty"`
-	Tunnels                []TunnelInfo  `json:"tunnels,omitempty"`
-	ActiveActiveHA         string        `json:"active_active_ha,omitempty"`
-	ManualBGPCidrs         []string      `json:"conn_bgp_manual_advertise_cidrs,omitempty"`
-	BackupRemoteGatewayIP  string
-	PreSharedKey           string
-	BackupPreSharedKey     string
-	IkeVer                 string         `json:"ike_ver,omitempty"`
-	PeerVnetId             string         `json:"peer_vnet_id,omitempty"`
-	RemoteLanIP            string         `json:"remote_lan_ip,omitempty"`
-	LocalLanIP             string         `json:"local_lan_ip,omitempty"`
-	BackupRemoteLanIP      string         `json:"backup_remote_lan_ip,omitempty"`
-	BackupLocalLanIP       string         `json:"backup_local_lan_ip,omitempty"`
-	EventTriggeredHA       string         `json:"event_triggered_ha,omitempty"`
-	Phase1LocalIdentifier  string         `json:"ph1_identifier,omitempty"`
-	Phase1RemoteIdentifier string         `json:"phase1_remote_id,omitempty"`
-	PrependAsPath          string         `json:"conn_bgp_prepend_as_path,omitempty"`
-	EnableJumboFrame       bool           `json:"jumbo_frame,omitempty"`
-	WanUnderlay            bool           `json:"wan_underlay,omitempty"`
-	RemoteCloudType        string         `json:"remote_cloud_type,omitempty"`
-	BgpBfdConfig           map[string]int `json:"bgp_bfd_params,omitempty"`
-	EnableBfd              bool           `json:"bgp_bfd_enabled,omitempty"`
-	EnableBgpMultihop      bool           `json:"bgp_multihop_enabled,omitempty"`
-	DisableActivemesh      bool           `json:"disable_activemesh,omitempty"`
-	TunnelSrcIP            string         `json:"local_device_ip,omitempty"`
+	VpcID                      []string      `json:"vpc_id,omitempty"`
+	ConnectionName             []string      `json:"name,omitempty"`
+	GwName                     string        `json:"gw_name,omitempty"`
+	BgpLocalAsNum              string        `json:"bgp_local_asn_number,omitempty"`
+	BgpRemoteAsNum             string        `json:"bgp_remote_asn_number,omitempty"`
+	BgpStatus                  string        `json:"bgp_status,omitempty"`
+	BgpSendCommunities         string        `json:"conn_bgp_send_communities,omitempty"`
+	BgpSendCommunitiesAdditive bool          `json:"conn_bgp_send_communities_additive,omitempty"`
+	BgpSendCommunitiesBlock    bool          `json:"conn_bgp_send_communities_block,omitempty"`
+	EnableBgpLanActiveMesh     bool          `json:"bgp_lan_activemesh,omitempty"`
+	RemoteGatewayIP            string        `json:"peer_ip,omitempty"`
+	RemoteSubnet               string        `json:"remote_cidr,omitempty"`
+	DirectConnect              bool          `json:"direct_connect_primary,omitempty"`
+	LocalTunnelCidr            string        `json:"bgp_local_ip,omitempty"`
+	RemoteTunnelCidr           string        `json:"bgp_remote_ip,omitempty"`
+	Algorithm                  AlgorithmInfo `json:"algorithm,omitempty"`
+	HAEnabled                  string        `json:"ha_status,omitempty"`
+	BackupBgpRemoteAsNum       string        `json:"bgp_remote_backup_asn_number,omitempty"`
+	BackupLocalTunnelCidr      string        `json:"bgp_backup_local_ip,omitempty"`
+	BackupRemoteTunnelCidr     string        `json:"bgp_backup_remote_ip,omitempty"`
+	BackupDirectConnect        bool          `json:"direct_connect_backup,omitempty"`
+	EnableEdgeSegmentation     bool          `json:"enable_edge_segmentation,omitempty"`
+	Tunnels                    []TunnelInfo  `json:"tunnels,omitempty"`
+	ActiveActiveHA             string        `json:"active_active_ha,omitempty"`
+	ManualBGPCidrs             []string      `json:"conn_bgp_manual_advertise_cidrs,omitempty"`
+	BackupRemoteGatewayIP      string
+	PreSharedKey               string
+	BackupPreSharedKey         string
+	IkeVer                     string         `json:"ike_ver,omitempty"`
+	PeerVnetID                 string         `json:"peer_vnet_id,omitempty"`
+	RemoteLanIP                string         `json:"remote_lan_ip,omitempty"`
+	LocalLanIP                 string         `json:"local_lan_ip,omitempty"`
+	BackupRemoteLanIP          string         `json:"backup_remote_lan_ip,omitempty"`
+	BackupLocalLanIP           string         `json:"backup_local_lan_ip,omitempty"`
+	EventTriggeredHA           string         `json:"event_triggered_ha,omitempty"`
+	Phase1LocalIdentifier      string         `json:"ph1_identifier,omitempty"`
+	Phase1RemoteIdentifier     string         `json:"phase1_remote_id,omitempty"`
+	PrependAsPath              string         `json:"conn_bgp_prepend_as_path,omitempty"`
+	EnableJumboFrame           bool           `json:"jumbo_frame,omitempty"`
+	WanUnderlay                bool           `json:"wan_underlay,omitempty"`
+	RemoteCloudType            string         `json:"remote_cloud_type,omitempty"`
+	BgpBfdConfig               map[string]int `json:"bgp_bfd_params,omitempty"`
+	EnableBfd                  bool           `json:"bgp_bfd_enabled,omitempty"`
+	EnableBgpMultihop          bool           `json:"bgp_multihop_enabled,omitempty"`
+	DisableActivemesh          bool           `json:"disable_activemesh,omitempty"`
+	TunnelSrcIP                string         `json:"local_device_ip,omitempty"`
+	TunnelType                 string         `json:"tunnel_type,omitempty"`
 }
 
 type BgpBfdConfig struct {
@@ -267,10 +271,20 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 						} else {
 							// two external devices, remote has HA
 							// activemesh is disabled, 2 straight tunnels only
-							externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
-							externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
-							externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
-							externalDeviceConn.HAEnabled = "disabled"
+							if strings.HasPrefix(externalDeviceConnDetail.TunnelType, "Transit") {
+								externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
+								externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
+								externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
+								externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
+								externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
+								externalDeviceConn.HAEnabled = "enabled"
+								externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
+							} else {
+								externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
+								externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
+								externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
+								externalDeviceConn.HAEnabled = "disabled"
+							}
 						}
 					} else if len(remoteIP) == 4 {
 						if remoteIP[0] == remoteIP[2] && remoteIP[1] == remoteIP[3] {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -163,7 +163,7 @@ func (c *Client) CreateExternalDeviceConn(externalDeviceConn *ExternalDeviceConn
 	return c.PostAPI(externalDeviceConn.Action, externalDeviceConn, BasicCheck)
 }
 
-func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceConn) (*ExternalDeviceConn, error) {
+func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceConn, localGateway *Gateway) (*ExternalDeviceConn, error) {
 	params := map[string]string{
 		"CID":       c.CID,
 		"action":    "get_site2cloud_conn_detail",
@@ -271,7 +271,7 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 						} else {
 							// two external devices, remote has HA
 							// activemesh is disabled, 2 straight tunnels only
-							if strings.HasPrefix(externalDeviceConnDetail.TunnelType, "Transit") {
+							if localGateway != nil && localGateway.EdgeGateway && localGateway.TransitVpc == "yes" {
 								externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
 								externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
 								externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -11,10 +11,26 @@ import (
 
 // ExternalDeviceConn: a simple struct to hold external device connection details
 const (
+	Enabled  = "enabled"
+	Disabled = "disabled"
+
 	defaultBfdReceiveInterval  = 300
 	defaultBfdTransmitInterval = 300
 	defaultBfdMultiplier       = 3
 )
+
+// on returns "enabled" if b is true, "disabled" otherwise
+func on(b bool) string {
+	if b {
+		return Enabled
+	}
+	return Disabled
+}
+
+// join2 joins two strings with a comma separator
+func join2(a, b string) string {
+	return strings.Join([]string{a, b}, ",")
+}
 
 var defaultBfdConfig = BgpBfdConfig{
 	TransmitInterval: defaultBfdTransmitInterval,
@@ -453,14 +469,14 @@ func configureHAForTwoDevices(externalDeviceConn *ExternalDeviceConn, externalDe
 		externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
 		externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
 		externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
-		externalDeviceConn.HAEnabled = "enabled"
+		externalDeviceConn.HAEnabled = Enabled
 		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
 	} else {
 		// Non-edge gateways treat dual devices as combined configuration (no true HA)
-		externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
-		externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
-		externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
-		externalDeviceConn.HAEnabled = "disabled"
+		externalDeviceConn.LocalTunnelCidr = join2(externalDeviceConnDetail.LocalTunnelCidr, externalDeviceConnDetail.BackupLocalTunnelCidr)
+		externalDeviceConn.RemoteTunnelCidr = join2(externalDeviceConnDetail.RemoteTunnelCidr, externalDeviceConnDetail.BackupRemoteTunnelCidr)
+		externalDeviceConn.RemoteGatewayIP = join2(remoteIP[0], remoteIP[1])
+		externalDeviceConn.HAEnabled = Disabled
 	}
 }
 
@@ -529,17 +545,8 @@ func populateAlgorithmInfo(externalDeviceConn *ExternalDeviceConn, externalDevic
 
 // populateDirectConnectInfo populates direct connect information
 func populateDirectConnectInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail) {
-	if externalDeviceConnDetail.DirectConnect {
-		externalDeviceConn.DirectConnect = "enabled"
-	} else {
-		externalDeviceConn.DirectConnect = "disabled"
-	}
-
-	if externalDeviceConnDetail.BackupDirectConnect {
-		externalDeviceConn.BackupDirectConnect = "enabled"
-	} else {
-		externalDeviceConn.BackupDirectConnect = "disabled"
-	}
+	externalDeviceConn.DirectConnect = on(externalDeviceConnDetail.DirectConnect)
+	externalDeviceConn.BackupDirectConnect = on(externalDeviceConnDetail.BackupDirectConnect)
 }
 
 // parseBackupBgpRemoteAsNumber parses backup BGP remote AS number
@@ -557,15 +564,19 @@ func populateBgpSendCommunitiesInfo(externalDeviceConn *ExternalDeviceConn, exte
 	// Example1: "conn_bgp_send_communities": "additive 444:444"
 	// Example2: "conn_bgp_send_communities": "block"
 	// We need to parse this field to set the BgpSendCommunities, BgpSendCommunitiesAdditive and BgpSendCommunitiesBlock fields
-	if externalDeviceConnDetail.BgpSendCommunities != "" {
-		commList := strings.Split(externalDeviceConnDetail.BgpSendCommunities, " ")
-		if len(commList) > 0 && commList[0] == "block" {
-			externalDeviceConn.BgpSendCommunitiesBlock = true
-		} else if len(commList) > 0 && commList[0] == "additive" {
-			externalDeviceConn.BgpSendCommunitiesAdditive = true
-			commList = commList[1:]
-			externalDeviceConn.BgpSendCommunities = strings.Join(commList, " ")
-		}
+	if externalDeviceConnDetail.BgpSendCommunities == "" {
+		return
+	}
+	parts := strings.Fields(externalDeviceConnDetail.BgpSendCommunities)
+	if len(parts) == 0 {
+		return
+	}
+	switch parts[0] {
+	case "block":
+		externalDeviceConn.BgpSendCommunitiesBlock = true
+	case "additive":
+		externalDeviceConn.BgpSendCommunitiesAdditive = true
+		externalDeviceConn.BgpSendCommunities = strings.Join(parts[1:], " ")
 	}
 }
 
@@ -585,35 +596,39 @@ func populateNonLANTunnelInfo(externalDeviceConn *ExternalDeviceConn, externalDe
 
 // configureLocalGatewayHAEnabled configures HA when local gateway has HA enabled
 func configureLocalGatewayHAEnabled(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail, localGateway *Gateway, backupBgpRemoteAsNumber int) {
-	if len(externalDeviceConnDetail.Tunnels) == 2 {
+	nTunnels := len(externalDeviceConnDetail.Tunnels)
+	switch nTunnels {
+	case 2:
 		remoteIP := strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")
-		if len(remoteIP) == 2 {
+		nIPs := len(remoteIP)
+		switch nIPs {
+		case 2:
 			if remoteIP[0] == remoteIP[1] {
 				// one external device, no remote HA
-				externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
-				externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
-				externalDeviceConn.HAEnabled = "disabled"
+				externalDeviceConn.LocalTunnelCidr = join2(externalDeviceConnDetail.LocalTunnelCidr, externalDeviceConnDetail.BackupLocalTunnelCidr)
+				externalDeviceConn.RemoteTunnelCidr = join2(externalDeviceConnDetail.RemoteTunnelCidr, externalDeviceConnDetail.BackupRemoteTunnelCidr)
+				externalDeviceConn.HAEnabled = Disabled
 			} else {
 				// two external devices, remote has HA
 				// activemesh is disabled, 2 straight tunnels only
 				configureHAForTwoDevices(externalDeviceConn, externalDeviceConnDetail, localGateway, remoteIP, backupBgpRemoteAsNumber)
 			}
-		} else if len(remoteIP) == 4 {
+		case 4:
 			if remoteIP[0] == remoteIP[2] && remoteIP[1] == remoteIP[3] {
-				externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
-				externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
-				externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
-				externalDeviceConn.HAEnabled = "disabled"
+				externalDeviceConn.LocalTunnelCidr = join2(externalDeviceConnDetail.LocalTunnelCidr, externalDeviceConnDetail.BackupLocalTunnelCidr)
+				externalDeviceConn.RemoteTunnelCidr = join2(externalDeviceConnDetail.RemoteTunnelCidr, externalDeviceConnDetail.BackupRemoteTunnelCidr)
+				externalDeviceConn.RemoteGatewayIP = join2(remoteIP[0], remoteIP[1])
+				externalDeviceConn.HAEnabled = Disabled
 			}
 		}
-	} else if len(externalDeviceConnDetail.Tunnels) == 4 {
+	case 4:
 		// activemesh is enabled, 4 tunnels, 2 straight tunnels and 2 crossing tunnels
 		externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
 		externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
 		externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
 		externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
 		externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
-		externalDeviceConn.HAEnabled = "enabled"
+		externalDeviceConn.HAEnabled = Enabled
 		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
 	}
 }
@@ -629,10 +644,10 @@ func configureLocalGatewayHADisabled(externalDeviceConn *ExternalDeviceConn, ext
 		externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
 		externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
 		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
-		externalDeviceConn.HAEnabled = "enabled"
+		externalDeviceConn.HAEnabled = Enabled
 	} else {
 		// one external device, no remote HA
-		externalDeviceConn.HAEnabled = "disabled"
+		externalDeviceConn.HAEnabled = Disabled
 	}
 }
 
@@ -640,12 +655,12 @@ func configureLocalGatewayHADisabled(externalDeviceConn *ExternalDeviceConn, ext
 func populateLANTunnelInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail, backupBgpRemoteAsNumber int) {
 	externalDeviceConn.EnableBgpLanActiveMesh = externalDeviceConnDetail.EnableBgpLanActiveMesh
 	if len(externalDeviceConnDetail.Tunnels) == 2 || len(externalDeviceConnDetail.Tunnels) == 4 {
-		externalDeviceConn.HAEnabled = "enabled"
+		externalDeviceConn.HAEnabled = Enabled
 		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
 		externalDeviceConn.BackupRemoteLanIP = externalDeviceConnDetail.BackupRemoteLanIP
 		externalDeviceConn.BackupLocalLanIP = externalDeviceConnDetail.BackupLocalLanIP
 	} else {
-		externalDeviceConn.HAEnabled = "disabled"
+		externalDeviceConn.HAEnabled = Disabled
 	}
 	externalDeviceConn.RemoteLanIP = externalDeviceConnDetail.RemoteLanIP
 	externalDeviceConn.LocalLanIP = externalDeviceConnDetail.LocalLanIP
@@ -653,18 +668,10 @@ func populateLANTunnelInfo(externalDeviceConn *ExternalDeviceConn, externalDevic
 
 // populateAdditionalConnectionInfo populates additional connection information
 func populateAdditionalConnectionInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail) {
-	if externalDeviceConnDetail.EnableEdgeSegmentation {
-		externalDeviceConn.EnableEdgeSegmentation = "enabled"
-	} else {
-		externalDeviceConn.EnableEdgeSegmentation = "disabled"
-	}
+	externalDeviceConn.EnableEdgeSegmentation = on(externalDeviceConnDetail.EnableEdgeSegmentation)
 	externalDeviceConn.ManualBGPCidrs = externalDeviceConnDetail.ManualBGPCidrs
 
-	if externalDeviceConnDetail.IkeVer == "2" {
-		externalDeviceConn.EnableIkev2 = "enabled"
-	} else {
-		externalDeviceConn.EnableIkev2 = "disabled"
-	}
+	externalDeviceConn.EnableIkev2 = on(externalDeviceConnDetail.IkeVer == "2")
 	externalDeviceConn.EventTriggeredHA = externalDeviceConnDetail.EventTriggeredHA == "enabled"
 	externalDeviceConn.EnableJumboFrame = externalDeviceConnDetail.EnableJumboFrame
 	externalDeviceConn.PeerVnetID = externalDeviceConnDetail.PeerVnetID

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -267,13 +267,10 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 						} else {
 							// two external devices, remote has HA
 							// activemesh is disabled, 2 straight tunnels only
-							externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
-							externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
-							externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
-							externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
-							externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
-							externalDeviceConn.HAEnabled = "enabled"
-							externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
+							externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
+							externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
+							externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
+							externalDeviceConn.HAEnabled = "disabled"
 						}
 					} else if len(remoteIP) == 4 {
 						if remoteIP[0] == remoteIP[2] && remoteIP[1] == remoteIP[3] {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -186,190 +186,28 @@ func (c *Client) GetExternalDeviceConnDetail(externalDeviceConn *ExternalDeviceC
 	}
 
 	externalDeviceConnDetail := data.Results.Connections
-	if len(externalDeviceConnDetail.ConnectionName) != 0 {
-		if len(externalDeviceConnDetail.VpcID) != 0 {
-			externalDeviceConn.VpcID = externalDeviceConnDetail.VpcID[0]
-		}
-
-		externalDeviceConn.ConnectionName = externalDeviceConnDetail.ConnectionName[0]
-		externalDeviceConn.GwName = externalDeviceConnDetail.GwName
-
-		if externalDeviceConnDetail.BgpStatus == "enabled" || externalDeviceConnDetail.BgpStatus == "Enabled" {
-			bgpLocalAsNumber, _ := strconv.Atoi(externalDeviceConnDetail.BgpLocalAsNum)
-			externalDeviceConn.BgpLocalAsNum = bgpLocalAsNumber
-			bgpRemoteAsNumber, _ := strconv.Atoi(externalDeviceConnDetail.BgpRemoteAsNum)
-			externalDeviceConn.BgpRemoteAsNum = bgpRemoteAsNumber
-			externalDeviceConn.ConnectionType = "bgp"
-			if len(externalDeviceConnDetail.Tunnels) >= 1 {
-				tunnelProtocol := externalDeviceConnDetail.Tunnels[0].TunnelProtocol
-				// LAN tunnel protocol is defined in the backend as "N/A(LAN)".
-				// Here we clean that up to be just "LAN" for Terraform users.
-				if strings.Contains(tunnelProtocol, "LAN") {
-					tunnelProtocol = "LAN"
-				}
-				externalDeviceConn.TunnelProtocol = tunnelProtocol
-			}
-		} else {
-			externalDeviceConn.RemoteSubnet = externalDeviceConnDetail.RemoteSubnet
-			externalDeviceConn.ConnectionType = "static"
-		}
-		externalDeviceConn.RemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[0]
-
-		// GRE and LAN tunnels cannot set Algorithms
-		if externalDeviceConn.TunnelProtocol != "GRE" && externalDeviceConn.TunnelProtocol != "LAN" {
-			if externalDeviceConnDetail.Algorithm.Phase1Auth[0] == "SHA-256" &&
-				externalDeviceConnDetail.Algorithm.Phase2Auth[0] == "HMAC-SHA-256" &&
-				externalDeviceConnDetail.Algorithm.Phase1DhGroups[0] == "14" &&
-				externalDeviceConnDetail.Algorithm.Phase2DhGroups[0] == "14" &&
-				externalDeviceConnDetail.Algorithm.Phase1Encrption[0] == "AES-256-CBC" &&
-				externalDeviceConnDetail.Algorithm.Phase2Encrption[0] == "AES-256-CBC" {
-				externalDeviceConn.CustomAlgorithms = false
-				externalDeviceConn.Phase1Auth = ""
-				externalDeviceConn.Phase2Auth = ""
-				externalDeviceConn.Phase1DhGroups = ""
-				externalDeviceConn.Phase2DhGroups = ""
-				externalDeviceConn.Phase1Encryption = ""
-				externalDeviceConn.Phase2Encryption = ""
-			} else {
-				externalDeviceConn.CustomAlgorithms = true
-				externalDeviceConn.Phase1Auth = externalDeviceConnDetail.Algorithm.Phase1Auth[0]
-				externalDeviceConn.Phase2Auth = externalDeviceConnDetail.Algorithm.Phase2Auth[0]
-				externalDeviceConn.Phase1DhGroups = externalDeviceConnDetail.Algorithm.Phase1DhGroups[0]
-				externalDeviceConn.Phase2DhGroups = externalDeviceConnDetail.Algorithm.Phase2DhGroups[0]
-				externalDeviceConn.Phase1Encryption = externalDeviceConnDetail.Algorithm.Phase1Encrption[0]
-				externalDeviceConn.Phase2Encryption = externalDeviceConnDetail.Algorithm.Phase2Encrption[0]
-			}
-		}
-
-		if externalDeviceConnDetail.DirectConnect {
-			externalDeviceConn.DirectConnect = "enabled"
-		} else {
-			externalDeviceConn.DirectConnect = "disabled"
-		}
-
-		backupBgpRemoteAsNumber := 0
-		if externalDeviceConnDetail.BackupBgpRemoteAsNum != "" {
-			backupBgpRemoteAsNumberRead, _ := strconv.Atoi(externalDeviceConnDetail.BackupBgpRemoteAsNum)
-			backupBgpRemoteAsNumber = backupBgpRemoteAsNumberRead
-		}
-
-		if externalDeviceConn.TunnelProtocol != "LAN" {
-			externalDeviceConn.DisableActivemesh = externalDeviceConnDetail.DisableActivemesh
-			externalDeviceConn.TunnelSrcIP = externalDeviceConnDetail.TunnelSrcIP
-			// extrnalDeviceConnDetail.HAEnabled returned from API indicate whether connection's local gateway has HA enabled
-			// We need to put whether remote HA is enabled in externalDeviceConn.HAEnabled
-			if externalDeviceConnDetail.HAEnabled == "enabled" {
-				// connection local gateway has HA enabled
-				if len(externalDeviceConnDetail.Tunnels) == 2 {
-					remoteIP := strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")
-					if len(remoteIP) == 2 {
-						if remoteIP[0] == remoteIP[1] {
-							// one external device, no remote HA
-							externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
-							externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
-							externalDeviceConn.HAEnabled = "disabled"
-						} else {
-							// two external devices, remote has HA
-							// activemesh is disabled, 2 straight tunnels only
-							if localGateway != nil && localGateway.EdgeGateway && localGateway.TransitVpc == "yes" {
-								externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
-								externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
-								externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
-								externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
-								externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
-								externalDeviceConn.HAEnabled = "enabled"
-								externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
-							} else {
-								externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
-								externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
-								externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
-								externalDeviceConn.HAEnabled = "disabled"
-							}
-						}
-					} else if len(remoteIP) == 4 {
-						if remoteIP[0] == remoteIP[2] && remoteIP[1] == remoteIP[3] {
-							externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
-							externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
-							externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
-							externalDeviceConn.HAEnabled = "disabled"
-						}
-					}
-				} else if len(externalDeviceConnDetail.Tunnels) == 4 {
-					// activemesh is enabled, 4 tunnels, 2 straight tunnels and 2 crossing tunnels
-					externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
-					externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
-					externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
-					externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
-					externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
-					externalDeviceConn.HAEnabled = "enabled"
-					externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
-				}
-			} else {
-				// local gateway no HA
-				externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
-				externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
-				if len(externalDeviceConnDetail.Tunnels) == 2 {
-					// two external devices, remote has HA
-					externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
-					externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
-					externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
-					externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
-					externalDeviceConn.HAEnabled = "enabled"
-				} else {
-					// one external device, no remote HA
-					externalDeviceConn.HAEnabled = "disabled"
-				}
-			}
-		} else {
-			externalDeviceConn.EnableBgpLanActiveMesh = externalDeviceConnDetail.EnableBgpLanActiveMesh
-			if len(externalDeviceConnDetail.Tunnels) == 2 || len(externalDeviceConnDetail.Tunnels) == 4 {
-				externalDeviceConn.HAEnabled = "enabled"
-				externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
-				externalDeviceConn.BackupRemoteLanIP = externalDeviceConnDetail.BackupRemoteLanIP
-				externalDeviceConn.BackupLocalLanIP = externalDeviceConnDetail.BackupLocalLanIP
-			} else {
-				externalDeviceConn.HAEnabled = "disabled"
-			}
-			externalDeviceConn.RemoteLanIP = externalDeviceConnDetail.RemoteLanIP
-			externalDeviceConn.LocalLanIP = externalDeviceConnDetail.LocalLanIP
-		}
-
-		if externalDeviceConnDetail.BackupDirectConnect {
-			externalDeviceConn.BackupDirectConnect = "enabled"
-		} else {
-			externalDeviceConn.BackupDirectConnect = "disabled"
-		}
-		if externalDeviceConnDetail.EnableEdgeSegmentation {
-			externalDeviceConn.EnableEdgeSegmentation = "enabled"
-		} else {
-			externalDeviceConn.EnableEdgeSegmentation = "disabled"
-		}
-		externalDeviceConn.ManualBGPCidrs = externalDeviceConnDetail.ManualBGPCidrs
-
-		if externalDeviceConnDetail.IkeVer == "2" {
-			externalDeviceConn.EnableIkev2 = "enabled"
-		} else {
-			externalDeviceConn.EnableIkev2 = "disabled"
-		}
-		externalDeviceConn.EventTriggeredHA = externalDeviceConnDetail.EventTriggeredHA == "enabled"
-		externalDeviceConn.EnableJumboFrame = externalDeviceConnDetail.EnableJumboFrame
-		externalDeviceConn.PeerVnetId = externalDeviceConnDetail.PeerVnetId
-		externalDeviceConn.Phase1RemoteIdentifier = externalDeviceConnDetail.Phase1RemoteIdentifier
-		externalDeviceConn.PrependAsPath = externalDeviceConnDetail.PrependAsPath
-		externalDeviceConn.EnableEdgeUnderlay = externalDeviceConnDetail.WanUnderlay
-		externalDeviceConn.RemoteCloudType = externalDeviceConnDetail.RemoteCloudType
-		externalDeviceConn.Phase1LocalIdentifier = externalDeviceConnDetail.Phase1LocalIdentifier
-		externalDeviceConn.EnableBfd = externalDeviceConnDetail.EnableBfd
-		if externalDeviceConn.EnableBfd {
-			externalDeviceConn.BgpBfdConfig.TransmitInterval = externalDeviceConnDetail.BgpBfdConfig["tx_interval"]
-			externalDeviceConn.BgpBfdConfig.ReceiveInterval = externalDeviceConnDetail.BgpBfdConfig["rx_interval"]
-			externalDeviceConn.BgpBfdConfig.Multiplier = externalDeviceConnDetail.BgpBfdConfig["multiplier"]
-		}
-		externalDeviceConn.EnableBgpMultihop = externalDeviceConnDetail.EnableBgpMultihop
-		return externalDeviceConn, nil
+	if len(externalDeviceConnDetail.ConnectionName) == 0 {
+		return nil, ErrNotFound
 	}
 
-	return nil, ErrNotFound
+	// Extract connection details into separate helper functions
+	populateBasicConnectionInfo(externalDeviceConn, externalDeviceConnDetail)
+	populateConnectionTypeInfo(externalDeviceConn, externalDeviceConnDetail)
+	populateAlgorithmInfo(externalDeviceConn, externalDeviceConnDetail)
+	populateDirectConnectInfo(externalDeviceConn, externalDeviceConnDetail)
+
+	backupBgpRemoteAsNumber := parseBackupBgpRemoteAsNumber(externalDeviceConnDetail.BackupBgpRemoteAsNum)
+	populateBgpSendCommunitiesInfo(externalDeviceConn, externalDeviceConnDetail)
+
+	if externalDeviceConn.TunnelProtocol != "LAN" {
+		populateNonLANTunnelInfo(externalDeviceConn, externalDeviceConnDetail, localGateway, backupBgpRemoteAsNumber)
+	} else {
+		populateLANTunnelInfo(externalDeviceConn, externalDeviceConnDetail, backupBgpRemoteAsNumber)
+	}
+
+	populateAdditionalConnectionInfo(externalDeviceConn, externalDeviceConnDetail)
+
+	return externalDeviceConn, nil
 }
 
 func (c *Client) DeleteExternalDeviceConn(externalDeviceConn *ExternalDeviceConn) error {
@@ -584,4 +422,262 @@ func (c *Client) DisableJumboFrameExternalDeviceConn(externalDeviceConn *Externa
 	}
 
 	return c.PostAPI(externalDeviceConn.Action, params, checkFunc)
+}
+
+func (c *Client) ConnectionBGPSendCommunities(bgpSendCommunities *BgpSendCommunities) error {
+	bgpSendCommunities.CID = c.CID
+	bgpSendCommunities.Action = "edit_connection_bgp_send_communities"
+
+	params := map[string]string{
+		"CID":                             c.CID,
+		"action":                          "edit_connection_bgp_send_communities",
+		"gateway_name":                    bgpSendCommunities.GwName,
+		"connection_name":                 bgpSendCommunities.ConnectionName,
+		"connection_bgp_send_communities": bgpSendCommunities.ConnSendCommunities,
+		"connection_bgp_send_communities_additive": fmt.Sprint(bgpSendCommunities.ConnSendAdditive),
+		"connection_bgp_send_communities_block":    fmt.Sprint(bgpSendCommunities.ConnSendBlock),
+	}
+
+	return c.PostAPI(params["action"], params, BasicCheck)
+}
+
+// configureHAForTwoDevices configures HA settings when there are two external devices
+func configureHAForTwoDevices(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail, localGateway *Gateway, remoteIP []string, backupBgpRemoteAsNumber int) {
+	// Check if this is an edge transit gateway that supports proper HA
+	isEdgeTransitGateway := localGateway != nil && localGateway.EdgeGateway && localGateway.TransitVpc == "yes"
+
+	if isEdgeTransitGateway {
+		// Edge transit gateways support true HA with separate tunnel configurations
+		externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
+		externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
+		externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
+		externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
+		externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
+		externalDeviceConn.HAEnabled = "enabled"
+		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
+	} else {
+		// Non-edge gateways treat dual devices as combined configuration (no true HA)
+		externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
+		externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
+		externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
+		externalDeviceConn.HAEnabled = "disabled"
+	}
+}
+
+// populateBasicConnectionInfo populates basic connection information
+func populateBasicConnectionInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail) {
+	if len(externalDeviceConnDetail.VpcID) != 0 {
+		externalDeviceConn.VpcID = externalDeviceConnDetail.VpcID[0]
+	}
+	externalDeviceConn.ConnectionName = externalDeviceConnDetail.ConnectionName[0]
+	externalDeviceConn.GwName = externalDeviceConnDetail.GwName
+	externalDeviceConn.RemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[0]
+	externalDeviceConn.BgpSendCommunities = externalDeviceConnDetail.BgpSendCommunities
+}
+
+// populateConnectionTypeInfo populates connection type and BGP information
+func populateConnectionTypeInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail) {
+	if externalDeviceConnDetail.BgpStatus == "enabled" || externalDeviceConnDetail.BgpStatus == "Enabled" {
+		bgpLocalAsNumber, _ := strconv.Atoi(externalDeviceConnDetail.BgpLocalAsNum)
+		externalDeviceConn.BgpLocalAsNum = bgpLocalAsNumber
+		bgpRemoteAsNumber, _ := strconv.Atoi(externalDeviceConnDetail.BgpRemoteAsNum)
+		externalDeviceConn.BgpRemoteAsNum = bgpRemoteAsNumber
+		externalDeviceConn.ConnectionType = "bgp"
+		if len(externalDeviceConnDetail.Tunnels) >= 1 {
+			tunnelProtocol := externalDeviceConnDetail.Tunnels[0].TunnelProtocol
+			// LAN tunnel protocol is defined in the backend as "N/A(LAN)".
+			// Here we clean that up to be just "LAN" for Terraform users.
+			if strings.Contains(tunnelProtocol, "LAN") {
+				tunnelProtocol = "LAN"
+			}
+			externalDeviceConn.TunnelProtocol = tunnelProtocol
+		}
+	} else {
+		externalDeviceConn.RemoteSubnet = externalDeviceConnDetail.RemoteSubnet
+		externalDeviceConn.ConnectionType = "static"
+	}
+}
+
+// populateAlgorithmInfo populates encryption algorithm information
+func populateAlgorithmInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail) {
+	// GRE and LAN tunnels cannot set Algorithms
+	if externalDeviceConn.TunnelProtocol != "GRE" && externalDeviceConn.TunnelProtocol != "LAN" {
+		if externalDeviceConnDetail.Algorithm.Phase1Auth[0] == "SHA-256" &&
+			externalDeviceConnDetail.Algorithm.Phase2Auth[0] == "HMAC-SHA-256" &&
+			externalDeviceConnDetail.Algorithm.Phase1DhGroups[0] == "14" &&
+			externalDeviceConnDetail.Algorithm.Phase2DhGroups[0] == "14" &&
+			externalDeviceConnDetail.Algorithm.Phase1Encrption[0] == "AES-256-CBC" &&
+			externalDeviceConnDetail.Algorithm.Phase2Encrption[0] == "AES-256-CBC" {
+			externalDeviceConn.CustomAlgorithms = false
+			externalDeviceConn.Phase1Auth = ""
+			externalDeviceConn.Phase2Auth = ""
+			externalDeviceConn.Phase1DhGroups = ""
+			externalDeviceConn.Phase2DhGroups = ""
+			externalDeviceConn.Phase1Encryption = ""
+			externalDeviceConn.Phase2Encryption = ""
+		} else {
+			externalDeviceConn.CustomAlgorithms = true
+			externalDeviceConn.Phase1Auth = externalDeviceConnDetail.Algorithm.Phase1Auth[0]
+			externalDeviceConn.Phase2Auth = externalDeviceConnDetail.Algorithm.Phase2Auth[0]
+			externalDeviceConn.Phase1DhGroups = externalDeviceConnDetail.Algorithm.Phase1DhGroups[0]
+			externalDeviceConn.Phase2DhGroups = externalDeviceConnDetail.Algorithm.Phase2DhGroups[0]
+			externalDeviceConn.Phase1Encryption = externalDeviceConnDetail.Algorithm.Phase1Encrption[0]
+			externalDeviceConn.Phase2Encryption = externalDeviceConnDetail.Algorithm.Phase2Encrption[0]
+		}
+	}
+}
+
+// populateDirectConnectInfo populates direct connect information
+func populateDirectConnectInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail) {
+	if externalDeviceConnDetail.DirectConnect {
+		externalDeviceConn.DirectConnect = "enabled"
+	} else {
+		externalDeviceConn.DirectConnect = "disabled"
+	}
+
+	if externalDeviceConnDetail.BackupDirectConnect {
+		externalDeviceConn.BackupDirectConnect = "enabled"
+	} else {
+		externalDeviceConn.BackupDirectConnect = "disabled"
+	}
+}
+
+// parseBackupBgpRemoteAsNumber parses backup BGP remote AS number
+func parseBackupBgpRemoteAsNumber(backupBgpRemoteAsNumStr string) int {
+	if backupBgpRemoteAsNumStr != "" {
+		backupBgpRemoteAsNumberRead, _ := strconv.Atoi(backupBgpRemoteAsNumStr)
+		return backupBgpRemoteAsNumberRead
+	}
+	return 0
+}
+
+// populateBgpSendCommunitiesInfo populates BGP send communities information
+func populateBgpSendCommunitiesInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail) {
+	// get_site2cloud_conn_detail API returns one field for communities, namely, conn_bgp_send_communities
+	// Example1: "conn_bgp_send_communities": "additive 444:444"
+	// Example2: "conn_bgp_send_communities": "block"
+	// We need to parse this field to set the BgpSendCommunities, BgpSendCommunitiesAdditive and BgpSendCommunitiesBlock fields
+	if externalDeviceConnDetail.BgpSendCommunities != "" {
+		commList := strings.Split(externalDeviceConnDetail.BgpSendCommunities, " ")
+		if len(commList) > 0 && commList[0] == "block" {
+			externalDeviceConn.BgpSendCommunitiesBlock = true
+		} else if len(commList) > 0 && commList[0] == "additive" {
+			externalDeviceConn.BgpSendCommunitiesAdditive = true
+			commList = commList[1:]
+			externalDeviceConn.BgpSendCommunities = strings.Join(commList, " ")
+		}
+	}
+}
+
+// populateNonLANTunnelInfo populates information for non-LAN tunnels including HA logic
+func populateNonLANTunnelInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail, localGateway *Gateway, backupBgpRemoteAsNumber int) {
+	externalDeviceConn.DisableActivemesh = externalDeviceConnDetail.DisableActivemesh
+	externalDeviceConn.TunnelSrcIP = externalDeviceConnDetail.TunnelSrcIP
+
+	// extrnalDeviceConnDetail.HAEnabled returned from API indicate whether connection's local gateway has HA enabled
+	// We need to put whether remote HA is enabled in externalDeviceConn.HAEnabled
+	if externalDeviceConnDetail.HAEnabled == "enabled" {
+		configureLocalGatewayHAEnabled(externalDeviceConn, externalDeviceConnDetail, localGateway, backupBgpRemoteAsNumber)
+	} else {
+		configureLocalGatewayHADisabled(externalDeviceConn, externalDeviceConnDetail, backupBgpRemoteAsNumber)
+	}
+}
+
+// configureLocalGatewayHAEnabled configures HA when local gateway has HA enabled
+func configureLocalGatewayHAEnabled(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail, localGateway *Gateway, backupBgpRemoteAsNumber int) {
+	if len(externalDeviceConnDetail.Tunnels) == 2 {
+		remoteIP := strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")
+		if len(remoteIP) == 2 {
+			if remoteIP[0] == remoteIP[1] {
+				// one external device, no remote HA
+				externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
+				externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
+				externalDeviceConn.HAEnabled = "disabled"
+			} else {
+				// two external devices, remote has HA
+				// activemesh is disabled, 2 straight tunnels only
+				configureHAForTwoDevices(externalDeviceConn, externalDeviceConnDetail, localGateway, remoteIP, backupBgpRemoteAsNumber)
+			}
+		} else if len(remoteIP) == 4 {
+			if remoteIP[0] == remoteIP[2] && remoteIP[1] == remoteIP[3] {
+				externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr + "," + externalDeviceConnDetail.BackupLocalTunnelCidr
+				externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr + "," + externalDeviceConnDetail.BackupRemoteTunnelCidr
+				externalDeviceConn.RemoteGatewayIP = remoteIP[0] + "," + remoteIP[1]
+				externalDeviceConn.HAEnabled = "disabled"
+			}
+		}
+	} else if len(externalDeviceConnDetail.Tunnels) == 4 {
+		// activemesh is enabled, 4 tunnels, 2 straight tunnels and 2 crossing tunnels
+		externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
+		externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
+		externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
+		externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
+		externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
+		externalDeviceConn.HAEnabled = "enabled"
+		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
+	}
+}
+
+// configureLocalGatewayHADisabled configures HA when local gateway has HA disabled
+func configureLocalGatewayHADisabled(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail, backupBgpRemoteAsNumber int) {
+	// local gateway no HA
+	externalDeviceConn.LocalTunnelCidr = externalDeviceConnDetail.LocalTunnelCidr
+	externalDeviceConn.RemoteTunnelCidr = externalDeviceConnDetail.RemoteTunnelCidr
+	if len(externalDeviceConnDetail.Tunnels) == 2 {
+		// two external devices, remote has HA
+		externalDeviceConn.BackupLocalTunnelCidr = externalDeviceConnDetail.BackupLocalTunnelCidr
+		externalDeviceConn.BackupRemoteTunnelCidr = externalDeviceConnDetail.BackupRemoteTunnelCidr
+		externalDeviceConn.BackupRemoteGatewayIP = strings.Split(externalDeviceConnDetail.RemoteGatewayIP, ",")[1]
+		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
+		externalDeviceConn.HAEnabled = "enabled"
+	} else {
+		// one external device, no remote HA
+		externalDeviceConn.HAEnabled = "disabled"
+	}
+}
+
+// populateLANTunnelInfo populates information for LAN tunnels
+func populateLANTunnelInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail, backupBgpRemoteAsNumber int) {
+	externalDeviceConn.EnableBgpLanActiveMesh = externalDeviceConnDetail.EnableBgpLanActiveMesh
+	if len(externalDeviceConnDetail.Tunnels) == 2 || len(externalDeviceConnDetail.Tunnels) == 4 {
+		externalDeviceConn.HAEnabled = "enabled"
+		externalDeviceConn.BackupBgpRemoteAsNum = backupBgpRemoteAsNumber
+		externalDeviceConn.BackupRemoteLanIP = externalDeviceConnDetail.BackupRemoteLanIP
+		externalDeviceConn.BackupLocalLanIP = externalDeviceConnDetail.BackupLocalLanIP
+	} else {
+		externalDeviceConn.HAEnabled = "disabled"
+	}
+	externalDeviceConn.RemoteLanIP = externalDeviceConnDetail.RemoteLanIP
+	externalDeviceConn.LocalLanIP = externalDeviceConnDetail.LocalLanIP
+}
+
+// populateAdditionalConnectionInfo populates additional connection information
+func populateAdditionalConnectionInfo(externalDeviceConn *ExternalDeviceConn, externalDeviceConnDetail EditExternalDeviceConnDetail) {
+	if externalDeviceConnDetail.EnableEdgeSegmentation {
+		externalDeviceConn.EnableEdgeSegmentation = "enabled"
+	} else {
+		externalDeviceConn.EnableEdgeSegmentation = "disabled"
+	}
+	externalDeviceConn.ManualBGPCidrs = externalDeviceConnDetail.ManualBGPCidrs
+
+	if externalDeviceConnDetail.IkeVer == "2" {
+		externalDeviceConn.EnableIkev2 = "enabled"
+	} else {
+		externalDeviceConn.EnableIkev2 = "disabled"
+	}
+	externalDeviceConn.EventTriggeredHA = externalDeviceConnDetail.EventTriggeredHA == "enabled"
+	externalDeviceConn.EnableJumboFrame = externalDeviceConnDetail.EnableJumboFrame
+	externalDeviceConn.PeerVnetID = externalDeviceConnDetail.PeerVnetID
+	externalDeviceConn.Phase1RemoteIdentifier = externalDeviceConnDetail.Phase1RemoteIdentifier
+	externalDeviceConn.PrependAsPath = externalDeviceConnDetail.PrependAsPath
+	externalDeviceConn.EnableEdgeUnderlay = externalDeviceConnDetail.WanUnderlay
+	externalDeviceConn.RemoteCloudType = externalDeviceConnDetail.RemoteCloudType
+	externalDeviceConn.Phase1LocalIdentifier = externalDeviceConnDetail.Phase1LocalIdentifier
+	externalDeviceConn.EnableBfd = externalDeviceConnDetail.EnableBfd
+	if externalDeviceConn.EnableBfd {
+		externalDeviceConn.BgpBfdConfig.TransmitInterval = externalDeviceConnDetail.BgpBfdConfig["tx_interval"]
+		externalDeviceConn.BgpBfdConfig.ReceiveInterval = externalDeviceConnDetail.BgpBfdConfig["rx_interval"]
+		externalDeviceConn.BgpBfdConfig.Multiplier = externalDeviceConnDetail.BgpBfdConfig["multiplier"]
+	}
+	externalDeviceConn.EnableBgpMultihop = externalDeviceConnDetail.EnableBgpMultihop
 }


### PR DESCRIPTION
Backport https://github.com/AviatrixSystems/terraform-provider-aviatrix/commit/a6068ad49e561dcfbf303011753ae83731521b21 from https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2298.
Enable HA value was enabled when there were two remote connections. This logic is only applicable for EAT external device connection.
PR - https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2167/files#diff-a74471d814210d0b5fa34660c7cedc4422bccbfc1ddd00cc8b2e24d0c7796db6R268-R276

For spoke external device connection, enable HA is disabled for 2 remote connections. Updating the get_site2cloud_conn_detail to handle the logic for spoke and EAT device connections differently