### PR TITLE
AVX-68208: Create a new resource user group membership

### DIFF
--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -170,6 +170,7 @@ func Provider() *schema.Provider {
 			"aviatrix_rbac_group_access_account_attachment":                   resourceAviatrixRbacGroupAccessAccountAttachment(),
 			"aviatrix_rbac_group_permission_attachment":                       resourceAviatrixRbacGroupPermissionAttachment(),
 			"aviatrix_rbac_group_user_attachment":                             resourceAviatrixRbacGroupUserAttachment(),
+			"aviatrix_rbac_group_user_membership":                             resourceAviatrixRbacGroupUserMembership(),
 			"aviatrix_remote_syslog":                                          resourceAviatrixRemoteSyslog(),
 			"aviatrix_saml_endpoint":                                          resourceAviatrixSamlEndpoint(),
 			"aviatrix_segmentation_network_domain":                            resourceAviatrixSegmentationNetworkDomain(),

--- a/aviatrix/resource_aviatrix_rbac_group_user_membership.go
+++ b/aviatrix/resource_aviatrix_rbac_group_user_membership.go
@@ -1,0 +1,166 @@
+package aviatrix
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAviatrixRbacGroupUserMembership() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAviatrixRbacGroupUserMembershipCreate,
+		Read:   resourceAviatrixRbacGroupUserMembershipRead,
+		Update: resourceAviatrixRbacGroupUserMembershipUpdate,
+		Delete: resourceAviatrixRbacGroupUserMembershipDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+				if d.Id() == "" {
+					return nil, fmt.Errorf("import requires group_name as ID")
+				}
+				_ = d.Set("group_name", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"group_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "RBAC permission group name. This resource is authoritative for the group's user membership.",
+			},
+			"user_names": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				MinItems:    1,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Description: "Complete set of user names that must be members of the group (authoritative).",
+			},
+			"remove_users_on_destroy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If true, deleting this resource will remove all users from the group. Default is false (the users are left in place).",
+			},
+		},
+	}
+}
+
+func resourceAviatrixRbacGroupUserMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+
+	group := d.Get("group_name").(string)
+	users := expandStringSet(d.Get("user_names").(*schema.Set))
+
+	log.Printf("[INFO] Creating (authoritative) user membership for group %q: %v", group, users)
+
+	if err := client.SetRbacGroupUsers(group, users); err != nil {
+		return fmt.Errorf("failed to set user for RBAC group %q: %w", group, err)
+	}
+
+	d.SetId(group)
+	return resourceAviatrixRbacGroupUserMembershipRead(d, meta)
+}
+
+func resourceAviatrixRbacGroupUserMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+
+	group := d.Get("group_name").(string)
+	if group == "" {
+		group = d.Id()
+		_ = d.Set("group_name", group)
+	}
+
+	log.Printf("[INFO] Reading (authoritative) user membership for group %q", group)
+
+	current, err := client.ListRbacGroupUsers(group)
+	if err != nil {
+		if errors.Is(err, goaviatrix.ErrNotFound) {
+			log.Printf("[WARN] RBAC group %q not found; removing from state", group)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("failed to list users for RBAC group %q: %w", group, err)
+	}
+
+	sort.Strings(current)
+	if err := d.Set("user_names", stringSliceToIfaceSlice(current)); err != nil {
+		return fmt.Errorf("failed to set user_names for %q: %w", group, err)
+	}
+
+	d.SetId(group)
+	return nil
+}
+
+func resourceAviatrixRbacGroupUserMembershipUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+	group := d.Get("group_name").(string)
+
+	if d.HasChange("user_names") {
+		desired := expandStringSet(d.Get("user_names").(*schema.Set))
+		if err := client.SetRbacGroupUsers(group, desired); err != nil {
+			return fmt.Errorf("failed to update users for RBAC group %q: %w", group, err)
+		}
+	}
+
+	return resourceAviatrixRbacGroupUserMembershipRead(d, meta)
+}
+
+func resourceAviatrixRbacGroupUserMembershipDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*goaviatrix.Client)
+
+	if v, ok := d.GetOk("remove_users_on_destroy"); !ok || !v.(bool) {
+		return nil
+	}
+
+	group := d.Get("group_name").(string)
+
+	users, err := client.ListRbacGroupUsers(group)
+	if err != nil {
+		if errors.Is(err, goaviatrix.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to list users before delete for group %q: %w", group, err)
+	}
+
+	if len(users) == 0 {
+		return nil
+	}
+
+	if err := client.DeleteRbacGroupUsers(group, users); err != nil {
+		return fmt.Errorf("failed to remove users for group %q: %w", group, err)
+	}
+
+	return nil
+}
+
+func expandStringSet(set *schema.Set) []string {
+	if set == nil {
+		return nil
+	}
+	items := set.List()
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out = append(out, strings.TrimSpace(s))
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+func stringSliceToIfaceSlice(in []string) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}

--- a/aviatrix/resource_aviatrix_rbac_group_user_membership_test.go
+++ b/aviatrix/resource_aviatrix_rbac_group_user_membership_test.go
@@ -1,0 +1,195 @@
+package aviatrix
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAviatrixRbacGroupUserMembership_basic(t *testing.T) {
+	var gotUsers []string
+
+	rName := acctest.RandString(5)
+
+	skipAcc := os.Getenv("SKIP_RBAC_GROUP_USER_MEMBERSHIP")
+	if skipAcc == "yes" {
+		t.Skip("Skipping rbac group user membership tests as SKIP_RBAC_GROUP_USER_MEMBERSHIP is set")
+	}
+
+	resourceName := "aviatrix_rbac_group_user_membership.test"
+	msgCommon := ". Set SKIP_RBAC_GROUP_USER_MEMBERSHIP to 'yes' to skip rbac group user membership tests"
+
+	usersStep1 := []string{
+		fmt.Sprintf("tf-user-a-%s", rName),
+		fmt.Sprintf("tf-user-b-%s", rName),
+		fmt.Sprintf("tf-user-c-%s", rName),
+	}
+	usersStep2 := []string{
+		fmt.Sprintf("tf-user-a-%s", rName),
+		fmt.Sprintf("tf-user-c-%s", rName),
+		fmt.Sprintf("tf-user-d-%s", rName),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRbacGroupUserMembershipDestroy(usersStep2),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRbacGroupUserMembershipConfig(rName, usersStep1, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRbacGroupUserMembershipExists(resourceName, &gotUsers),
+					resource.TestCheckResourceAttr(resourceName, "group_name", fmt.Sprintf("tf-%s", rName)),
+					testCheckStringSet(resourceName, "user_names", usersStep1),
+				),
+			},
+			{
+				Config: testAccRbacGroupUserMembershipConfig(rName, usersStep2, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRbacGroupUserMembershipExists(resourceName, &gotUsers),
+					testCheckStringSet(resourceName, "user_names", usersStep2),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRbacGroupUserMembershipConfig(rName string, users []string, removeOnDestroy bool) string {
+	group := fmt.Sprintf("tf-%s", rName)
+
+	var userBlocks strings.Builder
+	for i, u := range users {
+		fmt.Fprintf(&userBlocks, `
+resource "aviatrix_account_user" "u%d" {
+  username = "%s"
+  email    = "%s@xyz.com"
+  password = "Password-1234"
+}
+`, i+1, u, u)
+	}
+
+	var userRefs strings.Builder
+	for i := range users {
+		fmt.Fprintf(&userRefs, "    aviatrix_account_user.u%d.username,\n", i+1)
+	}
+
+	return fmt.Sprintf(`
+resource "aviatrix_rbac_group" "test" {
+  group_name = "%s"
+}
+
+%s
+
+resource "aviatrix_rbac_group_user_membership" "test" {
+  group_name = aviatrix_rbac_group.test.group_name
+  user_names = [
+%s  ]
+  remove_users_on_destroy = %t
+}
+`, group, userBlocks.String(), userRefs.String(), removeOnDestroy)
+}
+
+func testAccCheckRbacGroupUserMembershipExists(n string, got *[]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("rbac group user membership not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no rbac group user membership ID set")
+		}
+
+		client := testAccProvider.Meta().(*goaviatrix.Client)
+		group := rs.Primary.Attributes["group_name"]
+		if group == "" {
+			group = rs.Primary.ID
+		}
+
+		current, err := client.ListRbacGroupUsers(group)
+		if err != nil {
+			if errors.Is(err, goaviatrix.ErrNotFound) {
+				return fmt.Errorf("rbac group %q not found in backend", group)
+			}
+			return err
+		}
+		sort.Strings(current)
+		*got = current
+		return nil
+	}
+}
+
+func testCheckStringSet(res, attr string, expected []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[res]
+		if !ok {
+			return fmt.Errorf("resource %s not found", res)
+		}
+		var got []string
+		prefix := attr + "."
+		for k, v := range rs.Primary.Attributes {
+			if strings.HasPrefix(k, prefix) && k != attr+".#" {
+				got = append(got, v)
+			}
+		}
+		sort.Strings(got)
+		exp := append([]string(nil), expected...)
+		sort.Strings(exp)
+
+		if !slices.Equal(got, exp) {
+			return fmt.Errorf("attribute %q mismatch.\n  got: %v\n  exp: %v", attr, got, exp)
+		}
+		return nil
+	}
+}
+
+// For destroy, because the resource may only remove users if remove_users_on_destroy=true,
+// we verify that none of the test users remain members. If the group is gone, that's fine.
+func testAccCheckRbacGroupUserMembershipDestroy(lastAppliedUsers []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*goaviatrix.Client)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aviatrix_rbac_group_user_membership" {
+				continue
+			}
+			group := rs.Primary.Attributes["group_name"]
+			if group == "" {
+				group = rs.Primary.ID
+			}
+
+			current, err := client.ListRbacGroupUsers(group)
+			if err != nil {
+				// Group missing is acceptable (treated as removed from state)
+				if errors.Is(err, goaviatrix.ErrNotFound) || strings.Contains(strings.ToLower(err.Error()), "not found") {
+					return nil
+				}
+				return err
+			}
+
+			// Ensure none of the last-applied users are still members
+			for _, u := range lastAppliedUsers {
+				if slices.Contains(current, u) {
+					return fmt.Errorf("rbac group %q still contains user %q after destroy", group, u)
+				}
+			}
+		}
+		return nil
+	}
+}

--- a/docs/resources/aviatrix_rbac_group_user_membership.md
+++ b/docs/resources/aviatrix_rbac_group_user_membership.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Accounts"
+layout: "aviatrix"
+page_title: "Aviatrix: aviatrix_rbac_group_user_membership"
+description: |-
+  Creates and manages Aviatrix RBAC group user membership
+---
+# aviatrix_rbac_group_user_membership
+The **aviatrix_rbac_group_user_membership** resource allows the creation and management of user membership for Aviatrix (Role-Based Access Control) RBAC groups. This resource is authoritative for the group's user membership, meaning it manages the complete set of users that belong to a specific group.
+
+> **Note:** There is another related resource, [`aviatrix_rbac_group_user_attachment`](./aviatrix_rbac_group_user_attachment.md), which manages a single user-to-group attachment per resource. While that resource is still available, you should prefer **`aviatrix_rbac_group_user_membership`** when managing an entire group’s membership as a single source of truth, especially for larger sets of users or groups.
+
+## Example Usage
+
+### Basic Usage
+```hcl
+# Create an Aviatrix RBAC Group User Membership
+resource "aviatrix_rbac_group_user_membership" "test_membership" {
+  group_name = "write_only"
+  user_names = [
+    "user1",
+    "user2",
+    "admin_user"
+  ]
+  remove_users_on_destroy = true
+}
+```
+
+### Advanced Usage with User References
+```hcl
+# Create Aviatrix account users
+resource "aviatrix_account_user" "rbac_user_1" {
+  username = "rbac_user_1"
+  email    = "rbac_user_1@aviatrix.com"
+  password = "Rbac_user1"
+}
+
+resource "aviatrix_account_user" "rbac_user_2" {
+  username = "rbac_user_2"
+  email    = "rbac_user_2@aviatrix.com"
+  password = "Rbac_user2"
+}
+
+resource "aviatrix_account_user" "rbac_user_3" {
+  username = "rbac_user_3"
+  email    = "rbac_user_3@aviatrix.com"
+  password = "Rbac_user3"
+}
+
+# Create RBAC group membership with referenced users
+resource "aviatrix_rbac_group_user_membership" "rbac_grp_membership1" {
+  group_name = "rbac_local_login_1"
+  user_names = [
+    aviatrix_account_user.rbac_user_1.username,
+    aviatrix_account_user.rbac_user_2.username,
+    aviatrix_account_user.rbac_user_3.username,
+  ]
+  remove_users_on_destroy = true
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+
+### Required
+* `group_name` - (Required) RBAC permission group name. This resource is authoritative for the group's user membership.
+* `user_names` - (Required) Complete set of user names that must be members of the group (authoritative). At least one user name must be specified.
+
+### Optional
+* `remove_users_on_destroy` - (Optional) If true, deleting this resource will remove all users from the group. Default is false (the users are left in place).
+
+## Import
+**rbac_group_user_membership** can be imported using the `group_name`, e.g.
+
+```
+$ terraform import aviatrix_rbac_group_user_membership.test write_only
+```


### PR DESCRIPTION
The **aviatrix_rbac_group_user_membership** resource allows the creation and management of user membership for Aviatrix  RBAC groups. This resource is authoritative for the group's user membership, meaning it manages the complete set of users that belong to a specific group.

**Note:** There is another related resource, `aviatrix_rbac_group_user_attachment` which manages a single user-to-group attachment per resource. While that resource is still available it would be preferable to use this new resource especially
for larger sets of users or groups.
