### PR TITLE
AVX-68263: Enable firenet for edge

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
@@ -422,19 +422,6 @@ func resourceAviatrixEdgeSpokeTransitAttachmentUpdate(ctx context.Context, d *sc
 		}
 	}
 
-	if d.HasChange("enable_firenet_for_edge") {
-		transitGatewayPeering := &goaviatrix.TransitGatewayPeering{
-			TransitGatewayName1:  spokeGwName,
-			TransitGatewayName2:  transitGwName,
-			EnableFirenetForEdge: d.Get("enable_firenet_for_edge").(bool),
-		}
-
-		err := client.UpdateTransitGatewayPeering(transitGatewayPeering)
-		if err != nil {
-			return diag.Errorf("could not update enable_firenet_for_edge for edge spoke transit attachment: %v : %v", spokeGwName+"~"+transitGwName, err)
-		}
-	}
-
 	d.Partial(false)
 	d.SetId(spokeGwName + "~" + transitGwName)
 	return resourceAviatrixEdgeSpokeTransitAttachmentRead(ctx, d, meta)

--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment.go
@@ -49,6 +49,12 @@ func resourceAviatrixEdgeSpokeTransitAttachment() *schema.Resource {
 				Default:     false,
 				Description: "Enable jumbo frame.",
 			},
+			"enable_firenet_for_edge": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable firenet for edge.",
+			},
 			"enable_insane_mode": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -144,6 +150,7 @@ func marshalEdgeSpokeTransitAttachmentInput(d *schema.ResourceData) *goaviatrix.
 		TransitGwName:            d.Get("transit_gw_name").(string),
 		EnableOverPrivateNetwork: d.Get("enable_over_private_network").(bool),
 		EnableJumboFrame:         d.Get("enable_jumbo_frame").(bool),
+		EnableFirenetForEdge:     d.Get("enable_firenet_for_edge").(bool),
 		EnableInsaneMode:         d.Get("enable_insane_mode").(bool),
 		InsaneModeTunnelNumber:   d.Get("insane_mode_tunnel_number").(int),
 		SpokePrependAsPath:       getStringList(d, "spoke_prepend_as_path"),
@@ -283,6 +290,7 @@ func resourceAviatrixEdgeSpokeTransitAttachmentRead(ctx context.Context, d *sche
 
 	d.Set("enable_over_private_network", attachment.EnableOverPrivateNetwork)
 	d.Set("enable_jumbo_frame", attachment.EnableJumboFrame)
+	d.Set("enable_firenet_for_edge", attachment.EnableFirenetForEdge)
 	d.Set("enable_insane_mode", attachment.EnableInsaneMode)
 	if attachment.EnableInsaneMode {
 		d.Set("insane_mode_tunnel_number", attachment.InsaneModeTunnelNumber)
@@ -411,6 +419,19 @@ func resourceAviatrixEdgeSpokeTransitAttachmentUpdate(ctx context.Context, d *sc
 		err := client.UpdateTransitGatewayPeering(transitGatewayPeering)
 		if err != nil {
 			return diag.Errorf("could not update insane_mode_tunnel_number for edge spoke transit attachment: %v : %v", spokeGwName+"~"+transitGwName, err)
+		}
+	}
+
+	if d.HasChange("enable_firenet_for_edge") {
+		transitGatewayPeering := &goaviatrix.TransitGatewayPeering{
+			TransitGatewayName1:  spokeGwName,
+			TransitGatewayName2:  transitGwName,
+			EnableFirenetForEdge: d.Get("enable_firenet_for_edge").(bool),
+		}
+
+		err := client.UpdateTransitGatewayPeering(transitGatewayPeering)
+		if err != nil {
+			return diag.Errorf("could not update enable_firenet_for_edge for edge spoke transit attachment: %v : %v", spokeGwName+"~"+transitGwName, err)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment_helper_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment_helper_test.go
@@ -141,3 +141,126 @@ func TestGetEdgeTransitLogicalIfNames(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalEdgeSpokeTransitAttachmentInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *goaviatrix.SpokeTransitAttachment
+	}{
+		{
+			name: "Basic configuration with enable_firenet_for_edge false",
+			input: map[string]interface{}{
+				"spoke_gw_name":               "test-spoke",
+				"transit_gw_name":             "test-transit",
+				"enable_over_private_network": true,
+				"enable_jumbo_frame":          false,
+				"enable_firenet_for_edge":     false,
+				"enable_insane_mode":          true,
+				"insane_mode_tunnel_number":   5,
+				"disable_activemesh":          false,
+				"spoke_prepend_as_path":       []interface{}{"65001", "65002"},
+				"transit_prepend_as_path":     []interface{}{"65003", "65004"},
+				"edge_wan_interfaces":         []interface{}{"wan0", "wan1"},
+			},
+			expected: &goaviatrix.SpokeTransitAttachment{
+				SpokeGwName:              "test-spoke",
+				TransitGwName:            "test-transit",
+				EnableOverPrivateNetwork: true,
+				EnableJumboFrame:         false,
+				EnableFirenetForEdge:     false,
+				EnableInsaneMode:         true,
+				InsaneModeTunnelNumber:   5,
+				DisableActivemesh:        false,
+				SpokePrependAsPath:       []string{"65001", "65002"},
+				TransitPrependAsPath:     []string{"65003", "65004"},
+				EdgeWanInterfaces:        "wan0,wan1",
+			},
+		},
+		{
+			name: "Configuration with enable_firenet_for_edge true",
+			input: map[string]interface{}{
+				"spoke_gw_name":               "test-spoke",
+				"transit_gw_name":             "test-transit",
+				"enable_over_private_network": true,
+				"enable_jumbo_frame":          false,
+				"enable_firenet_for_edge":     true,
+				"enable_insane_mode":          false,
+				"insane_mode_tunnel_number":   0,
+				"disable_activemesh":          true,
+				"spoke_prepend_as_path":       []interface{}{},
+				"transit_prepend_as_path":     []interface{}{},
+				"edge_wan_interfaces":         []interface{}{},
+			},
+			expected: &goaviatrix.SpokeTransitAttachment{
+				SpokeGwName:              "test-spoke",
+				TransitGwName:            "test-transit",
+				EnableOverPrivateNetwork: true,
+				EnableJumboFrame:         false,
+				EnableFirenetForEdge:     true,
+				EnableInsaneMode:         false,
+				InsaneModeTunnelNumber:   0,
+				DisableActivemesh:        true,
+				SpokePrependAsPath:       nil,
+				TransitPrependAsPath:     nil,
+				EdgeWanInterfaces:        "",
+			},
+		},
+		{
+			name: "Default values",
+			input: map[string]interface{}{
+				"spoke_gw_name":           "test-spoke",
+				"transit_gw_name":         "test-transit",
+				"spoke_prepend_as_path":   []interface{}{},
+				"transit_prepend_as_path": []interface{}{},
+				"edge_wan_interfaces":     []interface{}{},
+			},
+			expected: &goaviatrix.SpokeTransitAttachment{
+				SpokeGwName:              "test-spoke",
+				TransitGwName:            "test-transit",
+				EnableOverPrivateNetwork: true,  // default from schema
+				EnableJumboFrame:         false, // default from schema
+				EnableFirenetForEdge:     false, // default from schema
+				EnableInsaneMode:         false, // default from schema
+				InsaneModeTunnelNumber:   0,     // default from schema
+				DisableActivemesh:        false, // default from schema
+				SpokePrependAsPath:       nil,
+				TransitPrependAsPath:     nil,
+				EdgeWanInterfaces:        "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a schema.ResourceData from the input
+			d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+				"spoke_gw_name":               {Type: schema.TypeString, Required: true},
+				"transit_gw_name":             {Type: schema.TypeString, Required: true},
+				"enable_over_private_network": {Type: schema.TypeBool, Optional: true, Default: true},
+				"enable_jumbo_frame":          {Type: schema.TypeBool, Optional: true, Default: false},
+				"enable_firenet_for_edge":     {Type: schema.TypeBool, Optional: true, Default: false},
+				"enable_insane_mode":          {Type: schema.TypeBool, Optional: true, Default: false},
+				"insane_mode_tunnel_number":   {Type: schema.TypeInt, Optional: true, Default: 0},
+				"disable_activemesh":          {Type: schema.TypeBool, Optional: true, Default: false},
+				"spoke_prepend_as_path":       {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"transit_prepend_as_path":     {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"edge_wan_interfaces":         {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+			}, tt.input)
+
+			result := marshalEdgeSpokeTransitAttachmentInput(d)
+
+			assert.Equal(t, tt.expected.SpokeGwName, result.SpokeGwName)
+			assert.Equal(t, tt.expected.TransitGwName, result.TransitGwName)
+			assert.Equal(t, tt.expected.EnableOverPrivateNetwork, result.EnableOverPrivateNetwork)
+			assert.Equal(t, tt.expected.EnableJumboFrame, result.EnableJumboFrame)
+			assert.Equal(t, tt.expected.EnableFirenetForEdge, result.EnableFirenetForEdge)
+			assert.Equal(t, tt.expected.EnableInsaneMode, result.EnableInsaneMode)
+			assert.Equal(t, tt.expected.InsaneModeTunnelNumber, result.InsaneModeTunnelNumber)
+			assert.Equal(t, tt.expected.DisableActivemesh, result.DisableActivemesh)
+			assert.Equal(t, tt.expected.SpokePrependAsPath, result.SpokePrependAsPath)
+			assert.Equal(t, tt.expected.TransitPrependAsPath, result.TransitPrependAsPath)
+			assert.Equal(t, tt.expected.EdgeWanInterfaces, result.EdgeWanInterfaces)
+		})
+	}
+}

--- a/aviatrix/resource_aviatrix_edge_spoke_transit_attachment_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_transit_attachment_test.go
@@ -58,10 +58,66 @@ func TestAccAviatrixEdgeSpokeTransitAttachment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameEdge, "transit_gw_name", transitGwName),
 					resource.TestCheckResourceAttr(resourceNameEdge, "enable_over_private_network", "true"),
 					resource.TestCheckResourceAttr(resourceNameEdge, "enable_jumbo_frame", "false"),
+					resource.TestCheckResourceAttr(resourceNameEdge, "enable_firenet_for_edge", "false"),
 					resource.TestCheckResourceAttr(resourceNameEdge, "enable_insane_mode", "true"),
 					resource.TestCheckResourceAttr(resourceNameEdge, "spoke_gateway_logical_ifnames.0", "wan1"),
 					resource.TestCheckResourceAttr(resourceNameEdge, "transit_gateway_logical_ifnames.0", "wan1"),
 					resource.TestCheckResourceAttr(resourceNameEdge, "disable_activemesh", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAviatrixEdgeSpokeTransitAttachment_enableFirenetForEdge(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_edge_spoke_transit_attachment.test"
+
+	accountName := "megaport-" + rName
+	spokeGwName := "spoke-" + rName
+	spokeSiteID := "site-" + rName
+	path, _ := os.Getwd()
+	transitGwName := "transit-" + rName
+	transitSiteID := "site-" + rName
+
+	skipAcc := os.Getenv("SKIP_EDGE_SPOKE_TRANSIT_ATTACHMENT")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Edge as a Spoke transit attachment tests as 'SKIP_EDGE_SPOKE_TRANSIT_ATTACHMENT' is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preEdgeSpokeTransitAttachmentCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEdgeSpokeTransitAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEdgeSpokeTransitAttachmentConfigFirenetForEdge(accountName, spokeGwName, spokeSiteID, path, transitGwName, transitSiteID, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeSpokeTransitAttachmentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "spoke_gw_name", spokeGwName),
+					resource.TestCheckResourceAttr(resourceName, "transit_gw_name", transitGwName),
+					resource.TestCheckResourceAttr(resourceName, "enable_firenet_for_edge", "false"),
+				),
+			},
+			{
+				Config: testAccEdgeSpokeTransitAttachmentConfigFirenetForEdge(accountName, spokeGwName, spokeSiteID, path, transitGwName, transitSiteID, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeSpokeTransitAttachmentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "spoke_gw_name", spokeGwName),
+					resource.TestCheckResourceAttr(resourceName, "transit_gw_name", transitGwName),
+					resource.TestCheckResourceAttr(resourceName, "enable_firenet_for_edge", "true"),
+				),
+			},
+			{
+				Config: testAccEdgeSpokeTransitAttachmentConfigFirenetForEdge(accountName, spokeGwName, spokeSiteID, path, transitGwName, transitSiteID, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeSpokeTransitAttachmentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "spoke_gw_name", spokeGwName),
+					resource.TestCheckResourceAttr(resourceName, "transit_gw_name", transitGwName),
+					resource.TestCheckResourceAttr(resourceName, "enable_firenet_for_edge", "false"),
 				),
 			},
 		},
@@ -205,6 +261,112 @@ resource "aviatrix_edge_spoke_transit_attachment" "test_edge_spoke_transit_attac
 	disable_activemesh = false
   }
 	`, accountName, spokeGwName, spokeSiteID, path, transitGwName, transitSiteID, path)
+}
+
+func testAccEdgeSpokeTransitAttachmentConfigFirenetForEdge(accountName, spokeGwName, spokeSiteID, path, transitGwName, transitSiteID string, enableFirenetForEdge bool) string {
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_edge_megaport" {
+	account_name       = "edge-%s"
+	cloud_type         = 1048576
+}
+resource "aviatrix_transit_gateway" "test_edge_transit" {
+	cloud_type   = 1048576
+	account_name = aviatrix_account.test_acc_edge_megaport.account_name
+	gw_name      = "%s"
+	vpc_id       = "%s"
+	gw_size      = "SMALL"
+	ztp_file_download_path = "%s"
+	interfaces {
+        gateway_ip     = "192.168.20.1"
+        ip_address     = "192.168.20.11/24"
+        public_ip      = "67.207.104.19"
+        logical_ifname = "wan0"
+        secondary_private_cidr_list = ["192.168.20.16/29"]
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.21.1"
+        ip_address     = "192.168.21.11/24"
+        public_ip      = "67.71.12.148"
+        logical_ifname = "wan1"
+        secondary_private_cidr_list = ["192.168.21.16/29"]
+    }
+
+    interfaces {
+        dhcp           = true
+        logical_ifname = "mgmt0"
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.22.1"
+        ip_address     = "192.168.22.11/24"
+        logical_ifname = "wan2"
+    }
+
+    interfaces {
+        gateway_ip     = "192.168.23.1"
+        ip_address     = "192.168.23.11/24"
+        logical_ifname = "wan3"
+    }
+}
+
+resource "aviatrix_edge_megaport" "test_edge_spoke" {
+	account_name                       = aviatrix_account.test_acc_edge_megaport.account_name
+	gw_name                            = "%s"
+	site_id                            = "%s"
+	ztp_file_download_path             = "%s"
+
+	interfaces {
+		gateway_ip     = "10.220.14.1"
+		ip_address     = "10.220.14.10/24"
+		logical_ifname = "lan0"
+	}
+
+	interfaces {
+		gateway_ip     = "192.168.99.1"
+		ip_address     = "192.168.99.14/24"
+		logical_ifname = "wan0"
+		wan_public_ip  = "67.207.104.19"
+	}
+
+	interfaces {
+		gateway_ip     = "192.168.88.1"
+		ip_address     = "192.168.88.14/24"
+		logical_ifname = "wan1"
+		wan_public_ip  = "67.71.12.148"
+	}
+
+	interfaces {
+		gateway_ip     = "192.168.77.1"
+		ip_address     = "192.168.77.14/24"
+		logical_ifname = "wan2"
+		wan_public_ip  = "67.72.12.149"
+	}
+
+	interfaces {
+		enable_dhcp   = true
+		logical_ifname = "mgmt0"
+	}
+
+	vlan {
+		parent_logical_interface_name = "lan0"
+		vlan_id                        = 21
+		ip_address                     = "10.220.21.11/24"
+	}
+}
+
+resource "aviatrix_edge_spoke_transit_attachment" "test" {
+	spoke_gw_name   = "aviatrix_edge_megaport.test_edge_spoke.gw_name"
+	transit_gw_name = "aviatrix_transit_gateway.test_edge_transit.gw_name"
+	enable_over_private_network = true
+	enable_jumbo_frame = false
+	enable_insane_mode = true
+	enable_firenet_for_edge = %t
+	spoke_gateway_logical_ifnames = ["wan1"]
+	transit_gateway_logical_ifnames = ["wan1"]
+	disable_activemesh = false
+  }
+	`, accountName, transitGwName, transitSiteID, path, spokeGwName, spokeSiteID, path, enableFirenetForEdge)
 }
 
 func testAccCheckEdgeSpokeTransitAttachmentExists(resourceName string) resource.TestCheckFunc {

--- a/docs/resources/aviatrix_edge_spoke_transit_attachment.md
+++ b/docs/resources/aviatrix_edge_spoke_transit_attachment.md
@@ -29,6 +29,7 @@ resource "aviatrix_edge_spoke_transit_attachment" "test_attachment_2" {
   enable_insane_mode          = true
   edge_wan_interfaces         = ["eth0"]
   transit_gateway_logical_ifnames = ["wan1"]
+  enable_firenet_for_edge     = false
 }
 ```
 ```hcl
@@ -67,6 +68,7 @@ The following arguments are supported:
 * `spoke_gateway_logical_ifnames` - (Optional) Spoke gateway logical interface names for edge gateways where the peering originates. Required only for Megaport edge as a transit attachment.
 * `transit_gateway_logical_ifnames` - (Optional) Transit gateway logical interface names for edge gateways where the peering terminates. Required only for edge as a transit attachment.
 * `disable_activemesh` - (Optional) Switch to disable ActiveMesh mode. Only valid for Edge Spoke to Edge Transit attachments. Valid values: true, false. Default value: false.
+* `enable_firenet_for_edge` - (Optional) Switch to enable propagation of firenet routes from Transit Gateway -> Edge as Spoke Gateway.
 
 ## Import
 

--- a/goaviatrix/spoke_transit_attachment.go
+++ b/goaviatrix/spoke_transit_attachment.go
@@ -139,6 +139,7 @@ func (c *Client) GetEdgeSpokeTransitAttachment(ctx context.Context, spokeTransit
 	spokeTransitAttachment.InsaneModeTunnelNumber = data.Results.InsaneModeTunnelNumber
 	spokeTransitAttachment.EdgeWanInterfacesResp = data.Results.EdgeWanInterfaces
 	spokeTransitAttachment.DisableActivemesh = data.Results.DisableActivemesh
+	spokeTransitAttachment.EnableFirenetForEdge = data.Results.EnableFirenetForEdge
 
 	if data.Results.Site1.ConnBgpPrependAsPath != "" {
 		var prependAsPath []string

--- a/goaviatrix/spoke_transit_attachment.go
+++ b/goaviatrix/spoke_transit_attachment.go
@@ -30,6 +30,7 @@ type SpokeTransitAttachment struct {
 	SpokeGatewayLogicalIfNames   []string `form:"spoke_gw_logical_ifnames,omitempty" json:"spoke_gw_logical_ifnames,omitempty"`
 	TransitGatewayLogicalIfNames []string `form:"transit_gw_logical_ifnames,omitempty" json:"transit_gw_logical_ifnames,omitempty"`
 	DisableActivemesh            bool     `form:"disable_activemesh,omitempty" json:"disable_activemesh,omitempty"`
+	EnableFirenetForEdge         bool     `form:"enable_firenet_for_edge,omitempty" json:"enable_firenet_for_edge"`
 }
 
 type EdgeSpokeTransitAttachmentResp struct {
@@ -49,6 +50,7 @@ type EdgeSpokeTransitAttachmentResults struct {
 	SpokeGatewayLogicalIfNames   []string   `json:"src_gw_logical_ifnames"`
 	TransitGatewayLogicalIfNames []string   `json:"dst_wan_interfaces"`
 	DisableActivemesh            bool       `json:"disable_activemesh,omitempty"`
+	EnableFirenetForEdge         bool       `json:"enable_firenet_for_edge,omitempty"`
 }
 
 type SiteDetail struct {

--- a/goaviatrix/spoke_transit_attachment_test.go
+++ b/goaviatrix/spoke_transit_attachment_test.go
@@ -1,0 +1,199 @@
+package goaviatrix
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEdgeSpokeTransitAttachment(t *testing.T) {
+	tests := []struct {
+		name           string
+		apiResponse    EdgeSpokeTransitAttachmentResp
+		expectedResult SpokeTransitAttachment
+		expectError    bool
+	}{
+		{
+			name: "Complete response with all fields",
+			apiResponse: EdgeSpokeTransitAttachmentResp{
+				Return: true,
+				Results: EdgeSpokeTransitAttachmentResults{
+					EnableOverPrivateNetwork:     true,
+					EnableJumboFrame:             false,
+					EnableInsaneMode:             true,
+					InsaneModeTunnelNumber:       5,
+					EdgeWanInterfaces:            []string{"wan0", "wan1"},
+					SpokeGatewayLogicalIfNames:   []string{"wan0"},
+					TransitGatewayLogicalIfNames: []string{"wan1"},
+					DisableActivemesh:            false,
+					EnableFirenetForEdge:         true,
+					Site1: SiteDetail{
+						ConnBgpPrependAsPath: "65001 65002",
+					},
+					Site2: SiteDetail{
+						ConnBgpPrependAsPath: "65003 65004",
+					},
+				},
+			},
+			expectedResult: SpokeTransitAttachment{
+				EnableOverPrivateNetwork:     true,
+				EnableJumboFrame:             false,
+				EnableInsaneMode:             true,
+				InsaneModeTunnelNumber:       5,
+				EdgeWanInterfacesResp:        []string{"wan0", "wan1"},
+				SpokeGatewayLogicalIfNames:   []string{"wan0"},
+				TransitGatewayLogicalIfNames: []string{"wan1"},
+				DisableActivemesh:            false,
+				EnableFirenetForEdge:         true,
+				SpokePrependAsPath:           []string{"65001", "65002"},
+				TransitPrependAsPath:         []string{"65003", "65004"},
+			},
+			expectError: false,
+		},
+		{
+			name: "Response with EnableFirenetForEdge false",
+			apiResponse: EdgeSpokeTransitAttachmentResp{
+				Return: true,
+				Results: EdgeSpokeTransitAttachmentResults{
+					EnableOverPrivateNetwork:     false,
+					EnableJumboFrame:             true,
+					EnableInsaneMode:             false,
+					InsaneModeTunnelNumber:       0,
+					EdgeWanInterfaces:            []string{},
+					SpokeGatewayLogicalIfNames:   []string{},
+					TransitGatewayLogicalIfNames: []string{},
+					DisableActivemesh:            true,
+					EnableFirenetForEdge:         false,
+					Site1: SiteDetail{
+						ConnBgpPrependAsPath: "",
+					},
+					Site2: SiteDetail{
+						ConnBgpPrependAsPath: "",
+					},
+				},
+			},
+			expectedResult: SpokeTransitAttachment{
+				EnableOverPrivateNetwork:     false,
+				EnableJumboFrame:             true,
+				EnableInsaneMode:             false,
+				InsaneModeTunnelNumber:       0,
+				EdgeWanInterfacesResp:        []string{},
+				SpokeGatewayLogicalIfNames:   []string{},
+				TransitGatewayLogicalIfNames: []string{},
+				DisableActivemesh:            true,
+				EnableFirenetForEdge:         false,
+				SpokePrependAsPath:           []string{},
+				TransitPrependAsPath:         []string{},
+			},
+			expectError: false,
+		},
+		{
+			name: "API error response",
+			apiResponse: EdgeSpokeTransitAttachmentResp{
+				Return: false,
+				Reason: "Resource not found",
+			},
+			expectedResult: SpokeTransitAttachment{},
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test input
+			input := &SpokeTransitAttachment{
+				SpokeGwName:   "test-spoke",
+				TransitGwName: "test-transit",
+			}
+
+			// Mock the GetAPI method by creating a custom client
+			// This is a simplified test - in a real scenario, you'd want to mock the HTTP client
+			// For now, we'll test the struct field assignments directly
+
+			// Simulate the field assignments that happen in GetEdgeSpokeTransitAttachment
+			if tt.apiResponse.Return {
+				input.EnableOverPrivateNetwork = tt.apiResponse.Results.EnableOverPrivateNetwork
+				input.EnableJumboFrame = tt.apiResponse.Results.EnableJumboFrame
+				input.EnableInsaneMode = tt.apiResponse.Results.EnableInsaneMode
+				input.InsaneModeTunnelNumber = tt.apiResponse.Results.InsaneModeTunnelNumber
+				input.EdgeWanInterfacesResp = tt.apiResponse.Results.EdgeWanInterfaces
+				input.DisableActivemesh = tt.apiResponse.Results.DisableActivemesh
+				input.EnableFirenetForEdge = tt.apiResponse.Results.EnableFirenetForEdge
+
+				// Test AS path prepend parsing
+				if tt.apiResponse.Results.Site1.ConnBgpPrependAsPath != "" {
+					var prependAsPath []string
+					for _, str := range []string{tt.apiResponse.Results.Site1.ConnBgpPrependAsPath} {
+						// Simulate the string splitting logic
+						if str != "" {
+							prependAsPath = append(prependAsPath, str)
+						}
+					}
+					input.SpokePrependAsPath = prependAsPath
+				}
+
+				if tt.apiResponse.Results.Site2.ConnBgpPrependAsPath != "" {
+					var prependAsPath []string
+					for _, str := range []string{tt.apiResponse.Results.Site2.ConnBgpPrependAsPath} {
+						// Simulate the string splitting logic
+						if str != "" {
+							prependAsPath = append(prependAsPath, str)
+						}
+					}
+					input.TransitPrependAsPath = prependAsPath
+				}
+			}
+
+			// Verify the EnableFirenetForEdge field is correctly set
+			assert.Equal(t, tt.expectedResult.EnableFirenetForEdge, input.EnableFirenetForEdge, "EnableFirenetForEdge field should match expected value")
+
+			// Verify other critical fields
+			assert.Equal(t, tt.expectedResult.EnableOverPrivateNetwork, input.EnableOverPrivateNetwork)
+			assert.Equal(t, tt.expectedResult.EnableJumboFrame, input.EnableJumboFrame)
+			assert.Equal(t, tt.expectedResult.EnableInsaneMode, input.EnableInsaneMode)
+			assert.Equal(t, tt.expectedResult.InsaneModeTunnelNumber, input.InsaneModeTunnelNumber)
+			assert.Equal(t, tt.expectedResult.DisableActivemesh, input.DisableActivemesh)
+		})
+	}
+}
+
+func TestSpokeTransitAttachmentStructTags(t *testing.T) {
+	// Test that the struct tags are correctly defined
+	attachment := SpokeTransitAttachment{
+		EnableFirenetForEdge: true,
+	}
+
+	// This test ensures the struct can be marshaled to JSON with correct field names
+	jsonData, err := json.Marshal(attachment)
+	assert.NoError(t, err)
+
+	// Verify the JSON contains the expected field name
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	assert.NoError(t, err)
+
+	// Check that the field is present in JSON output
+	_, exists := result["enable_firenet_for_edge"]
+	assert.True(t, exists, "enable_firenet_for_edge field should be present in JSON output")
+}
+
+func TestEdgeSpokeTransitAttachmentResultsStructTags(t *testing.T) {
+	// Test that the response struct tags are correctly defined
+	results := EdgeSpokeTransitAttachmentResults{
+		EnableFirenetForEdge: true,
+	}
+
+	// This test ensures the struct can be marshaled to JSON with correct field names
+	jsonData, err := json.Marshal(results)
+	assert.NoError(t, err)
+
+	// Verify the JSON contains the expected field name
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	assert.NoError(t, err)
+
+	// Check that the field is present in JSON output
+	_, exists := result["enable_firenet_for_edge"]
+	assert.True(t, exists, "enable_firenet_for_edge field should be present in JSON output")
+}

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -37,7 +37,6 @@ type TransitGatewayPeering struct {
 	Gateway1LogicalIfNames              []string `form:"gateway1_logical_ifnames,omitempty" json:"gateway1_logical_ifnames,omitempty"`
 	Gateway2LogicalIfNames              []string `form:"gateway2_logical_ifnames,omitempty" json:"gateway2_logical_ifnames,omitempty"`
 	DisableActivemesh                   bool     `form:"disable_activemesh,omitempty" json:"disable_activemesh,omitempty"`
-	EnableFirenetForEdge                bool     `form:"enable_firenet_for_edge" json:"enable_firenet_for_edge,omitempty"`
 }
 
 type TransitGatewayPeeringEdit struct {
@@ -83,7 +82,6 @@ type TransitGatewayPeeringDetailsResults struct {
 	Gateway2LogicalIfNames []string                    `json:"dst_wan_interfaces"`
 	InsaneMode             bool                        `json:"insane_mode"`
 	DisableActivemesh      bool                        `json:"disable_activemesh,omitempty"`
-	EnableFirenetForEdge   bool                        `json:"enable_firenet_for_edge,omitempty"`
 }
 
 type TransitGatewayPeeringDetail struct {

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -83,7 +83,7 @@ type TransitGatewayPeeringDetailsResults struct {
 	Gateway2LogicalIfNames []string                    `json:"dst_wan_interfaces"`
 	InsaneMode             bool                        `json:"insane_mode"`
 	DisableActivemesh      bool                        `json:"disable_activemesh,omitempty"`
-	EnableFirenetForEdge   bool                        `json:"enable_firenet_for_edge"`
+	EnableFirenetForEdge   bool                        `json:"enable_firenet_for_edge,omitempty"`
 }
 
 type TransitGatewayPeeringDetail struct {

--- a/goaviatrix/transit_gateway_peering.go
+++ b/goaviatrix/transit_gateway_peering.go
@@ -37,6 +37,7 @@ type TransitGatewayPeering struct {
 	Gateway1LogicalIfNames              []string `form:"gateway1_logical_ifnames,omitempty" json:"gateway1_logical_ifnames,omitempty"`
 	Gateway2LogicalIfNames              []string `form:"gateway2_logical_ifnames,omitempty" json:"gateway2_logical_ifnames,omitempty"`
 	DisableActivemesh                   bool     `form:"disable_activemesh,omitempty" json:"disable_activemesh,omitempty"`
+	EnableFirenetForEdge                bool     `form:"enable_firenet_for_edge" json:"enable_firenet_for_edge,omitempty"`
 }
 
 type TransitGatewayPeeringEdit struct {
@@ -82,6 +83,7 @@ type TransitGatewayPeeringDetailsResults struct {
 	Gateway2LogicalIfNames []string                    `json:"dst_wan_interfaces"`
 	InsaneMode             bool                        `json:"insane_mode"`
 	DisableActivemesh      bool                        `json:"disable_activemesh,omitempty"`
+	EnableFirenetForEdge   bool                        `json:"enable_firenet_for_edge"`
 }
 
 type TransitGatewayPeeringDetail struct {


### PR DESCRIPTION
This pull request adds support for the `EnableFirenetForEdge` option to both spoke-transit attachments and transit gateway peering configurations. This new boolean field allows users to enable Firenet features specifically for edge scenarios. The changes ensure that this field is properly represented in both request and response structures.

**Support for Firenet for Edge:**

* Added the `EnableFirenetForEdge` boolean field to the `SpokeTransitAttachment` and `EdgeSpokeTransitAttachmentResults` structs in `goaviatrix/spoke_transit_attachment.go` to allow enabling Firenet for edge in spoke-transit attachment workflows. [[1]](diffhunk://#diff-e99f84d5a2829b3664b9aac8d8b071586314c59194cef8e8e8a4aece669b8567R33) [[2]](diffhunk://#diff-e99f84d5a2829b3664b9aac8d8b071586314c59194cef8e8e8a4aece669b8567R53)
* Added the `EnableFirenetForEdge` boolean field to the `TransitGatewayPeering` and `TransitGatewayPeeringDetailsResults` structs in `goaviatrix/transit_gateway_peering.go` to support Firenet for edge in transit gateway peering operations. [[1]](diffhunk://#diff-d91e59c5dbd1788e52dc175ae8e6b3e4666b65bafc6c0bcb7e271a46d8a3bbcdR40) [[2]](diffhunk://#diff-d91e59c5dbd1788e52dc175ae8e6b3e4666b65bafc6c0bcb7e271a46d8a3bbcdR86)