### PR TITLE
AVX-67564: fix tag state persistence for gw launch

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1473,7 +1473,10 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("insane_mode_az", "")
 	}
 
-	setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+	err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+	if err != nil {
+		return fmt.Errorf("failed to set tags for gateway %s: %v", gw.GwName, err)
+	}
 
 	if gw.VpnStatus == "enabled" && gw.SplitTunnel == "yes" {
 		d.Set("name_servers", gw.NameServers)

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1474,9 +1474,21 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-		tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
-		if err := d.Set("tags", tags); err != nil {
-			log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
+		tags := &goaviatrix.Tags{
+			ResourceType: "gw",
+			ResourceName: d.Get("gw_name").(string),
+			CloudType:    gw.CloudType,
+		}
+
+		_, err := client.GetTags(tags)
+		if err != nil {
+			log.Printf("[WARN] Failed to get tags for gateway %s: %v", tags.ResourceName, err)
+		}
+		if len(tags.Tags) > 0 {
+			tagsMap := goaviatrix.KeyValueTags(tags.Tags).IgnoreConfig(ignoreTagsConfig)
+			if err := d.Set("tags", tagsMap); err != nil {
+				log.Printf("[WARN] Error setting tags for gateway %s: %v", tags.ResourceName, err)
+			}
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1473,24 +1473,7 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("insane_mode_az", "")
 	}
 
-	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-		tags := &goaviatrix.Tags{
-			ResourceType: "gw",
-			ResourceName: d.Get("gw_name").(string),
-			CloudType:    gw.CloudType,
-		}
-
-		_, err := client.GetTags(tags)
-		if err != nil {
-			log.Printf("[WARN] Failed to get tags for gateway %s: %v", tags.ResourceName, err)
-		}
-		if len(tags.Tags) > 0 {
-			tagsMap := goaviatrix.KeyValueTags(tags.Tags).IgnoreConfig(ignoreTagsConfig)
-			if err := d.Set("tags", tagsMap); err != nil {
-				log.Printf("[WARN] Error setting tags for gateway %s: %v", tags.ResourceName, err)
-			}
-		}
-	}
+	setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
 
 	if gw.VpnStatus == "enabled" && gw.SplitTunnel == "yes" {
 		d.Set("name_servers", gw.NameServers)

--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1475,7 +1475,7 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 
 	err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
 	if err != nil {
-		return fmt.Errorf("failed to set tags for gateway %s: %v", gw.GwName, err)
+		return fmt.Errorf("failed to set tags for gateway %s: %w", gw.GwName, err)
 	}
 
 	if gw.VpnStatus == "enabled" && gw.SplitTunnel == "yes" {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1665,7 +1665,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 
 	err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
 	if err != nil {
-		return fmt.Errorf("failed to set tags for spoke gateway %s: %v", gw.GwName, err)
+		return fmt.Errorf("failed to set tags for spoke gateway %s: %w", gw.GwName, err)
 	}
 
 	var spokeBgpManualAdvertiseCidrs []string

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1663,7 +1663,10 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("setting 'monitor_exclude_list' to state: %w", err)
 	}
 
-	setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+	err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+	if err != nil {
+		return fmt.Errorf("failed to set tags for spoke gateway %s: %v", gw.GwName, err)
+	}
 
 	var spokeBgpManualAdvertiseCidrs []string
 	if val, ok := d.GetOk("spoke_bgp_manual_advertise_cidrs"); ok {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1663,24 +1663,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("setting 'monitor_exclude_list' to state: %w", err)
 	}
 
-	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-		tags := &goaviatrix.Tags{
-			ResourceType: "gw",
-			ResourceName: d.Get("gw_name").(string),
-			CloudType:    gw.CloudType,
-		}
-
-		_, err := client.GetTags(tags)
-		if err != nil {
-			log.Printf("[WARN] Failed to get tags for spoke gateway %s: %v", tags.ResourceName, err)
-		}
-		if len(tags.Tags) > 0 {
-			tagsMap := goaviatrix.KeyValueTags(tags.Tags).IgnoreConfig(ignoreTagsConfig)
-			if err := d.Set("tags", tagsMap); err != nil {
-				log.Printf("[WARN] Error setting tags for spoke gateway %s: %v", tags.ResourceName, err)
-			}
-		}
-	}
+	setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
 
 	var spokeBgpManualAdvertiseCidrs []string
 	if val, ok := d.GetOk("spoke_bgp_manual_advertise_cidrs"); ok {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1664,9 +1664,21 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-		tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
-		if err := d.Set("tags", tags); err != nil {
-			log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
+		tags := &goaviatrix.Tags{
+			ResourceType: "gw",
+			ResourceName: d.Get("gw_name").(string),
+			CloudType:    gw.CloudType,
+		}
+
+		_, err := client.GetTags(tags)
+		if err != nil {
+			log.Printf("[WARN] Failed to get tags for spoke gateway %s: %v", tags.ResourceName, err)
+		}
+		if len(tags.Tags) > 0 {
+			tagsMap := goaviatrix.KeyValueTags(tags.Tags).IgnoreConfig(ignoreTagsConfig)
+			if err := d.Set("tags", tagsMap); err != nil {
+				log.Printf("[WARN] Error setting tags for spoke gateway %s: %v", tags.ResourceName, err)
+			}
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2348,9 +2348,21 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		d.Set("lan_interface_cidr", lanCidr)
 
 		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-			tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
-			if err := d.Set("tags", tags); err != nil {
-				log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
+			tags := &goaviatrix.Tags{
+				ResourceType: "gw",
+				ResourceName: d.Get("gw_name").(string),
+				CloudType:    gw.CloudType,
+			}
+
+			_, err := client.GetTags(tags)
+			if err != nil {
+				log.Printf("[WARN] Failed to get tags for transit gateway %s: %v", tags.ResourceName, err)
+			}
+			if len(tags.Tags) > 0 {
+				tagsMap := goaviatrix.KeyValueTags(tags.Tags).IgnoreConfig(ignoreTagsConfig)
+				if err := d.Set("tags", tagsMap); err != nil {
+					log.Printf("[WARN] Error setting tags for transit gateway %s: %v", tags.ResourceName, err)
+				}
 			}
 		}
 

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2347,7 +2347,10 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		}
 		d.Set("lan_interface_cidr", lanCidr)
 
-		setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+		err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+		if err != nil {
+			return fmt.Errorf("failed to set tags for transit gateway %s: %v", gw.GwName, err)
+		}
 
 		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.OCIRelatedCloudTypes) {
 			if gw.GatewayZone != "" {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2347,24 +2347,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		}
 		d.Set("lan_interface_cidr", lanCidr)
 
-		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-			tags := &goaviatrix.Tags{
-				ResourceType: "gw",
-				ResourceName: d.Get("gw_name").(string),
-				CloudType:    gw.CloudType,
-			}
-
-			_, err := client.GetTags(tags)
-			if err != nil {
-				log.Printf("[WARN] Failed to get tags for transit gateway %s: %v", tags.ResourceName, err)
-			}
-			if len(tags.Tags) > 0 {
-				tagsMap := goaviatrix.KeyValueTags(tags.Tags).IgnoreConfig(ignoreTagsConfig)
-				if err := d.Set("tags", tagsMap); err != nil {
-					log.Printf("[WARN] Error setting tags for transit gateway %s: %v", tags.ResourceName, err)
-				}
-			}
-		}
+		setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
 
 		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.OCIRelatedCloudTypes) {
 			if gw.GatewayZone != "" {

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2349,7 +2349,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 
 		err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
 		if err != nil {
-			return fmt.Errorf("failed to set tags for transit gateway %s: %v", gw.GwName, err)
+			return fmt.Errorf("failed to set tags for transit gateway %s: %w", gw.GwName, err)
 		}
 
 		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.OCIRelatedCloudTypes) {


### PR DESCRIPTION
Tags were not being saved in TF state properly for GWs. Seems to be some issue with the return structure from list_vpcs_summary either not returning them or putting them under a different key but I swapped it to existing client calls used in the data sources instead. Works just fine.

Validated with spoke GW deployment, no diff in state when running `terraform plan` afterwards.