### PR TITLE
AVX-69456: add public_ip when enable associated copilot

### DIFF
--- a/goaviatrix/copilot_association.go
+++ b/goaviatrix/copilot_association.go
@@ -7,6 +7,7 @@ func (c *Client) EnableCopilotAssociation(ctx context.Context, addr string) erro
 		"action":     "enable_copilot_association",
 		"CID":        c.CID,
 		"copilot_ip": addr,
+		"public_ip":  addr,
 	}
 	return c.PostAPIContext(ctx, form["action"], form, BasicCheck)
 }


### PR DESCRIPTION
This PR added `public_ip` when enable associated copilot via terraform.
* CoPilot DB server collection stored in MongoDB has two IP attributes: `ip` and `public_ip`. 
* controller v2 API `enable_copilot_association` accept `copilot_ip` as required and `public_ip` as optional. 
* However, observed that the `public_ip` is None when deploy copilot via terraform, which leads the problem that gateway cannot connect to remote copilot avx-oteld endpoint. 
* the fix is to provide `public_ip` when enable copilot association. 