### PR TITLE
AVX-62871: Should support underlay_cidr

### DIFF
--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -785,6 +785,12 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"underlay_cidr": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "The underlay CIDR in the format of ipaddr/netmask for this interface.",
+							ValidateFunc: validation.IsCIDR,
+						},
 					},
 				},
 			},
@@ -830,6 +836,12 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+						},
+						"underlay_cidr": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "The underlay CIDR in the format of ipaddr/netmask for this interface.",
+							ValidateFunc: validation.IsCIDR,
 						},
 					},
 				},
@@ -4589,9 +4601,9 @@ func getInterfaceDetails(interfaces []interface{}, cloudType int) (string, error
 
 func parseInterface(ifaceInfo map[string]interface{}, wanCount, cloudType int) (goaviatrix.EdgeTransitInterface, error) {
 	var (
-		logicalIfName, ifaceName, ifaceType, ifaceGatewayIP, ifaceIP, ifacePublicIP string
-		ifaceDHCP                                                                   bool
-		secondaryCIDRs                                                              []string
+		logicalIfName, ifaceName, ifaceType, ifaceGatewayIP, ifaceIP, ifacePublicIP, ifaceUnderlayCidr string
+		ifaceDHCP                                                                                      bool
+		secondaryCIDRs                                                                                 []string
 	)
 
 	logicalIfName, err := getStringAttribute(ifaceInfo, "logical_ifname")
@@ -4612,6 +4624,7 @@ func parseInterface(ifaceInfo map[string]interface{}, wanCount, cloudType int) (
 	ifaceGatewayIP, _ = getStringAttribute(ifaceInfo, "gateway_ip")
 	ifaceIP, _ = getStringAttribute(ifaceInfo, "ip_address")
 	ifacePublicIP, _ = getStringAttribute(ifaceInfo, "public_ip")
+	ifaceUnderlayCidr, _ = getStringAttribute(ifaceInfo, "underlay_cidr")
 	ifaceDHCP, _ = getBoolAttribute(ifaceInfo, "dhcp")
 	secondaryCIDRs, _ = getStringListAttribute(ifaceInfo, "secondary_private_cidr_list")
 
@@ -4621,6 +4634,7 @@ func parseInterface(ifaceInfo map[string]interface{}, wanCount, cloudType int) (
 		Dhcp:           ifaceDHCP,
 		IpAddress:      ifaceIP,
 		SecondaryCIDRs: secondaryCIDRs,
+		UnderlayCidr:   ifaceUnderlayCidr,
 	}
 
 	if cloudType == goaviatrix.EDGEMEGAPORT {
@@ -4697,6 +4711,9 @@ func setInterfaceDetails(interfaces []goaviatrix.EdgeTransitInterface, interface
 		}
 		if intf.GatewayIp != "" {
 			interfaceDict["gateway_ip"] = intf.GatewayIp
+		}
+		if intf.UnderlayCidr != "" {
+			interfaceDict["underlay_cidr"] = intf.UnderlayCidr
 		}
 		if intf.SecondaryCIDRs != nil {
 			secondaryCIDRs := make([]string, 0)

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -44,6 +44,12 @@ var interfaces = []interface{}{
 		"ip_address":     "192.168.23.11/24",
 		"logical_ifname": "wan3",
 	},
+	map[string]interface{}{
+		"gateway_ip":     "169.254.100.1",
+		"ip_address":     "10.0.1.10/24",
+		"logical_ifname": "wan4",
+		"underlay_cidr":  "169.254.100.2/30",
+	},
 }
 
 var expectedInterfaceDetails = []goaviatrix.EdgeTransitInterface{
@@ -72,6 +78,12 @@ var expectedInterfaceDetails = []goaviatrix.EdgeTransitInterface{
 		GatewayIp:     "192.168.23.1",
 		IpAddress:     "192.168.23.11/24",
 		LogicalIfName: "wan3",
+	},
+	{
+		GatewayIp:     "169.254.100.1",
+		IpAddress:     "10.0.1.10/24",
+		LogicalIfName: "wan4",
+		UnderlayCidr:  "169.254.100.2/30",
 	},
 }
 
@@ -1031,7 +1043,7 @@ func TestCountInterfaceTypes(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	// Check that the WAN count matches the expected value
-	expectedWANCount := 4
+	expectedWANCount := 5
 	if wanCount != expectedWANCount {
 		t.Errorf("Expected %d WAN interfaces, got %d", expectedWANCount, wanCount)
 	}

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -311,10 +311,11 @@ resource "aviatrix_transit_gateway" "edge-transit-test" {
         secondary_private_cidr_list = ["192.168.19.16/29"]
     }
     interfaces {
-        gateway_ip    = "192.168.21.1"
+        gateway_ip    = "169.254.100.1"
         ip_address    = "192.168.21.11/24"
         type          = "WAN"
         index         = 1
+        underlay_cidr = "169.254.100.2/30"
         secondary_private_cidr_list = ["192.168.21.16/29"]
     }
     interfaces {
@@ -370,10 +371,11 @@ resource "aviatrix_transit_gateway" "edge-transit-test" {
         type          = "WAN"
     }
     ha_interfaces {
-        gateway_ip   = "192.168.21.1"
+        gateway_ip   = "169.254.200.1"
         index        = 1
         ip_address   = "192.168.21.12/24"
         type         = "WAN"
+        underlay_cidr = "169.254.200.2/30"
         secondary_private_cidr_list = ["192.168.21.32/29"]
     }
     ha_interfaces {
@@ -445,6 +447,7 @@ The following arguments are supported:
   * `ip_address` - (Optional) The static IP address assigned to this interface.
   * `public_ip` - (Optional) The public IP address associated with this interface.
   * `dhcp` - (Optional) Whether DHCP is enabled on this interface. Set the value to true or false. Applicable to only 'MANAGEMENT' type interface.
+  * `underlay_cidr` - (Optional) The underlay CIDR for BGP over LAN functionality. Must be a link-local address in CIDR format (e.g., "169.254.100.2/30"). When specified, the gateway_ip must be within this CIDR range.
   * `secondary_private_cidr_list` - (Optional) A list of secondary private CIDR blocks associated with this interface.
 * `interface_mapping` - (Optional) A list of interface names mapped to interface types and indices. Required and valid only for edge transit gateways (AEP). Each interface has the following attributes:
   * `name` - (Required) Interface name e.g. eth0, eth1, eth2 etc.
@@ -475,6 +478,7 @@ The following arguments are supported:
   * `ip_address` - (Optional) The static IP address assigned to this interface.
   * `public_ip` - (Optional) The public IP address associated with this interface.
   * `dhcp` - (Optional) Whether DHCP is enabled on this interface. Set the value to true or false. Applicable to only 'MANAGEMENT' type interface.
+  * `underlay_cidr` - (Optional) The underlay CIDR for BGP over LAN functionality. Must be a link-local address in CIDR format (e.g., "169.254.100.2/30"). When specified, the gateway_ip must be within this CIDR range.
   * `secondary_private_cidr_list` - (Optional) A list of secondary private CIDR blocks associated with this interface.
 
 ### Insane Mode

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -157,6 +157,7 @@ type EdgeTransitInterface struct {
 	GatewayIp      string   `json:"gateway_ip,omitempty"`
 	SecondaryCIDRs []string `json:"secondary_private_cidr_list,omitempty"`
 	LogicalIfName  string   `json:"logical_ifname,omitempty"`
+	UnderlayCidr   string   `json:"underlay_cidr,omitempty"`
 }
 
 type EipMap struct {


### PR DESCRIPTION
configure when creating EaT using Terraform

Way to use this is:

```
interfaces = [
  {
    logical_ifname = "wan0"
    ip_address     = "169.254.100.1"
    gateway_ip     = "10.0.1.10/24"
    underlay_cidr  = "169.254.100.2/28"
  },
]
```

To understand the backend controller code, use:
https://github.com/AviatrixDev/cloudn/pull/38890

for reference.