### PR TITLE
AVX-61864 Adding the advertised cidr list to edge spoke gateways [Backport rc-8.0.30]

### DIFF
--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -935,6 +935,8 @@ func editAdvertisedSpokeRoutesWithRetry(client *goaviatrix.Client, gatewayForGat
 	const retryDelay = 10 * time.Second
 	includedAdvertisedSpokeRoutes := getStringList(d, "included_advertised_spoke_routes")
 	if len(includedAdvertisedSpokeRoutes) > 0 {
+		return nil
+	}
 		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
 		avxerrRegex := regexp.MustCompile(`AVXERR[-_A-Z0-9]+`)
 		for i := 0; ; i++ {

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -546,22 +546,9 @@ func resourceAviatrixEdgeGatewaySelfmanagedCreate(ctx context.Context, d *schema
 	}
 
 	// set the advertised spoke cidr routes
-	includedAdvertisedSpokeRoutes := getStringList(d, "included_advertised_spoke_routes")
-	if len(includedAdvertisedSpokeRoutes) > 0 {
-		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
-		for i := 0; ; i++ {
-			log.Printf("[INFO] Editing customized routes advertisement of spoke gateway: %s ", gatewayForGatewayFunctions.GwName)
-			err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
-			if err == nil {
-				break
-			}
-			if i <= 30 && (strings.Contains(err.Error(), "when it is down") || strings.Contains(err.Error(), "hagw is down") ||
-				strings.Contains(err.Error(), "gateway is down")) {
-				time.Sleep(10 * time.Second)
-			} else {
-				return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %s due to: %s", gatewayForGatewayFunctions.GwName, err)
-			}
-		}
+	err = editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
+	if err != nil {
+		return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %s due to: %s", gatewayForGatewayFunctions.GwName, err)
 	}
 
 	return resourceAviatrixEdgeGatewaySelfmanagedReadIfRequired(ctx, d, meta, &flag)
@@ -620,8 +607,8 @@ func resourceAviatrixEdgeGatewaySelfmanagedRead(ctx context.Context, d *schema.R
 		d.Set("management_egress_ip_prefix_list", strings.Split(edgeSpoke.ManagementEgressIpPrefix, ","))
 	}
 
-	if len(edgeSpoke.AdvertisedSpokeRoutes) > 0 {
-		_ = d.Set("included_advertised_spoke_routes", edgeSpoke.AdvertisedSpokeRoutes)
+	if len(edgeSpoke.AdvertisedCidrList) > 0 {
+		_ = d.Set("included_advertised_spoke_routes", edgeSpoke.AdvertisedCidrList)
 	}
 
 	if edgeSpoke.EnableLearnedCidrsApproval {
@@ -797,7 +784,7 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 	}
 
 	if d.HasChange("included_advertised_spoke_routes") {
-		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeSpoke.AdvertisedSpokeRoutes
+		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeSpoke.AdvertisedCidrList
 		err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
 		if err != nil {
 			return diag.Errorf("could not update included advertised spoke routes during Edge Gateway Selfmanaged update: %v", err)
@@ -938,5 +925,32 @@ func resourceAviatrixEdgeGatewaySelfmanagedDelete(ctx context.Context, d *schema
 		log.Printf("[WARN] could not remove the ztp file: %v", err)
 	}
 
+	return nil
+}
+
+func editAdvertisedSpokeRoutesWithRetry(client *goaviatrix.Client, gatewayForGatewayFunctions *goaviatrix.Gateway, d *schema.ResourceData) error {
+	const maxRetries = 30
+	const retryDelay = 10 * time.Second
+	includedAdvertisedSpokeRoutes := getStringList(d, "included_advertised_spoke_routes")
+	if len(includedAdvertisedSpokeRoutes) > 0 {
+		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
+		// Retry logic: EditGatewayAdvertisedCidr may fail if the gateway or HA gateway is down.
+		// These transient errors can occur during provisioning or if the gateway is rebooting,
+		// so retry for up to 5 minutes before failing.
+		for i := 0; ; i++ {
+			log.Printf("[INFO] Editing customized routes advertisement of spoke gateway: %s ", gatewayForGatewayFunctions.GwName)
+			err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
+			if err == nil {
+				break
+			}
+			// If the gateway is unreachable, retry before failing as this can be transient.
+			if i <= maxRetries && (strings.Contains(err.Error(), "when it is down") || strings.Contains(err.Error(), "hagw is down") ||
+				strings.Contains(err.Error(), "gateway is down")) {
+				time.Sleep(retryDelay)
+			} else {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -550,7 +550,6 @@ func resourceAviatrixEdgeGatewaySelfmanagedCreate(ctx context.Context, d *schema
 	err = editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
 	if err != nil {
 		return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %q: %s", gatewayForGatewayFunctions.GwName, err)
-
 	}
 
 	return resourceAviatrixEdgeGatewaySelfmanagedReadIfRequired(ctx, d, meta, &flag)
@@ -934,33 +933,33 @@ func editAdvertisedSpokeRoutesWithRetry(client *goaviatrix.Client, gatewayForGat
 	const maxRetries = 30
 	const retryDelay = 10 * time.Second
 	includedAdvertisedSpokeRoutes := getStringList(d, "included_advertised_spoke_routes")
-	if len(includedAdvertisedSpokeRoutes) > 0 {
+	if len(includedAdvertisedSpokeRoutes) == 0 {
 		return nil
 	}
-		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
-		avxerrRegex := regexp.MustCompile(`AVXERR-[A-Z0-9-]+`)
-		for i := 0; ; i++ {
-			log.Printf("[INFO] Editing customized routes advertisement of spoke gateway %q", gatewayForGatewayFunctions.GwName)
-			err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
-			if err == nil {
-				break
-			}
 
-			shouldRetry := false
-			// Try to extract AVXERR code from error string
-			matches := avxerrRegex.FindStringSubmatch(err.Error())
-			if len(matches) > 0 {
-				switch matches[0] {
-				case "AVXERR-GATEWAY-0079", "AVXERR-SITE2CLOUD-0049", "AVXERR-SECDOMAIN-0013":
-					shouldRetry = true
-				}
-			}
+	gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
+	avxerrRegex := regexp.MustCompile(`AVXERR-[A-Z0-9-]+`)
+	for i := 0; ; i++ {
+		log.Printf("[INFO] Editing customized routes advertisement of spoke gateway %q", gatewayForGatewayFunctions.GwName)
+		err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
+		if err == nil {
+			break
+		}
 
-			if i <= maxRetries && shouldRetry {
-				time.Sleep(retryDelay)
-			} else {
-				return err
+		shouldRetry := false
+		// Try to extract AVXERR code from error string
+		matches := avxerrRegex.FindStringSubmatch(err.Error())
+		if len(matches) > 0 {
+			switch matches[0] {
+			case "AVXERR-GATEWAY-0079", "AVXERR-SITE2CLOUD-0049", "AVXERR-SECDOMAIN-0013":
+				shouldRetry = true
 			}
+		}
+
+		if i <= maxRetries && shouldRetry {
+			time.Sleep(retryDelay)
+		} else {
+			return err
 		}
 	}
 	return nil

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -938,7 +938,7 @@ func editAdvertisedSpokeRoutesWithRetry(client *goaviatrix.Client, gatewayForGat
 		return nil
 	}
 		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
-		avxerrRegex := regexp.MustCompile(`AVXERR[-_A-Z0-9]+`)
+		avxerrRegex := regexp.MustCompile(`AVXERR-[A-Z0-9-]+`)
 		for i := 0; ; i++ {
 			log.Printf("[INFO] Editing customized routes advertisement of spoke gateway %q", gatewayForGatewayFunctions.GwName)
 			err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -938,7 +938,7 @@ func editAdvertisedSpokeRoutesWithRetry(client *goaviatrix.Client, gatewayForGat
 		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
 		avxerrRegex := regexp.MustCompile(`AVXERR[-_A-Z0-9]+`)
 		for i := 0; ; i++ {
-			log.Printf("[INFO] Editing customized routes advertisement of spoke gateway: %s ", gatewayForGatewayFunctions.GwName)
+			log.Printf("[INFO] Editing customized routes advertisement of spoke gateway %q", gatewayForGatewayFunctions.GwName)
 			err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
 			if err == nil {
 				break

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -547,7 +547,7 @@ func resourceAviatrixEdgeGatewaySelfmanagedCreate(ctx context.Context, d *schema
 	}
 
 	// set the advertised spoke cidr routes
-	err = editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
+	err := editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
 	if err != nil {
 		return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %q: %s", gatewayForGatewayFunctions.GwName, err)
 	}

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -796,6 +796,14 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 		}
 	}
 
+	if d.HasChange("included_advertised_spoke_routes") {
+		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeSpoke.AdvertisedSpokeRoutes
+		err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
+		if err != nil {
+			return diag.Errorf("could not update included advertised spoke routes during Edge Gateway Selfmanaged update: %v", err)
+		}
+	}
+
 	if edgeSpoke.EnableLearnedCidrsApproval && d.HasChange("approved_learned_cidrs") {
 		gatewayForTransitFunctions.ApprovedLearnedCidrs = edgeSpoke.ApprovedLearnedCidrs
 		err := client.UpdateTransitPendingApprovedCidrs(gatewayForTransitFunctions)

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -934,18 +935,25 @@ func editAdvertisedSpokeRoutesWithRetry(client *goaviatrix.Client, gatewayForGat
 	includedAdvertisedSpokeRoutes := getStringList(d, "included_advertised_spoke_routes")
 	if len(includedAdvertisedSpokeRoutes) > 0 {
 		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
-		// Retry logic: EditGatewayAdvertisedCidr may fail if the gateway or HA gateway is down.
-		// These transient errors can occur during provisioning or if the gateway is rebooting,
-		// so retry for up to 5 minutes before failing.
+		avxerrRegex := regexp.MustCompile(`AVXERR[-_A-Z0-9]+`)
 		for i := 0; ; i++ {
 			log.Printf("[INFO] Editing customized routes advertisement of spoke gateway: %s ", gatewayForGatewayFunctions.GwName)
 			err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
 			if err == nil {
 				break
 			}
-			// If the gateway is unreachable, retry before failing as this can be transient.
-			if i <= maxRetries && (strings.Contains(err.Error(), "when it is down") || strings.Contains(err.Error(), "hagw is down") ||
-				strings.Contains(err.Error(), "gateway is down")) {
+
+			shouldRetry := false
+			// Try to extract AVXERR code from error string
+			matches := avxerrRegex.FindStringSubmatch(err.Error())
+			if len(matches) > 0 {
+				switch matches[0] {
+				case "AVXERR-GATEWAY-0079", "AVXERR-SITE2CLOUD-0049", "AVXERR-SECDOMAIN-0013":
+					shouldRetry = true
+				}
+			}
+
+			if i <= maxRetries && shouldRetry {
 				time.Sleep(retryDelay)
 			} else {
 				return err

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -549,7 +549,8 @@ func resourceAviatrixEdgeGatewaySelfmanagedCreate(ctx context.Context, d *schema
 	// set the advertised spoke cidr routes
 	err = editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
 	if err != nil {
-		return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %s due to: %s", gatewayForGatewayFunctions.GwName, err)
+		return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %q: %s", gatewayForGatewayFunctions.GwName, err)
+
 	}
 
 	return resourceAviatrixEdgeGatewaySelfmanagedReadIfRequired(ctx, d, meta, &flag)

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
@@ -41,6 +41,8 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.0", "10.230.3.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.1", "10.230.5.0/24"),
 				),
 			},
 			{
@@ -84,6 +86,11 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 		ip_address  = "172.16.15.162/20"
 		gateway_ip  = "172.16.0.1"
 	}
+
+	included_advertised_spoke_routes = [
+		"10.230.3.0/24",
+		"10.230.5.0/24"
+	]
 }
   `, gwName, siteId, path)
 }

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -639,7 +639,7 @@ func resourceAviatrixEdgePlatformCreate(ctx context.Context, d *schema.ResourceD
 	// set the advertised spoke cidr routes
 	err := editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
 	if err != nil {
-		return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %s due to: %s", gatewayForGatewayFunctions.GwName, err)
+		return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway %q: %s", gatewayForGatewayFunctions.GwName, err)
 	}
 
 	return resourceAviatrixEdgePlatformReadIfRequired(ctx, d, meta, &flag)

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -879,6 +879,14 @@ func resourceAviatrixEdgePlatformUpdate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
+	if d.HasChange("included_advertised_spoke_routes") {
+		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeNEO.AdvertisedSpokeRoutes
+		err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
+		if err != nil {
+			return diag.Errorf("could not update included advertised spoke routes during Edge Platform update: %v", err)
+		}
+	}
+
 	if d.HasChange("enable_learned_cidrs_approval") {
 		if edgeNEO.EnableLearnedCidrsApproval {
 			err := client.EnableTransitLearnedCidrsApproval(gatewayForTransitFunctions)

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -1024,15 +1024,6 @@ func resourceAviatrixEdgePlatformUpdate(ctx context.Context, d *schema.ResourceD
 
 	}
 
-	if d.HasChange("included_advertised_spoke_routes") {
-		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeNEO.ApprovedLearnedCidrs
-		err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
-		log.Printf("[INFO] Editing included advertised spoke vpc routes of spoke gateway: %s ", gatewayForGatewayFunctions.GwName)
-		if err != nil {
-			return diag.Errorf("failed to edit included advertised spoke vpc routes of spoke gateway: %s due to: %s", gatewayForGatewayFunctions.GwName, err)
-		}
-	}
-
 	d.Partial(false)
 
 	return resourceAviatrixEdgePlatformRead(ctx, d, meta)

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -638,22 +637,9 @@ func resourceAviatrixEdgePlatformCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	// set the advertised spoke cidr routes
-	includedAdvertisedSpokeRoutes := getStringList(d, "included_advertised_spoke_routes")
-	if len(includedAdvertisedSpokeRoutes) > 0 {
-		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes
-		for i := 0; ; i++ {
-			log.Printf("[INFO] Editing customized routes advertisement of spoke gateway: %s ", gatewayForGatewayFunctions.GwName)
-			err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
-			if err == nil {
-				break
-			}
-			if i <= 30 && (strings.Contains(err.Error(), "when it is down") || strings.Contains(err.Error(), "hagw is down") ||
-				strings.Contains(err.Error(), "gateway is down")) {
-				time.Sleep(10 * time.Second)
-			} else {
-				return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %s due to: %s", gatewayForGatewayFunctions.GwName, err)
-			}
-		}
+	err := editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
+	if err != nil {
+		return diag.Errorf("failed to edit advertised spoke vpc routes of spoke gateway: %s due to: %s", gatewayForGatewayFunctions.GwName, err)
 	}
 
 	return resourceAviatrixEdgePlatformReadIfRequired(ctx, d, meta, &flag)
@@ -701,8 +687,8 @@ func resourceAviatrixEdgePlatformRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("enable_edge_active_standby_preemptive", edgeNEOResp.EnableEdgeActiveStandbyPreemptive)
 	d.Set("enable_learned_cidrs_approval", edgeNEOResp.EnableLearnedCidrsApproval)
 
-	if len(edgeNEOResp.AdvertisedSpokeRoutes) > 0 {
-		_ = d.Set("included_advertised_spoke_routes", edgeNEOResp.AdvertisedSpokeRoutes)
+	if len(edgeNEOResp.AdvertisedCidrList) > 0 {
+		_ = d.Set("included_advertised_spoke_routes", edgeNEOResp.AdvertisedCidrList)
 	}
 
 	if edgeNEOResp.ManagementEgressIpPrefix == "" {
@@ -880,7 +866,7 @@ func resourceAviatrixEdgePlatformUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.HasChange("included_advertised_spoke_routes") {
-		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeNEO.AdvertisedSpokeRoutes
+		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeNEO.AdvertisedCidrList
 		err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
 		if err != nil {
 			return diag.Errorf("could not update included advertised spoke routes during Edge Platform update: %v", err)

--- a/aviatrix/resource_aviatrix_edge_platform_test.go
+++ b/aviatrix/resource_aviatrix_edge_platform_test.go
@@ -100,7 +100,7 @@ resource "aviatrix_edge_platform" "test" {
 		ip_address  = "172.16.15.162/20"
 		gateway_ip  = "172.16.0.1"
 	}
-	
+
 	included_advertised_spoke_routes = [
 		"10.230.3.0/24",
 		"10.230.5.0/24"

--- a/aviatrix/resource_aviatrix_edge_platform_test.go
+++ b/aviatrix/resource_aviatrix_edge_platform_test.go
@@ -42,6 +42,8 @@ func TestAccAviatrixEdgePlatform_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.0", "10.230.3.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.1", "10.230.5.0/24"),
 				),
 			},
 			{
@@ -98,6 +100,11 @@ resource "aviatrix_edge_platform" "test" {
 		ip_address  = "172.16.15.162/20"
 		gateway_ip  = "172.16.0.1"
 	}
+	
+	included_advertised_spoke_routes = [
+		"10.230.3.0/24",
+		"10.230.5.0/24"
+	]
 }
  `, accountName, deviceName, os.Getenv("EDGE_PLATFORM_DEVICE_SERIAL_NUMBER"), os.Getenv("EDGE_PLATFORM_DEVICE_HARDWARE_MODEL"),
 		gwName, siteId)

--- a/aviatrix/resource_aviatrix_transit_gateway_peering_helpers.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering_helpers.go
@@ -63,7 +63,7 @@ func setWanInterfaceNames(
 		} else {
 			transitGatewayPeering.DstWanInterfaces = wanInterfacesStr
 		}
-	case goaviatrix.IsCloudType(cloudType, goaviatrix.EDGEMEGAPORT|goaviatrix.EDGESELFMANAGED):
+	case goaviatrix.IsCloudType(cloudType, goaviatrix.EDGEMEGAPORT):
 		if gatewayPrefix == "gateway1" {
 			transitGatewayPeering.Gateway1LogicalIfNames = logicalIfNames
 			log.Printf("[INFO] Gateway1 Logical Interface Names: %#v", transitGatewayPeering.Gateway1LogicalIfNames)

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -46,6 +46,11 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
     ip_address  = "172.16.15.162/20"
     gateway_ip  = "172.16.0.1"
   }
+
+  included_advertised_spoke_routes = [
+    "10.10.0.0/16",
+    "172.16.0.0/12"
+  ]
 }
 ```
 
@@ -99,6 +104,7 @@ The following arguments are supported:
   * `peer_gateway_ip` - (Optional) LAN sub-interface gateway IP on HA gateway.
   * `vrrp_virtual_ip` - (Optional) LAN sub-interface virtual IP.
   * `tag` - (Optional) Tag.
+* `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -104,7 +104,7 @@ The following arguments are supported:
   * `peer_gateway_ip` - (Optional) LAN sub-interface gateway IP on HA gateway.
   * `vrrp_virtual_ip` - (Optional) LAN sub-interface virtual IP.
   * `tag` - (Optional) Tag.
-* `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
+* `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem gateways as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_edge_platform.md
+++ b/docs/resources/aviatrix_edge_platform.md
@@ -45,6 +45,11 @@ resource "aviatrix_edge_platform" "test" {
     ip_address  = "172.16.15.162/20"
     gateway_ip  = "172.16.0.1"
   }
+
+  included_advertised_spoke_routes = [
+    "10.10.0.0/16",
+    "172.16.0.0/12"
+  ]
 }
 ```
 
@@ -134,6 +139,7 @@ The following arguments are supported:
     * `tag` - (Optional) Tag.
 * `enable_single_ip_snat` - (Optional) Enable Single IP SNAT. Valid values: true, false. Default value: false.
 * `enable_auto_advertise_lan_cidrs` - (Optional) Enable auto advertise LAN CIDRs. Valid values: true, false. Default value: true.
+* `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_edge_platform.md
+++ b/docs/resources/aviatrix_edge_platform.md
@@ -139,7 +139,7 @@ The following arguments are supported:
     * `tag` - (Optional) Tag.
 * `enable_single_ip_snat` - (Optional) Enable Single IP SNAT. Valid values: true, false. Default value: false.
 * `enable_auto_advertise_lan_cidrs` - (Optional) Enable auto advertise LAN CIDRs. Valid values: true, false. Default value: true.
-* `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
+* `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem gateways as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
 
 ## Attribute Reference
 

--- a/goaviatrix/edge_neo.go
+++ b/goaviatrix/edge_neo.go
@@ -119,6 +119,7 @@ type EdgeNEOResp struct {
 	EnableNat                          string              `json:"enable_nat"`
 	SnatMode                           string              `json:"snat_target"`
 	EnableAutoAdvertiseLanCidrs        bool                `json:"auto_advertise_lan_cidrs"`
+	AdvertisedSpokeRoutes              []string            `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeNEOListResp struct {

--- a/goaviatrix/edge_neo.go
+++ b/goaviatrix/edge_neo.go
@@ -52,7 +52,7 @@ type EdgeNEO struct {
 	EnableAutoAdvertiseLanCidrs        string `json:"auto_advertise_lan_cidrs,omitempty"`
 	LanInterfaceIpPrefix               string
 	DirectAttachLan                    bool     `json:"direct_attach_lan,omitempty"`
-	AdvertisedSpokeRoutes              []string `json:"advertise_cidr_list,omitempty"`
+	AdvertisedCidrList                 []string `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeNEOInterface struct {
@@ -120,7 +120,7 @@ type EdgeNEOResp struct {
 	EnableNat                          string              `json:"enable_nat"`
 	SnatMode                           string              `json:"snat_target"`
 	EnableAutoAdvertiseLanCidrs        bool                `json:"auto_advertise_lan_cidrs"`
-	AdvertisedSpokeRoutes              []string            `json:"advertise_cidr_list,omitempty"`
+	AdvertisedCidrList                 []string            `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeNEOListResp struct {

--- a/goaviatrix/edge_neo.go
+++ b/goaviatrix/edge_neo.go
@@ -51,7 +51,8 @@ type EdgeNEO struct {
 	EnableSingleIpSnat                 bool
 	EnableAutoAdvertiseLanCidrs        string `json:"auto_advertise_lan_cidrs,omitempty"`
 	LanInterfaceIpPrefix               string
-	DirectAttachLan                    bool `json:"direct_attach_lan,omitempty"`
+	DirectAttachLan                    bool     `json:"direct_attach_lan,omitempty"`
+	AdvertisedSpokeRoutes              []string `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeNEOInterface struct {

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -54,7 +54,9 @@ type EdgeSpoke struct {
 	InterfaceList                      []*EdgeSpokeInterface
 	Interfaces                         string `json:"interfaces,omitempty"`
 	VlanList                           []*EdgeSpokeVlan
-	Vlan                               string `json:"vlan,omitempty"`
+	Vlan                               string                        `json:"vlan,omitempty"`
+	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
+	AdvertisedSpokeRoutes              []string                      `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeSpokeInterface struct {

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -94,22 +94,24 @@ type EdgeSpokeResp struct {
 	EnableEdgeActiveStandbyPreemptive  bool   `json:"edge_active_standby_preemptive"`
 	LocalAsNumber                      string `json:"local_as_number"`
 	PrependAsPath                      []string
-	PrependAsPathReturn                string                `json:"prepend_as_path"`
-	IncludeCidrList                    []string              `json:"include_cidr_list"`
-	EnableLearnedCidrsApproval         bool                  `json:"enable_learned_cidrs_approval"`
-	ApprovedLearnedCidrs               []string              `form:"approved_learned_cidrs,omitempty"`
-	SpokeBgpManualAdvertisedCidrs      []string              `json:"bgp_manual_spoke_advertise_cidrs"`
-	EnablePreserveAsPath               bool                  `json:"preserve_as_path"`
-	BgpPollingTime                     int                   `json:"bgp_polling_time"`
-	BgpBfdPollingTime                  int                   `json:"bgp_neighbor_status_polling_time"`
-	BgpHoldTime                        int                   `json:"bgp_hold_time"`
-	EnableEdgeTransitiveRouting        bool                  `json:"edge_transitive_routing"`
-	EnableJumboFrame                   bool                  `json:"jumbo_frame"`
-	Latitude                           float64               `json:"latitude"`
-	Longitude                          float64               `json:"longitude"`
-	RxQueueSize                        string                `json:"rx_queue_size"`
-	State                              string                `json:"vpc_state"`
-	InterfaceList                      []*EdgeSpokeInterface `json:"interfaces"`
+	PrependAsPathReturn                string                        `json:"prepend_as_path"`
+	IncludeCidrList                    []string                      `json:"include_cidr_list"`
+	EnableLearnedCidrsApproval         bool                          `json:"enable_learned_cidrs_approval"`
+	ApprovedLearnedCidrs               []string                      `form:"approved_learned_cidrs,omitempty"`
+	SpokeBgpManualAdvertisedCidrs      []string                      `json:"bgp_manual_spoke_advertise_cidrs"`
+	EnablePreserveAsPath               bool                          `json:"preserve_as_path"`
+	BgpPollingTime                     int                           `json:"bgp_polling_time"`
+	BgpBfdPollingTime                  int                           `json:"bgp_neighbor_status_polling_time"`
+	BgpHoldTime                        int                           `json:"bgp_hold_time"`
+	EnableEdgeTransitiveRouting        bool                          `json:"edge_transitive_routing"`
+	EnableJumboFrame                   bool                          `json:"jumbo_frame"`
+	Latitude                           float64                       `json:"latitude"`
+	Longitude                          float64                       `json:"longitude"`
+	RxQueueSize                        string                        `json:"rx_queue_size"`
+	State                              string                        `json:"vpc_state"`
+	InterfaceList                      []*EdgeSpokeInterface         `json:"interfaces"`
+	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
+	AdvertisedSpokeRoutes              []string                      `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeSpokeListResp struct {

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -56,7 +56,7 @@ type EdgeSpoke struct {
 	VlanList                           []*EdgeSpokeVlan
 	Vlan                               string                        `json:"vlan,omitempty"`
 	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
-	AdvertisedSpokeRoutes              []string                      `json:"advertise_cidr_list,omitempty"`
+	AdvertisedCidrList                 []string                      `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeSpokeInterface struct {
@@ -113,7 +113,7 @@ type EdgeSpokeResp struct {
 	State                              string                        `json:"vpc_state"`
 	InterfaceList                      []*EdgeSpokeInterface         `json:"interfaces"`
 	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
-	AdvertisedSpokeRoutes              []string                      `json:"advertise_cidr_list,omitempty"`
+	AdvertisedCidrList                 []string                      `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeSpokeListResp struct {

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -54,9 +54,8 @@ type EdgeSpoke struct {
 	InterfaceList                      []*EdgeSpokeInterface
 	Interfaces                         string `json:"interfaces,omitempty"`
 	VlanList                           []*EdgeSpokeVlan
-	Vlan                               string                        `json:"vlan,omitempty"`
-	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
-	AdvertisedCidrList                 []string                      `json:"advertise_cidr_list,omitempty"`
+	Vlan                               string   `json:"vlan,omitempty"`
+	AdvertisedCidrList                 []string `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeSpokeInterface struct {
@@ -96,24 +95,23 @@ type EdgeSpokeResp struct {
 	EnableEdgeActiveStandbyPreemptive  bool   `json:"edge_active_standby_preemptive"`
 	LocalAsNumber                      string `json:"local_as_number"`
 	PrependAsPath                      []string
-	PrependAsPathReturn                string                        `json:"prepend_as_path"`
-	IncludeCidrList                    []string                      `json:"include_cidr_list"`
-	EnableLearnedCidrsApproval         bool                          `json:"enable_learned_cidrs_approval"`
-	ApprovedLearnedCidrs               []string                      `form:"approved_learned_cidrs,omitempty"`
-	SpokeBgpManualAdvertisedCidrs      []string                      `json:"bgp_manual_spoke_advertise_cidrs"`
-	EnablePreserveAsPath               bool                          `json:"preserve_as_path"`
-	BgpPollingTime                     int                           `json:"bgp_polling_time"`
-	BgpBfdPollingTime                  int                           `json:"bgp_neighbor_status_polling_time"`
-	BgpHoldTime                        int                           `json:"bgp_hold_time"`
-	EnableEdgeTransitiveRouting        bool                          `json:"edge_transitive_routing"`
-	EnableJumboFrame                   bool                          `json:"jumbo_frame"`
-	Latitude                           float64                       `json:"latitude"`
-	Longitude                          float64                       `json:"longitude"`
-	RxQueueSize                        string                        `json:"rx_queue_size"`
-	State                              string                        `json:"vpc_state"`
-	InterfaceList                      []*EdgeSpokeInterface         `json:"interfaces"`
-	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
-	AdvertisedCidrList                 []string                      `json:"advertise_cidr_list,omitempty"`
+	PrependAsPathReturn                string                `json:"prepend_as_path"`
+	IncludeCidrList                    []string              `json:"include_cidr_list"`
+	EnableLearnedCidrsApproval         bool                  `json:"enable_learned_cidrs_approval"`
+	ApprovedLearnedCidrs               []string              `form:"approved_learned_cidrs,omitempty"`
+	SpokeBgpManualAdvertisedCidrs      []string              `json:"bgp_manual_spoke_advertise_cidrs"`
+	EnablePreserveAsPath               bool                  `json:"preserve_as_path"`
+	BgpPollingTime                     int                   `json:"bgp_polling_time"`
+	BgpBfdPollingTime                  int                   `json:"bgp_neighbor_status_polling_time"`
+	BgpHoldTime                        int                   `json:"bgp_hold_time"`
+	EnableEdgeTransitiveRouting        bool                  `json:"edge_transitive_routing"`
+	EnableJumboFrame                   bool                  `json:"jumbo_frame"`
+	Latitude                           float64               `json:"latitude"`
+	Longitude                          float64               `json:"longitude"`
+	RxQueueSize                        string                `json:"rx_queue_size"`
+	State                              string                `json:"vpc_state"`
+	InterfaceList                      []*EdgeSpokeInterface `json:"interfaces"`
+	AdvertisedCidrList                 []string              `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeSpokeListResp struct {


### PR DESCRIPTION
Backport for https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2267
Adding new attribute included_advertised_spoke_routes to edge platform and self managed spoke gateways.

E.g.
```
resource "aviatrix_edge_gateway_selfmanaged" "edge_self_managed_1" {
    gw_name = "eas_self_managed_1"
    site_id = "eas-site-1"
    ztp_file_type = "cloud-init"
    ztp_file_download_path = "ztp"
    management_egress_ip_prefix_list = [ 
        "162.43.141.85/32"
    ]
    interfaces {
        name = "eth0"
        type = "WAN"
        ip_address = "192.168.19.12/24"
        gateway_ip = "192.168.19.1"
    }

    interfaces {
        name = "eth1"
        type = "LAN"
        ip_address = "192.168.20.12/24"
        gateway_ip = "192.168.20.1"
    }

    interfaces {
        name = "eth2"
        type = "MANAGEMENT"
        enable_dhcp = true
    }
    included_advertised_spoke_routes = [
        "10.10.0.0/16",
        "172.16.0.0/12"
    ]
}
```