### PR TITLE
AVX-69475: Add support for K8s configuration resource in Terraform

### DIFF
--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -163,6 +163,7 @@ func Provider() *schema.Provider {
 			"aviatrix_global_vpc_excluded_instance":                           resourceAviatrixGlobalVpcExcludedInstance(),
 			"aviatrix_global_vpc_tagging_settings":                            resourceAviatrixGlobalVpcTaggingSettings(),
 			"aviatrix_kubernetes_cluster":                                     resourceAviatrixKubernetesCluster(),
+			"aviatrix_k8s_config":                                             resourceAviatrixK8sConfig(),
 			"aviatrix_link_hierarchy":                                         resourceAviatrixLinkHierarchy(),
 			"aviatrix_netflow_agent":                                          resourceAviatrixNetflowAgent(),
 			"aviatrix_periodic_ping":                                          resourceAviatrixPeriodicPing(),

--- a/aviatrix/resource_aviatrix_k8s_config.go
+++ b/aviatrix/resource_aviatrix_k8s_config.go
@@ -93,11 +93,8 @@ func resourceAviatrixK8sConfigRead(ctx context.Context, d *schema.ResourceData, 
 
 	k8sConfig, err := client.GetK8sStatus(ctx)
 	if err != nil {
-		// err will never be sth like that the resource was not found, all feature flags are always present
-		// and in doubt the controller will simply respond with unknown features disabled.
-		// However, the features "k8s" and "k8s_dcf_policies" are defined in
-		// cloudx-local/controller_feature/definitions.py:90 and :92.
-		// That means any error here is unexpected and a real exception.
+		// The API always exposes these feature flags. GetK8sStatus should not return "not found".
+		// If a feature is unknown, the controller reports it as disabled (enabled=false).
 		return diag.Errorf("failed to read K8s status: %s", err)
 	}
 	if err := d.Set(propertyEnableK8s, k8sConfig.EnableK8s); err != nil {

--- a/aviatrix/resource_aviatrix_k8s_config.go
+++ b/aviatrix/resource_aviatrix_k8s_config.go
@@ -93,6 +93,11 @@ func resourceAviatrixK8sConfigRead(ctx context.Context, d *schema.ResourceData, 
 
 	k8sConfig, err := client.GetK8sStatus(ctx)
 	if err != nil {
+		// err will never be sth like that the resource was not found, all feature flags are always present
+		// and in doubt the controller will simply respond with unknown features disabled.
+		// However, the features "k8s" and "k8s_dcf_policies" are defined in
+		// cloudx-local/controller_feature/definitions.py:90 and :92.
+		// That means any error here is unexpected and a real exception.
 		return diag.Errorf("failed to read K8s status: %s", err)
 	}
 	if err := d.Set(propertyEnableK8s, k8sConfig.EnableK8s); err != nil {

--- a/aviatrix/resource_aviatrix_k8s_config.go
+++ b/aviatrix/resource_aviatrix_k8s_config.go
@@ -1,0 +1,152 @@
+package aviatrix
+
+import (
+	"context"
+	"strings"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAviatrixK8sConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceAviatrixK8sConfigCreate,
+		ReadWithoutTimeout:   resourceAviatrixK8sConfigRead,
+		UpdateWithoutTimeout: resourceAviatrixK8sConfigUpdate,
+		DeleteWithoutTimeout: resourceAviatrixK8sConfigDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"enable_k8s": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to enable K8s.",
+			},
+			"enable_dcf_policies": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to enable DCF policies in K8s clusters. Can only be true if enable_k8s is also true.",
+			},
+		},
+	}
+}
+
+func resourceAviatrixK8sConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	enableK8s := d.Get("enable_k8s").(bool)
+	enableDcfPolicies := d.Get("enable_dcf_policies").(bool)
+
+	// Validate that enable_dcf_policies can only be true if enable_k8s is true
+	if enableDcfPolicies && !enableK8s {
+		return diag.Errorf("enable_dcf_policies can only be true when enable_k8s is also true")
+	}
+
+	if enableK8s {
+		err := client.EnableK8s(ctx)
+		if err != nil {
+			return diag.Errorf("failed to enable K8s: %s", err)
+		}
+	} else {
+		err := client.DisableK8s(ctx)
+		if err != nil {
+			return diag.Errorf("failed to disable K8s: %s", err)
+		}
+	}
+
+	if enableDcfPolicies {
+		err := client.EnableK8sDcfPolicies(ctx)
+		if err != nil {
+			return diag.Errorf("failed to enable K8s DCF policies: %s", err)
+		}
+	} else {
+		err := client.DisableK8sDcfPolicies(ctx)
+		if err != nil {
+			return diag.Errorf("failed to disable K8s DCF policies: %s", err)
+		}
+	}
+
+	d.SetId(strings.Replace(client.ControllerIP, ".", "-", -1))
+	return resourceAviatrixK8sConfigRead(ctx, d, meta)
+}
+
+func resourceAviatrixK8sConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	if d.Id() != strings.Replace(client.ControllerIP, ".", "-", -1) {
+		return diag.Errorf("ID: %s does not match controller IP. Please provide correct ID for importing", d.Id())
+	}
+
+	k8sConfig, err := client.GetK8sStatus(ctx)
+	if err != nil {
+		return diag.Errorf("failed to read K8s status: %s", err)
+	}
+	d.Set("enable_k8s", k8sConfig.EnableK8s)
+	d.Set("enable_dcf_policies", k8sConfig.EnableDcfPolicies)
+
+	d.SetId(strings.Replace(client.ControllerIP, ".", "-", -1))
+	return nil
+}
+
+func resourceAviatrixK8sConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	enableK8s := d.Get("enable_k8s").(bool)
+	enableDcfPolicies := d.Get("enable_dcf_policies").(bool)
+
+	// Validate that enable_dcf_policies can only be true if enable_k8s is true
+	if enableDcfPolicies && !enableK8s {
+		return diag.Errorf("enable_dcf_policies can only be true when enable_k8s is also true")
+	}
+
+	if d.HasChange("enable_k8s") {
+		if enableK8s {
+			err := client.EnableK8s(ctx)
+			if err != nil {
+				return diag.Errorf("failed to enable K8s during update: %s", err)
+			}
+		} else {
+			err := client.DisableK8s(ctx)
+			if err != nil {
+				return diag.Errorf("failed to disable K8s during update: %s", err)
+			}
+		}
+	}
+
+	if d.HasChange("enable_dcf_policies") {
+		if enableDcfPolicies {
+			err := client.EnableK8sDcfPolicies(ctx)
+			if err != nil {
+				return diag.Errorf("failed to enable K8s DCF policies during update: %s", err)
+			}
+		} else {
+			err := client.DisableK8sDcfPolicies(ctx)
+			if err != nil {
+				return diag.Errorf("failed to disable K8s DCF policies during update: %s", err)
+			}
+		}
+	}
+
+	return resourceAviatrixK8sConfigRead(ctx, d, meta)
+}
+
+func resourceAviatrixK8sConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	err := client.DisableK8sDcfPolicies(ctx)
+	if err != nil {
+		return diag.Errorf("failed to disable K8s DCF policies during delete: %s", err)
+	}
+
+	err = client.DisableK8s(ctx)
+	if err != nil {
+		return diag.Errorf("failed to delete K8s config: %s", err)
+	}
+
+	return nil
+}

--- a/aviatrix/resource_aviatrix_k8s_config.go
+++ b/aviatrix/resource_aviatrix_k8s_config.go
@@ -24,7 +24,7 @@ func resourceAviatrixK8sConfig() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 			enableK8s := d.Get(propertyEnableK8s).(bool)
 			enableDcfPolicies := d.Get(propertyEnableDcfPolicies).(bool)
 

--- a/aviatrix/resource_aviatrix_k8s_config_test.go
+++ b/aviatrix/resource_aviatrix_k8s_config_test.go
@@ -1,0 +1,126 @@
+package aviatrix
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAviatrixK8sConfig_basic(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_K8S_CONFIG")
+	if skipAcc == "yes" {
+		t.Skip("Skipping K8s config tests as SKIP_K8S_CONFIG is set")
+	}
+
+	resourceName := "aviatrix_k8s_config.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccK8sConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccK8sConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccK8sConfigExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_k8s", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_dcf_policies", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAviatrixK8sConfig_validation(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_K8S_CONFIG")
+	if skipAcc == "yes" {
+		t.Skip("Skipping K8s config tests as SKIP_K8S_CONFIG is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccK8sConfigInvalid(),
+				ExpectError: regexp.MustCompile("enable_dcf_policies can only be true when enable_k8s is also true"),
+			},
+		},
+	})
+}
+
+func testAccK8sConfigInvalid() string {
+	return `
+resource "aviatrix_k8s_config" "test" {
+	enable_k8s = false
+	enable_dcf_policies = true
+}
+	`
+}
+
+func testAccK8sConfigBasic() string {
+	return `
+resource "aviatrix_k8s_config" "test" {
+	enable_k8s = true
+	enable_dcf_policies = true
+}
+	`
+}
+
+func testAccK8sConfigExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("k8s config Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no k8s config ID is set")
+		}
+
+		client := testAccProvider.Meta().(*goaviatrix.Client)
+
+		if strings.Replace(client.ControllerIP, ".", "-", -1) != rs.Primary.ID {
+			return fmt.Errorf("k8s config ID not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccK8sConfigDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*goaviatrix.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aviatrix_k8s_config" {
+			continue
+		}
+
+		k8sConfig, err := client.GetK8sStatus(context.Background())
+		if err != nil {
+			return fmt.Errorf("could not retrieve k8s config")
+		}
+		if k8sConfig.EnableK8s {
+			return fmt.Errorf("k8s is still enabled")
+		}
+		if k8sConfig.EnableDcfPolicies {
+			return fmt.Errorf("k8s DCF policies are still enabled")
+		}
+	}
+
+	return nil
+}

--- a/docs/resources/aviatrix_k8s_config.md
+++ b/docs/resources/aviatrix_k8s_config.md
@@ -25,9 +25,9 @@ resource "aviatrix_k8s_config" "test" {
 
 The following arguments are supported:
 
-### Required
-* `enable_k8s` - (Optional) Whether to enable the K8s feature on an Aviatrix Controller. Valid values: true, false. Default value: false.
-* `enable_dcf_policies` - (Optional) Whether to enable DCF policies in K8s clusters. Can only be true if enable_k8s is also true. Valid values: true, false. Default value: false.
+### Optional
+* `enable_k8s` - Whether to enable the K8s feature on an Aviatrix Controller. Valid values: true, false. Default value: false.
+* `enable_dcf_policies` - Whether to enable DCF policies in K8s clusters. Can only be true if enable_k8s is also true. Valid values: true, false. Default value: false.
 
 ## Import
 

--- a/docs/resources/aviatrix_k8s_config.md
+++ b/docs/resources/aviatrix_k8s_config.md
@@ -1,0 +1,38 @@
+---
+subcategory: "Secured Networking"
+layout: "aviatrix"
+page_title: "Aviatrix: aviatrix_k8s_config"
+description: |-
+  Creates and manages an Aviatrix K8s Config
+---
+
+# aviatrix_k8s_config
+
+The **aviatrix_k8s_config** resource allows management of an Aviatrix K8s configuration. This resource is available as of provider version R3.0+.
+
+## Example Usage
+
+```hcl
+# Create an Aviatrix K8s config
+resource "aviatrix_k8s_config" "test" {
+  enable_k8s = true
+  enable_dcf_policies = true
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+### Required
+* `enable_k8s` - (Optional) Whether to enable the K8s feature on an Aviatrix Controller. Valid values: true, false. Default value: false.
+* `enable_dcf_policies` - (Optional) Whether to enable DCF policies in K8s clusters. Can only be true if enable_k8s is also true. Valid values: true, false. Default value: false.
+
+## Import
+
+**aviatrix_k8s_config** can be imported using controller IP, e.g. controller IP is : 10.11.12.13
+
+```
+$ terraform import aviatrix_k8s_config.test 10-11-12-13
+```

--- a/goaviatrix/k8s_config.go
+++ b/goaviatrix/k8s_config.go
@@ -10,66 +10,15 @@ type K8sConfig struct {
 	EnableDcfPolicies bool `json:"enable_dcf_policies"`
 }
 
-func (c *Client) EnableK8s(ctx context.Context) error {
+func (c *Client) ToggleControllerFeature(ctx context.Context, feature string, enabled bool) error {
 	action := "enable_controller_feature"
+	if !enabled {
+		action = "disable_controller_feature"
+	}
 	form := map[string]string{
 		"CID":     c.CID,
 		"action":  action,
-		"feature": "k8s",
-	}
-
-	checkFunc := func(act, method, reason string, ret bool) error {
-		if !ret {
-			return fmt.Errorf("rest API %s %s failed: %s", act, method, reason)
-		}
-		return nil
-	}
-
-	return c.PostAPIContext2(ctx, nil, action, form, checkFunc)
-}
-
-func (c *Client) DisableK8s(ctx context.Context) error {
-	action := "disable_controller_feature"
-	form := map[string]string{
-		"CID":     c.CID,
-		"action":  action,
-		"feature": "k8s",
-	}
-
-	checkFunc := func(act, method, reason string, ret bool) error {
-		if !ret {
-			return fmt.Errorf("rest API %s %s failed: %s", act, method, reason)
-		}
-		return nil
-	}
-
-	return c.PostAPIContext2(ctx, nil, action, form, checkFunc)
-}
-
-func (c *Client) EnableK8sDcfPolicies(ctx context.Context) error {
-	action := "enable_controller_feature"
-	form := map[string]string{
-		"CID":     c.CID,
-		"action":  action,
-		"feature": "k8s_dcf_policies",
-	}
-
-	checkFunc := func(act, method, reason string, ret bool) error {
-		if !ret {
-			return fmt.Errorf("rest API %s %s failed: %s", act, method, reason)
-		}
-		return nil
-	}
-
-	return c.PostAPIContext2(ctx, nil, action, form, checkFunc)
-}
-
-func (c *Client) DisableK8sDcfPolicies(ctx context.Context) error {
-	action := "disable_controller_feature"
-	form := map[string]string{
-		"CID":     c.CID,
-		"action":  action,
-		"feature": "k8s_dcf_policies",
+		"feature": feature,
 	}
 
 	checkFunc := func(act, method, reason string, ret bool) error {

--- a/goaviatrix/k8s_config.go
+++ b/goaviatrix/k8s_config.go
@@ -1,0 +1,123 @@
+package goaviatrix
+
+import (
+	"context"
+	"fmt"
+)
+
+type K8sConfig struct {
+	EnableK8s         bool `json:"enable_k8s"`
+	EnableDcfPolicies bool `json:"enable_dcf_policies"`
+}
+
+func (c *Client) EnableK8s(ctx context.Context) error {
+	action := "enable_controller_feature"
+	form := map[string]string{
+		"CID":     c.CID,
+		"action":  action,
+		"feature": "k8s",
+	}
+
+	checkFunc := func(act, method, reason string, ret bool) error {
+		if !ret {
+			return fmt.Errorf("rest API %s %s failed: %s", act, method, reason)
+		}
+		return nil
+	}
+
+	return c.PostAPIContext2(ctx, nil, action, form, checkFunc)
+}
+
+func (c *Client) DisableK8s(ctx context.Context) error {
+	action := "disable_controller_feature"
+	form := map[string]string{
+		"CID":     c.CID,
+		"action":  action,
+		"feature": "k8s",
+	}
+
+	checkFunc := func(act, method, reason string, ret bool) error {
+		if !ret {
+			return fmt.Errorf("rest API %s %s failed: %s", act, method, reason)
+		}
+		return nil
+	}
+
+	return c.PostAPIContext2(ctx, nil, action, form, checkFunc)
+}
+
+func (c *Client) EnableK8sDcfPolicies(ctx context.Context) error {
+	action := "enable_controller_feature"
+	form := map[string]string{
+		"CID":     c.CID,
+		"action":  action,
+		"feature": "k8s_dcf_policies",
+	}
+
+	checkFunc := func(act, method, reason string, ret bool) error {
+		if !ret {
+			return fmt.Errorf("rest API %s %s failed: %s", act, method, reason)
+		}
+		return nil
+	}
+
+	return c.PostAPIContext2(ctx, nil, action, form, checkFunc)
+}
+
+func (c *Client) DisableK8sDcfPolicies(ctx context.Context) error {
+	action := "disable_controller_feature"
+	form := map[string]string{
+		"CID":     c.CID,
+		"action":  action,
+		"feature": "k8s_dcf_policies",
+	}
+
+	checkFunc := func(act, method, reason string, ret bool) error {
+		if !ret {
+			return fmt.Errorf("rest API %s %s failed: %s", act, method, reason)
+		}
+		return nil
+	}
+
+	return c.PostAPIContext2(ctx, nil, action, form, checkFunc)
+}
+
+func (c *Client) GetK8sStatus(ctx context.Context) (*K8sConfig, error) {
+	k8sConfig := &K8sConfig{}
+
+	// Get k8s feature status
+	action := "get_controller_feature"
+	form := map[string]string{
+		"CID":     c.CID,
+		"action":  action,
+		"feature": "k8s",
+	}
+
+	type ControllerSingleFeatureStatus struct {
+		Feature string `json:"feature"`
+		Enabled bool   `json:"enabled"`
+	}
+
+	type K8sConfigResp struct {
+		Results ControllerSingleFeatureStatus `json:"results"`
+	}
+
+	var resp K8sConfigResp
+	err := c.PostAPIContext2(ctx, &resp, action, form, BasicCheck)
+	if err != nil {
+		return nil, err
+	}
+
+	k8sConfig.EnableK8s = resp.Results.Enabled
+
+	// Get k8s_dcf_policies feature status
+	form["feature"] = "k8s_dcf_policies"
+	var dcfResp K8sConfigResp
+	err = c.PostAPIContext2(ctx, &dcfResp, action, form, BasicCheck)
+	if err != nil {
+		return nil, err
+	}
+
+	k8sConfig.EnableDcfPolicies = dcfResp.Results.Enabled
+	return k8sConfig, nil
+}

--- a/goaviatrix/k8s_config.go
+++ b/goaviatrix/k8s_config.go
@@ -10,10 +10,18 @@ type K8sConfig struct {
 	EnableDcfPolicies bool `json:"enable_dcf_policies"`
 }
 
+const (
+	FeatureK8s            = "k8s"
+	FeatureK8sDcfPolicies = "k8s_dcf_policies"
+
+	actionEnableControllerFeature  = "enable_controller_feature"
+	actionDisableControllerFeature = "disable_controller_feature"
+)
+
 func (c *Client) ToggleControllerFeature(ctx context.Context, feature string, enabled bool) error {
-	action := "enable_controller_feature"
+	action := actionEnableControllerFeature
 	if !enabled {
-		action = "disable_controller_feature"
+		action = actionDisableControllerFeature
 	}
 	form := map[string]string{
 		"CID":     c.CID,
@@ -39,7 +47,7 @@ func (c *Client) GetK8sStatus(ctx context.Context) (*K8sConfig, error) {
 	form := map[string]string{
 		"CID":     c.CID,
 		"action":  action,
-		"feature": "k8s",
+		"feature": FeatureK8s,
 	}
 
 	type ControllerSingleFeatureStatus struct {
@@ -60,7 +68,7 @@ func (c *Client) GetK8sStatus(ctx context.Context) (*K8sConfig, error) {
 	k8sConfig.EnableK8s = resp.Results.Enabled
 
 	// Get k8s_dcf_policies feature status
-	form["feature"] = "k8s_dcf_policies"
+	form["feature"] = FeatureK8sDcfPolicies
 	var dcfResp K8sConfigResp
 	err = c.PostAPIContext2(ctx, &dcfResp, action, form, BasicCheck)
 	if err != nil {


### PR DESCRIPTION
# Add K8s Config Resource with DCF Policies Support

(Disclaimer: The code in this PR was generated entirely by cursor, I reviewed the code and tested it against my local controller. I asked the AI to align with the current implementation of the "distributed_firewalling_config" resource)

## Summary
This PR introduces a new Terraform resource `aviatrix_k8s_config` that enables the K8s feature on Aviatrix Controllers, with additional support for enabling DCF policies within K8s clusters.

## Features Added
- **New Resource**: `aviatrix_k8s_config` for managing K8s feature configuration
- **DCF Policies Support**: Optional `enable_dcf_policies` parameter to enable DCF policies in K8s clusters
- **Validation**: Ensures `enable_dcf_policies` can only be true when `enable_k8s` is also true
- **Full CRUD Operations**: Create, Read, Update, Delete with proper state management
- **Import Support**: Can import existing K8s configurations using controller IP

## Files Added/Modified

### New Files:
- `goaviatrix/k8s_config.go` - Go client functions for K8s feature management
- `aviatrix/resource_aviatrix_k8s_config.go` - Terraform resource implementation
- `aviatrix/resource_aviatrix_k8s_config_test.go` - Comprehensive test suite
- `docs/resources/aviatrix_k8s_config.md` - Documentation for the new resource

### Modified Files:
- `aviatrix/provider.go` - Registered the new resource in the provider

## API Integration
- Uses Aviatrix Controller Feature API endpoints:
  - `enable_controller_feature` with `feature: "k8s"`
  - `disable_controller_feature` with `feature: "k8s"`
  - `enable_controller_feature` with `feature: "k8s_dcf_policies"`
  - `disable_controller_feature` with `feature: "k8s_dcf_policies"`
  - `get_controller_feature` for both features

## Usage Example
```hcl
resource "aviatrix_k8s_config" "test" {
  enable_k8s = true
  enable_dcf_policies = true
}
```

## Testing
- Basic functionality test with both features enabled
- Validation test to ensure constraint enforcement
- Import/export functionality test
- Proper cleanup verification in destroy tests

## Validation Rules
- `enable_dcf_policies` can only be set to `true` when `enable_k8s` is also `true`
- Validation occurs during both create and update operations
- Clear error messages for constraint violations

## Documentation
- Complete resource documentation with examples
- Parameter descriptions and validation rules
- Import instructions using controller IP format

## Backward Compatibility
- No breaking changes to existing functionality
- New resource is additive to the provider