### PR TITLE
AVX-68592 ipv6 cidr info is missing from terraform.tfstate dump

### DIFF
--- a/aviatrix/resource_aviatrix_vpc.go
+++ b/aviatrix/resource_aviatrix_vpc.go
@@ -132,6 +132,11 @@ func resourceAviatrixVpc() *schema.Resource {
 							Computed:    true,
 							Description: "Subnet ID.",
 						},
+						"ipv6_cidr": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "IPv6 CIDR of the subnet.",
+						},
 					},
 				},
 			},
@@ -163,6 +168,11 @@ func resourceAviatrixVpc() *schema.Resource {
 							Computed:    true,
 							Description: "Subnet ID.",
 						},
+						"ipv6_cidr": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "IPv6 CIDR of the subnet.",
+						},
 					},
 				},
 			},
@@ -186,6 +196,11 @@ func resourceAviatrixVpc() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Subnet ID.",
+						},
+						"ipv6_cidr": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "IPv6 CIDR of the subnet.",
 						},
 					},
 				},
@@ -563,6 +578,7 @@ func resourceAviatrixVpcRead(d *schema.ResourceData, meta interface{}) error {
 		subnetInfo["cidr"] = subnet.Cidr
 		subnetInfo["name"] = subnet.Name
 		subnetInfo["subnet_id"] = subnet.SubnetID
+		subnetInfo["ipv6_cidr"] = subnet.IPv6Cidr
 
 		privateSubnets = append(privateSubnets, subnetInfo)
 	}
@@ -576,6 +592,7 @@ func resourceAviatrixVpcRead(d *schema.ResourceData, meta interface{}) error {
 		subnetInfo["cidr"] = subnet.Cidr
 		subnetInfo["name"] = subnet.Name
 		subnetInfo["subnet_id"] = subnet.SubnetID
+		subnetInfo["ipv6_cidr"] = subnet.IPv6Cidr
 
 		publicSubnets = append(publicSubnets, subnetInfo)
 	}

--- a/docs/resources/aviatrix_vpc.md
+++ b/docs/resources/aviatrix_vpc.md
@@ -193,14 +193,17 @@ In addition to all arguments above, the following attributes are exported:
   * `cidr` - CIDR block.
   * `name` - Name of this subnet.
   * `subnet_id` - ID of this subnet.
+  * `ipv6_cidr` - IPv6 CIDR of this subnet.
 * `private_subnets` - List of private subnet of the VPC(AWS, Azure) to be created.
   * `cidr` - CIDR block.
   * `name` - Name of this subnet.
   * `subnet_id` - ID of this subnet.
+  * `ipv6_cidr` - IPv6 CIDR of this subnet.
 * `public_subnets` - List of public subnet of the VPC(AWS, Azure) to be created.
   * `cidr` - CIDR block.
   * `name` - Name of this subnet.
   * `subnet_id` - ID of this subnet.
+  * `ipv6_cidr` - IPv6 CIDR of this subnet.
 * `availability_domains` - List of OCI availability domains.
 * `fault_domains` - List of OCI fault domains.
 

--- a/goaviatrix/vpc.go
+++ b/goaviatrix/vpc.go
@@ -70,6 +70,7 @@ type SubnetInfo struct {
 	Cidr     string `json:"cidr,omitempty"`
 	Name     string `json:"name,omitempty"`
 	SubnetID string `json:"id,omitempty"`
+	IPv6Cidr string `json:"ipv6_cidr,omitempty"`
 }
 
 func (c *Client) CreateVpc(vpc *Vpc) error {


### PR DESCRIPTION
Added IPv6 cidr in subnet info for VPC.

controller PR - https://github.com/AviatrixDev/cloudn/pull/49641