### PR TITLE
AVX-68276: check SslServerPool length before get index

### DIFF
--- a/goaviatrix/site2cloud.go
+++ b/goaviatrix/site2cloud.go
@@ -423,7 +423,7 @@ func (c *Client) GetSite2CloudConnDetail(site2cloud *Site2Cloud) (*Site2Cloud, e
 		} else {
 			site2cloud.PrivateRouteEncryption = "false"
 		}
-		if s2cConnDetail.SslServerPool[0] != "192.168.44.0/24" {
+		if len(s2cConnDetail.SslServerPool) > 0 && s2cConnDetail.SslServerPool[0] != "192.168.44.0/24" {
 			site2cloud.SslServerPool = s2cConnDetail.SslServerPool[0]
 		}
 		if s2cConnDetail.DeadPeerDetectionConfig == "enable" {


### PR DESCRIPTION
Fix this panic in GetSite2CloudConnDetail

```
panic: runtime error: index out of range [0] with length 0
                                         
goroutine 132 [running]:
github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix.(*Client).GetSite2CloudConnDetail(0xc000274630, 0xc0006fd508)
/home/runner/work/cloudn/cloudn/goaviatrix/site2cloud.go:426 +0x13db
github.com/AviatrixSystems/terraform-provider-aviatrix/v3/aviatrix.resourceAviatrixSite2CloudRead(0xc000670a80, ***0x1039ec0?, 0xc000274630***)
/home/runner/work/cloudn/cloudn/aviatrix/resource_aviatrix_site2cloud.go:871 +0x41c
```
