### PR TITLE
AVX-68408 Fixing the update functionality for advertised spoke routes in edge gateways

### DIFF
--- a/aviatrix/resource_aviatrix_edge_equinix.go
+++ b/aviatrix/resource_aviatrix_edge_equinix.go
@@ -701,7 +701,7 @@ func resourceAviatrixEdgeEquinixRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if len(edgeEquinixResp.AdvertisedCidrList) > 0 {
-		_ = d.Set("advertised_cidr_list", edgeEquinixResp.AdvertisedCidrList)
+		_ = d.Set("included_advertised_spoke_routes", edgeEquinixResp.AdvertisedCidrList)
 	}
 
 	d.Set("rx_queue_size", edgeEquinixResp.RxQueueSize)

--- a/aviatrix/resource_aviatrix_edge_equinix_test.go
+++ b/aviatrix/resource_aviatrix_edge_equinix_test.go
@@ -43,6 +43,8 @@ func TestAccAviatrixEdgeEquinix_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.0", "10.230.3.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.1", "10.230.5.0/24"),
 				),
 			},
 			{
@@ -91,6 +93,11 @@ resource "aviatrix_edge_equinix" "test" {
 		ip_address  = "172.16.15.162/20"
 		gateway_ip  = "172.16.0.1"
 	}
+
+	included_advertised_spoke_routes = [
+		"10.230.3.0/24",
+		"10.230.5.0/24"
+	]
 }
  `, accountName, edgeEquinixUsername, gwName, siteId, path)
 }

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -323,7 +323,7 @@ func resourceAviatrixEdgeGatewaySelfmanaged() *schema.Resource {
 				},
 			},
 			"included_advertised_spoke_routes": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "A list of CIDRs to be advertised to on-prem as 'Included CIDR List'. When configured, it will replace all advertised routes from this VPC.",
 				Elem: &schema.Schema{
@@ -772,8 +772,7 @@ func resourceAviatrixEdgeGatewaySelfmanagedUpdate(ctx context.Context, d *schema
 	}
 
 	if d.HasChange("included_advertised_spoke_routes") {
-		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeSpoke.AdvertisedCidrList
-		err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
+		err := editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
 		if err != nil {
 			return diag.Errorf("could not update included advertised spoke routes during Edge Gateway Selfmanaged update: %v", err)
 		}
@@ -919,7 +918,7 @@ func resourceAviatrixEdgeGatewaySelfmanagedDelete(ctx context.Context, d *schema
 func editAdvertisedSpokeRoutesWithRetry(client *goaviatrix.Client, gatewayForGatewayFunctions *goaviatrix.Gateway, d *schema.ResourceData) error {
 	const maxRetries = 30
 	const retryDelay = 10 * time.Second
-	includedAdvertisedSpokeRoutes := getStringList(d, "included_advertised_spoke_routes")
+	includedAdvertisedSpokeRoutes := getStringSet(d, "included_advertised_spoke_routes")
 	if len(includedAdvertisedSpokeRoutes) == 0 {
 		return nil
 	}

--- a/aviatrix/resource_aviatrix_edge_megaport_test.go
+++ b/aviatrix/resource_aviatrix_edge_megaport_test.go
@@ -50,6 +50,8 @@ func TestAccAviatrixEdgeMegaport_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "vlan.0.parent_logical_interface_name", "lan0"),
 					resource.TestCheckResourceAttr(resourceName, "vlan.0.vlan_id", "21"),
 					resource.TestCheckResourceAttr(resourceName, "vlan.0.ip_address", "10.220.21.11/24"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.0", "10.230.3.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.1", "10.230.5.0/24"),
 				),
 			},
 			{
@@ -123,6 +125,11 @@ func testAccEdgeMegaportBasic(accountName, gwName, siteId, path string) string {
 			vlan_id                        = 21
 			ip_address                     = "10.220.21.11/24"
 		}
+
+	    included_advertised_spoke_routes = [
+			"10.230.3.0/24",
+			"10.230.5.0/24"
+		]
 	}
  `, accountName, gwName, siteId, path)
 }

--- a/aviatrix/resource_aviatrix_edge_platform.go
+++ b/aviatrix/resource_aviatrix_edge_platform.go
@@ -374,7 +374,7 @@ func resourceAviatrixEdgePlatform() *schema.Resource {
 				Description: "Enable auto advertise LAN CIDRs.",
 			},
 			"included_advertised_spoke_routes": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "A list of CIDRs to be advertised to on-prem as 'Included CIDR List'. When configured, it will replace all advertised routes from this VPC.",
 				Elem: &schema.Schema{
@@ -868,8 +868,7 @@ func resourceAviatrixEdgePlatformUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.HasChange("included_advertised_spoke_routes") {
-		gatewayForGatewayFunctions.AdvertisedSpokeRoutes = edgeNEO.AdvertisedCidrList
-		err := client.EditGatewayAdvertisedCidr(gatewayForGatewayFunctions)
+		err := editAdvertisedSpokeRoutesWithRetry(client, gatewayForGatewayFunctions, d)
 		if err != nil {
 			return diag.Errorf("could not update included advertised spoke routes during Edge Platform update: %v", err)
 		}

--- a/docs/resources/aviatrix_edge_equinix.md
+++ b/docs/resources/aviatrix_edge_equinix.md
@@ -41,6 +41,11 @@ resource "aviatrix_edge_equinix" "test" {
     ip_address  = "172.16.15.162/20"
     gateway_ip  = "172.16.0.1"
   }
+
+  included_advertised_spoke_routes = [
+    "10.10.0.0/16",
+    "172.16.0.0/12"
+  ]
 }
 ```
 
@@ -125,6 +130,7 @@ The following arguments are supported:
   * `tag` - (Optional) Tag.
 * `enable_single_ip_snat` - (Optional) Enable Single IP SNAT. Valid values: true, false. Default value: false.
 * `enable_auto_advertise_lan_cidrs` - (Optional) Enable auto advertise LAN CIDRs. Valid values: true, false. Default value: true.
+* `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem gateways as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_edge_megaport.md
+++ b/docs/resources/aviatrix_edge_megaport.md
@@ -56,6 +56,11 @@ resource "aviatrix_edge_megaport" "test" {
     dns_server_ip  = "192.168.77.1"
   }
   management_egress_ip_prefix_list = ["162.43.147.137/31"]
+
+  included_advertised_spoke_routes = [
+    "10.10.0.0/16",
+    "172.16.0.0/12"
+  ]
 }
 ```
 
@@ -112,6 +117,7 @@ The following arguments are supported:
   * `tag` - (Optional) Tag.
 * `enable_single_ip_snat` - (Optional) Enable Single IP SNAT. Valid values: true, false. Default value: false.
 * `enable_auto_advertise_lan_cidrs` - (Optional) Enable auto advertise LAN CIDRs. Valid values: true, false. Default value: true.
+* `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem gateways as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_edge_megaport.md
+++ b/docs/resources/aviatrix_edge_megaport.md
@@ -19,7 +19,6 @@ resource "aviatrix_edge_megaport" "test" {
   gw_name                = "megaport-test"
   site_id                = "site-123"
   ztp_file_download_path = "/ztp/file/download/path"
-  tag                    = "edge-megaport-test"
   interfaces {
     gateway_ip     = "10.220.14.1"
     ip_address     = "10.220.14.10/24"

--- a/goaviatrix/edge_equinix.go
+++ b/goaviatrix/edge_equinix.go
@@ -116,6 +116,7 @@ type EdgeEquinixResp struct {
 	EnableNat                          string       `json:"enable_nat"`
 	SnatMode                           string       `json:"snat_target"`
 	EnableAutoAdvertiseLanCidrs        bool         `json:"auto_advertise_lan_cidrs"`
+	AdvertisedCidrList                 []string     `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeEquinixListResp struct {

--- a/goaviatrix/edge_megaport.go
+++ b/goaviatrix/edge_megaport.go
@@ -119,6 +119,7 @@ type EdgeMegaportResp struct {
 	SnatMode                           string              `json:"snat_target"`
 	EnableAutoAdvertiseLanCidrs        bool                `json:"auto_advertise_lan_cidrs"`
 	InterfaceMapping                   []InterfaceMapping  `json:"interface_mapping"`
+	AdvertisedCidrList                 []string            `json:"advertise_cidr_list,omitempty"`
 }
 
 type EdgeMegaportListResp struct {


### PR DESCRIPTION
- Fixing the update functionality for `included_advertised_spoke_routes`
- Suppressing the diff for this attribute by updating the schema from type list to set
- This attribute was added in 8.1.10 release
- Adding the `included_advertised_spoke_routes` for equinix and megaport spoke gateways

```
resource "aviatrix_edge_gateway_selfmanaged" "edge_self_managed_2" {
    gw_name = "eas_self_managed_2"
    site_id = "eas-site-2"
    ztp_file_type = "cloud-init"
    ztp_file_download_path = "ztp"
    management_egress_ip_prefix_list = [ 
        "162.43.141.85/32"
    ]
    interfaces {
        name = "eth0"
        type = "WAN"
        ip_address = "192.168.19.12/24"
        gateway_ip = "192.168.19.1"
    }

    interfaces {
        name = "eth1"
        type = "LAN"
        ip_address = "192.168.20.12/24"
        gateway_ip = "192.168.20.1"
    }

    interfaces {
        name = "eth2"
        type = "MANAGEMENT"
        enable_dhcp = true
    }
    included_advertised_spoke_routes = [
        "10.10.0.0/16",
        "172.16.0.0/12",
        "10.0.91.0/24",
        "10.0.92.0/24",
        "10.0.93.0/24",
        "10.0.94.0/24",
        "10.0.95.0/24"
    ]
}
```
