### PR TITLE
Removing the cidr routes when empty values are passed for edge gateways

### DIFF
--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged.go
@@ -918,9 +918,13 @@ func resourceAviatrixEdgeGatewaySelfmanagedDelete(ctx context.Context, d *schema
 func editAdvertisedSpokeRoutesWithRetry(client *goaviatrix.Client, gatewayForGatewayFunctions *goaviatrix.Gateway, d *schema.ResourceData) error {
 	const maxRetries = 30
 	const retryDelay = 10 * time.Second
+
 	includedAdvertisedSpokeRoutes := getStringSet(d, "included_advertised_spoke_routes")
+
+	// If empty array is provided, we still want to make the API call to clear routes
+	// We'll pass an empty string to signal clearing all routes
 	if len(includedAdvertisedSpokeRoutes) == 0 {
-		return nil
+		includedAdvertisedSpokeRoutes = []string{""}
 	}
 
 	gatewayForGatewayFunctions.AdvertisedSpokeRoutes = includedAdvertisedSpokeRoutes

--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_helper_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_helper_test.go
@@ -735,3 +735,47 @@ func TestPopulateCustomInterfaceMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestEditAdvertisedSpokeRoutesEmptyArrayHandling(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputRoutes    []string
+		expectedRoutes []string
+		description    string
+	}{
+		{
+			name:           "Empty array should be converted to empty string array",
+			inputRoutes:    []string{},
+			expectedRoutes: []string{""},
+			description:    "When user sets included_advertised_spoke_routes = [], it should be converted to [\"\"] to clear routes",
+		},
+		{
+			name:           "Non-empty array should remain unchanged",
+			inputRoutes:    []string{"10.0.0.0/8", "192.168.0.0/16"},
+			expectedRoutes: []string{"10.0.0.0/8", "192.168.0.0/16"},
+			description:    "When user sets actual CIDR routes, they should remain unchanged",
+		},
+		{
+			name:           "Single empty string should remain unchanged",
+			inputRoutes:    []string{""},
+			expectedRoutes: []string{""},
+			description:    "When user sets included_advertised_spoke_routes = [\"\"], it should remain as is",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Simulate the logic from editAdvertisedSpokeRoutesWithRetry
+			includedAdvertisedSpokeRoutes := test.inputRoutes
+
+			// Apply the same logic as in the actual function
+			if len(includedAdvertisedSpokeRoutes) == 0 {
+				includedAdvertisedSpokeRoutes = []string{""}
+			}
+
+			if !reflect.DeepEqual(includedAdvertisedSpokeRoutes, test.expectedRoutes) {
+				t.Errorf("Test '%s' failed: expected %v, got %v", test.name, test.expectedRoutes, includedAdvertisedSpokeRoutes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For edge gateway resource:
```
resource "aviatrix_edge_equinix" "test_edge_equinix_3" {
  account_name           = "edge_equinix"
  gw_name                = "equinix-edge-3"
  site_id                = "site-125"
  ztp_file_download_path = "ztp"

  interfaces {
    name          = "eth0"
    type          = "WAN"
    ip_address    = "10.230.5.32/24"
    gateway_ip    = "10.230.5.100"
    wan_public_ip = "64.71.24.221"
  }

  interfaces {
    name       = "eth1"
    type       = "LAN"
    ip_address = "10.230.3.32/24"
  }

  included_advertised_spoke_routes = [
    "10.10.0.0/16",
    "172.16.0.0/12",
    "10.0.91.0/24",
    "10.0.92.0/24",
    "10.0.93.0/24",
    "10.0.94.0/24",
    "10.0.95.0/24"
  ]
}
```

Setting the `included_advertised_spoke_routes = []` removes the cidr routes from the edge gateways. 
This change is applicable to for the following edge gateway types:

1. selfmanaged
2. equinix
3. mergaport
4. edge platform