### PR TITLE
AVX-54809: Adding a data source for webgroups to search by name

### DIFF
--- a/aviatrix/data_source_aviatrix_dcf_webgroups.go
+++ b/aviatrix/data_source_aviatrix_dcf_webgroups.go
@@ -1,0 +1,103 @@
+package aviatrix
+
+import (
+	"context"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAviatrixDcfWebgroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAviatrixDcfWebgroupsRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the Web Group.",
+			},
+			"selector": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"match_expressions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"snifilter": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Server name indicator this expression matches.",
+									},
+									"urlfilter": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "URL address this expression matches.",
+									},
+								},
+							},
+						},
+					},
+				},
+				Description: "List of match expressions for the Web Group.",
+			},
+			"uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of the Web Group.",
+			},
+		},
+	}
+}
+
+func dataSourceAviatrixDcfWebgroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	name, ok := d.Get("name").(string)
+	if !ok {
+		return diag.Errorf("name must be of type string")
+	}
+	if name == "" {
+		return diag.Errorf("name must be specified")
+	}
+
+	webGroup, err := client.GetWebGroupByName(ctx, name)
+	if err != nil {
+		return diag.Errorf("could not get DCF webgroups: %s", err)
+	}
+
+	err = d.Set("name", webGroup.Name)
+	if err != nil {
+		return diag.Errorf("could not set name: %s", err)
+	}
+	err = d.Set("uuid", webGroup.UUID)
+	if err != nil {
+		return diag.Errorf("could not set uuid: %s", err)
+	}
+	var expressions []interface{}
+
+	for _, filter := range webGroup.Selector.Expressions {
+		filterMap := map[string]interface{}{
+			"snifilter": filter.SniFilter,
+			"urlfilter": filter.UrlFilter,
+		}
+
+		expressions = append(expressions, filterMap)
+	}
+
+	selector := []interface{}{
+		map[string]interface{}{
+			"match_expressions": expressions,
+		},
+	}
+	if err := d.Set("selector", selector); err != nil {
+		return diag.Errorf("failed to set selector during Web Group read: %s", err)
+	}
+
+	d.SetId(webGroup.UUID)
+
+	return nil
+}

--- a/aviatrix/data_source_aviatrix_dcf_webgroups_test.go
+++ b/aviatrix/data_source_aviatrix_dcf_webgroups_test.go
@@ -1,0 +1,67 @@
+package aviatrix
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceAviatrixDcfWebgroups_basic(t *testing.T) {
+	resourceName := "data.aviatrix_web_group.test"
+
+	skipAcc := os.Getenv("SKIP_DATA_DCF_WEBGROUPS")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Data Source DCF Webgroups test as SKIP_DATA_DCF_WEBGROUPS is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, ". Set SKIP_DATA_DCF_WEBGROUPS to yes to skip Data Source DCF Webgroups tests")
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAviatrixDcfWebgroupsConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAviatrixDcfWebgroups(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
+					resource.TestCheckResourceAttr(resourceName, "selector.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAviatrixDcfWebgroupsConfigBasic() string {
+	return `
+resource aviatrix_web_group "test_webgroup" {
+	name = "test-webgroup"
+	selector {
+		match_expressions {
+			snifilter = "example.com"
+		}
+	}
+}
+
+data "aviatrix_web_group" "test" {
+	depends_on = [aviatrix_web_group.test_webgroup]
+	name = "test-webgroup"
+}
+	`
+}
+
+func testAccDataSourceAviatrixDcfWebgroups(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no data source called %s", name)
+		}
+
+		return nil
+	}
+}

--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -209,6 +209,7 @@ func Provider() *schema.Provider {
 			"aviatrix_account":                              dataSourceAviatrixAccount(),
 			"aviatrix_caller_identity":                      dataSourceAviatrixCallerIdentity(),
 			"aviatrix_controller_metadata":                  dataSourceAviatrixControllerMetadata(),
+			"aviatrix_web_group":                            dataSourceAviatrixDcfWebgroups(),
 			"aviatrix_dcf_mwp_attachment_point":             dataSourceAviatrixDcfMwpAttachmentPoints(),
 			"aviatrix_device_interfaces":                    dataSourceAviatrixDeviceInterfaces(),
 			"aviatrix_edge_gateway_wan_interface_discovery": dataSourceAviatrixEdgeGatewayWanInterfaceDiscovery(),

--- a/docs/data-sources/aviatrix_web_group.md
+++ b/docs/data-sources/aviatrix_web_group.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Secured Networking"
+layout: "aviatrix"
+page_title: "Aviatrix: aviatrix_web_group"
+description: |-
+    Gets details about a DCF Web Group.
+---
+
+# aviatrix_web_group
+
+The **aviatrix_web_group** data source provides details about a specific DCF Web Group created by the Aviatrix Controller.
+
+## Example Usage
+
+```hcl
+# Aviatrix Web Group Data Source
+data "aviatrix_web_group" "example" {
+    name = "my-web-group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the Web Group.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `name` - Name of the Web Group.
+* `uuid` - UUID of the Web Group.
+* `selector` - Block containing match expressions to filter the Web Group.
+        * `match_expressions` - List of match expressions for the Web Group.
+                * `snifilter` - Server name indicator this expression matches.
+                * `urlfilter` - URL address this expression matches.

--- a/docs/data-sources/aviatrix_web_group.md
+++ b/docs/data-sources/aviatrix_web_group.md
@@ -33,5 +33,5 @@ The following attributes are exported:
 * `uuid` - UUID of the Web Group.
 * `selector` - Block containing match expressions to filter the Web Group.
         * `match_expressions` - List of match expressions for the Web Group.
-                * `snifilter` - Server name indicator this expression matches.
+                * `snifilter` - Server name indication this expression matches.
                 * `urlfilter` - URL address this expression matches.


### PR DESCRIPTION
The webgroups can now be queried by name using this data source. They will return the Selector and UUID of the webgroups.

Example usage:

```tf
data "aviatrix_web_group" "foo" {
  name = "testing-ad"
}

resource "aviatrix_distributed_firewalling_policy_list" "testing1" {
    policies {
    name                     = "df-policy-1"
    action                   = "DEEP_PACKET_INSPECTION_PERMIT"
    priority                 = 1
    protocol                 = "ANY"
    logging                  = false
    watch                    = false
    exclude_sg_orchestration = true
    src_smart_groups         = [
      "def000ad-0000-0000-0000-000000000000"
    ]
    dst_smart_groups         = [
      "def000ad-0000-0000-0000-000000000000"
    ]
    web_groups = [
      data.aviatrix_web_group.foo.id
    ]
    flow_app_requirement     = "TLS_REQUIRED"
    decrypt_policy           = "DECRYPT_ALLOWED"
    port_ranges {
      hi = 50000
      lo = 49000
    }
  }
}
```