### PR TITLE
AVX-69413: Added a data source for DCF trust bundles

### DIFF
--- a/aviatrix/data_source_aviatrix_dcf_trustbundle.go
+++ b/aviatrix/data_source_aviatrix_dcf_trustbundle.go
@@ -1,0 +1,73 @@
+package aviatrix
+
+import (
+	"context"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAviatrixDcfTrustbundle() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAviatrixDcfTrustbundleRead,
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Display Name of the DCF Trust Bundle.",
+			},
+			"bundle_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the DCF Trust Bundle.",
+			},
+			"bundle_content": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Content of the DCF Trust Bundle as a list of strings.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Timestamp when the DCF Trust Bundle was created.",
+			},
+		},
+	}
+}
+
+func dataSourceAviatrixDcfTrustbundleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	name, ok := d.Get("display_name").(string)
+	if !ok {
+		return diag.Errorf("display_name must be of type string")
+	}
+	if name == "" {
+		return diag.Errorf("display_name must be specified")
+	}
+
+	trustBundle, err := client.GetDCFTrustBundleByName(ctx, name)
+	if err != nil {
+		return diag.Errorf("could not get DCF trust bundle: %s", err)
+	}
+
+	// fmt.Printf("trustBundle ID: %s", trustBundle.BundleID)
+
+	if err := d.Set("bundle_id", trustBundle.BundleID); err != nil {
+		return diag.Errorf("could not set bundle_id: %s", err)
+	}
+
+	if err := d.Set("bundle_content", trustBundle.BundleContent); err != nil {
+		return diag.Errorf("could not set bundle_content: %s", err)
+	}
+
+	if err := d.Set("created_at", trustBundle.CreatedAt); err != nil {
+		return diag.Errorf("could not set created_at: %s", err)
+	}
+
+	d.SetId(trustBundle.UUID)
+
+	return nil
+}

--- a/aviatrix/data_source_aviatrix_dcf_trustbundle_test.go
+++ b/aviatrix/data_source_aviatrix_dcf_trustbundle_test.go
@@ -1,0 +1,84 @@
+package aviatrix
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceAviatrixDcfTrustbundle_basic(t *testing.T) {
+	resourceName := "data.aviatrix_dcf_trustbundle.test"
+
+	skipAcc := os.Getenv("SKIP_DATA_DCF_TRUSTBUNDLE")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Data Source DCF Trust Bundle test as SKIP_DATA_DCF_TRUSTBUNDLE is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, ". Set SKIP_DATA_DCF_TRUSTBUNDLE to yes to skip Data Source DCF Trust Bundle tests")
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAviatrixDcfTrustbundleConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAviatrixDcfTrustbundle(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "bundle_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "bundle_content"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAviatrixDcfTrustbundleConfigBasic() string {
+	return `
+resource "aviatrix_dcf_trustbundle" "test_trustbundle" {
+	display_name    = "test-trustbundle-data-source"
+	bundle_content = <<EOF
+-----BEGIN CERTIFICATE-----
+MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTMwODI3MjM1NzUwWhcNMTQwODI3MjM1NzUwWjBF
+MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAwUdHPiQnY1MxrE6iPCtJ3cIw/XhKsjsKlswiynxOzN4tOW9LsAyCChJH
+2mx6kRYE5wD/T8Qk3SzZGw7Bcd8sCnvvODyC5XQwNMJkMu2YyLT6yl8DbV/gLIny
+LdM6EKVGM8zo7FKsD3ZmzY9JN+sLO4Pwy9w8AGU8C5aA/7MCwqJhYzUfKLQx9Yl6
+gcEw5VF8Ma8o72VexSdENQOSW/Gsc8QdpB3VxGhGrMsOXjOdaMdAStvGyLjK+2w3
+C4XeYEtFxXE9ctSP9OFGP8Ee4XltZDiIoIJ5vYBKCpqFrWsb3RwDjkZGdE8fW5yJ
+mHSI3f3HgP9vehtRfFmjZy0TItS8CQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQC6
+SKqr5r8DlQl1K7BV9+j0iKp7vr19LQVoQQzcOgl7sBLlNJvQaZCvOmHf3ES3UhHZ
+4HqyFy8hRRi0sRluOSSdrBfOZYDgXdB3Hv+i9JBHrWKUtr9YG8a7z1VqCcqNKvrK
+TLLvw6YLJ7c4kVuQb2sFyMPS9j0RRQ/B7VoIWO5VsO0QU+CzICFCpwxcUKapF8YL
+OdPKuHUP9DhNXDJHSM5j+QWi8u9K9QVzKWi3g9XdKYmmjghtjlNoHgDeBmF7dMQJ
+5D8ZG7DQ2ZvQBGFVzZ9nf/JcaOO8IOBdXGFQg8sCHN5KgZaGt2GU8vxQPgzMklha
+0YJdD5hHuWfxG5N4o0S2
+-----END CERTIFICATE-----
+EOF
+}
+
+data "aviatrix_dcf_trustbundle" "test" {
+	depends_on   = [aviatrix_dcf_trustbundle.test_trustbundle]
+	display_name = "test-trustbundle-data-source"
+}
+	`
+}
+
+func testAccDataSourceAviatrixDcfTrustbundle(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no data source called %s", name)
+		}
+
+		return nil
+	}
+}

--- a/aviatrix/data_source_aviatrix_dcf_trustbundle_test.go
+++ b/aviatrix/data_source_aviatrix_dcf_trustbundle_test.go
@@ -3,6 +3,7 @@ package aviatrix
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -39,37 +40,17 @@ func TestAccDataSourceAviatrixDcfTrustbundle_basic(t *testing.T) {
 }
 
 func testAccDataSourceAviatrixDcfTrustbundleConfigBasic() string {
-	return `
+	return fmt.Sprintf(`
 resource "aviatrix_dcf_trustbundle" "test_trustbundle" {
 	display_name    = "test-trustbundle-data-source"
-	bundle_content = <<EOF
------BEGIN CERTIFICATE-----
-MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
-BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
-aWRnaXRzIFB0eSBMdGQwHhcNMTMwODI3MjM1NzUwWhcNMTQwODI3MjM1NzUwWjBF
-MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
-ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-CgKCAQEAwUdHPiQnY1MxrE6iPCtJ3cIw/XhKsjsKlswiynxOzN4tOW9LsAyCChJH
-2mx6kRYE5wD/T8Qk3SzZGw7Bcd8sCnvvODyC5XQwNMJkMu2YyLT6yl8DbV/gLIny
-LdM6EKVGM8zo7FKsD3ZmzY9JN+sLO4Pwy9w8AGU8C5aA/7MCwqJhYzUfKLQx9Yl6
-gcEw5VF8Ma8o72VexSdENQOSW/Gsc8QdpB3VxGhGrMsOXjOdaMdAStvGyLjK+2w3
-C4XeYEtFxXE9ctSP9OFGP8Ee4XltZDiIoIJ5vYBKCpqFrWsb3RwDjkZGdE8fW5yJ
-mHSI3f3HgP9vehtRfFmjZy0TItS8CQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQC6
-SKqr5r8DlQl1K7BV9+j0iKp7vr19LQVoQQzcOgl7sBLlNJvQaZCvOmHf3ES3UhHZ
-4HqyFy8hRRi0sRluOSSdrBfOZYDgXdB3Hv+i9JBHrWKUtr9YG8a7z1VqCcqNKvrK
-TLLvw6YLJ7c4kVuQb2sFyMPS9j0RRQ/B7VoIWO5VsO0QU+CzICFCpwxcUKapF8YL
-OdPKuHUP9DhNXDJHSM5j+QWi8u9K9QVzKWi3g9XdKYmmjghtjlNoHgDeBmF7dMQJ
-5D8ZG7DQ2ZvQBGFVzZ9nf/JcaOO8IOBdXGFQg8sCHN5KgZaGt2GU8vxQPgzMklha
-0YJdD5hHuWfxG5N4o0S2
------END CERTIFICATE-----
-EOF
+	bundle_content = "%s"
 }
 
 data "aviatrix_dcf_trustbundle" "test" {
 	depends_on   = [aviatrix_dcf_trustbundle.test_trustbundle]
 	display_name = "test-trustbundle-data-source"
 }
-	`
+`, strings.ReplaceAll(testAccDataSourceCertificateContent(), "\n", "\\n"))
 }
 
 func testAccDataSourceAviatrixDcfTrustbundle(name string) resource.TestCheckFunc {
@@ -81,4 +62,27 @@ func testAccDataSourceAviatrixDcfTrustbundle(name string) resource.TestCheckFunc
 
 		return nil
 	}
+}
+
+func testAccDataSourceCertificateContent() string {
+	return `-----BEGIN CERTIFICATE-----
+MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF
+ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6
+b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL
+MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv
+b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj
+ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM
+9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw
+IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6
+VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L
+93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm
+jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC
+AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA
+A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI
+U5PMCCjjmCXPI6T53iHTfIuJruydjsw2hUwsqdnHnFx9k6Tpdp4xvN0dWQVmIUgX
+tc9RiOQTUM8IzG2wDz1oydw+RVF/TmRQ6EQfoQJynfKzKkCzR4LGLd4IySQsv0GB
+CbFy9K3VRIs57/m3NY+8R4Z8qFJutMSlV+gYBbXUz/+ibZb5l6j9jCFZ5CNczKx8
+iTiYXZ68GCDImLLJqTgCp8SysbyMVGLWwUNzbyBqEjxHqGB/Kryl9SEgvQS0hrLN
+FQfVdG2q7fM3lGeyx/HFfaOvgYMi
+-----END CERTIFICATE-----`
 }

--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -214,6 +214,7 @@ func Provider() *schema.Provider {
 			"aviatrix_caller_identity":                      dataSourceAviatrixCallerIdentity(),
 			"aviatrix_controller_metadata":                  dataSourceAviatrixControllerMetadata(),
 			"aviatrix_web_group":                            dataSourceAviatrixDcfWebgroups(),
+			"aviatrix_dcf_trustbundle":                      dataSourceAviatrixDcfTrustbundle(),
 			"aviatrix_dcf_mwp_attachment_point":             dataSourceAviatrixDcfMwpAttachmentPoints(),
 			"aviatrix_device_interfaces":                    dataSourceAviatrixDeviceInterfaces(),
 			"aviatrix_edge_gateway_wan_interface_discovery": dataSourceAviatrixEdgeGatewayWanInterfaceDiscovery(),

--- a/aviatrix/resource_aviatrix_dcf_trustbundle.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle.go
@@ -73,7 +73,7 @@ func resourceAviatrixDCFTrustBundleRead(ctx context.Context, d *schema.ResourceD
 
 	bundleID := d.Id()
 
-	trustBundle, err := client.GetDCFTrustBundle(ctx, bundleID)
+	trustBundle, err := client.GetDCFTrustBundleByID(ctx, bundleID)
 	if err != nil {
 		if errors.Is(err, goaviatrix.ErrNotFound) {
 			d.SetId("")

--- a/aviatrix/resource_aviatrix_dcf_trustbundle_test.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle_test.go
@@ -178,7 +178,7 @@ func testAccCheckDCFTrustBundleExists(n string) resource.TestCheckFunc {
 
 		client := testAccProviderVersionValidation.Meta().(*goaviatrix.Client)
 
-		trustBundle, err := client.GetDCFTrustBundle(context.Background(), rs.Primary.ID)
+		trustBundle, err := client.GetDCFTrustBundleByID(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("failed to get DCF Trust Bundle status: %w", err)
 		}
@@ -199,7 +199,7 @@ func testAccCheckDCFTrustBundleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.GetDCFTrustBundle(context.Background(), rs.Primary.ID)
+		_, err := client.GetDCFTrustBundleByID(context.Background(), rs.Primary.ID)
 		if err == nil || !errors.Is(err, goaviatrix.ErrNotFound) {
 			return fmt.Errorf("DCF Trust Bundle still exists when it should be destroyed")
 		}

--- a/docs/data-sources/aviatrix_dcf_trustbundle.md
+++ b/docs/data-sources/aviatrix_dcf_trustbundle.md
@@ -32,5 +32,5 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `bundle_id` - ID of the DCF Trust Bundle. This is typically used as `target_uuid` in DCF policies.
-* `bundle_content` - Content of the DCF Trust Bundle as a list of strings. Contains the certificate data.
+* `bundle_content` - Content of the DCF Trust Bundle as a string. Contains the certificate data.
 * `created_at` - Timestamp when the DCF Trust Bundle was created.

--- a/docs/data-sources/aviatrix_dcf_trustbundle.md
+++ b/docs/data-sources/aviatrix_dcf_trustbundle.md
@@ -1,0 +1,36 @@
+---
+subcategory: "Secured Networking"
+layout: "aviatrix"
+page_title: "Aviatrix: aviatrix_dcf_trustbundle"
+description: |-
+    Gets details about a DCF Trust Bundle.
+---
+
+# aviatrix_dcf_trustbundle
+
+The **aviatrix_dcf_trustbundle** data source provides details about a specific DCF Trust Bundle created by the Aviatrix Controller.
+
+This data source can be useful when you need to reference an existing trust bundle in other resources, such as TLS profiles.
+
+## Example Usage
+
+```hcl
+# Aviatrix DCF Trust Bundle Data Source
+data "aviatrix_dcf_trustbundle" "example" {
+    display_name = "my-trust-bundle"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) Display name of the DCF Trust Bundle.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `bundle_id` - ID of the DCF Trust Bundle. This is typically used as `target_uuid` in DCF policies.
+* `bundle_content` - Content of the DCF Trust Bundle as a list of strings. Contains the certificate data.
+* `created_at` - Timestamp when the DCF Trust Bundle was created.

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -23,7 +23,7 @@ type DCFTrustBundle struct {
 	DisplayName   string    `json:"display_name"`
 	BundleContent []string  `json:"bundle_content"`
 	CreatedAt     time.Time `json:"created_at"`
-	UUID          string   `json:"uuid,omitempty"`
+	UUID          string    `json:"uuid,omitempty"`
 }
 
 // TrustBundleCreateResponse represents the response from creating/updating trust bundles
@@ -66,19 +66,19 @@ func (c *Client) GetDCFTrustBundleByID(ctx context.Context, bundleUUID string) (
 
 // GetDCFTrustBundleByName retrieves a DCF trust bundle by name
 func (c *Client) GetDCFTrustBundleByName(ctx context.Context, bundleName string) (*DCFTrustBundle, error) {
-    endpoint, err := url.JoinPath("dcf/trustbundle/name", bundleName)
-    if err != nil {
-        return nil, fmt.Errorf("failed to construct endpoint: %w", err)
-    }
-    var trustBundle DCFTrustBundle
-    err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
+	endpoint, err := url.JoinPath("dcf/trustbundle/name", bundleName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct endpoint: %w", err)
+	}
+	var trustBundle DCFTrustBundle
+	err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "not found") {
 			return nil, ErrNotFound
 		}
 		return nil, err
 	}
-    trustBundle.UUID = trustBundle.BundleID
+	trustBundle.UUID = trustBundle.BundleID
 	return &trustBundle, nil
 }
 

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -1,0 +1,87 @@
+package goaviatrix
+
+import (
+	"context"
+	"fmt"
+)
+
+// DCFTrustBundle represents a DCF trust bundle structure for GET responses
+type DCFTrustBundle struct {
+	DisplayName   string   `json:"display_name"`
+	BundleID      string   `json:"bundle_id"`
+	BundleContent []string `json:"bundle_content"`
+	CreatedAt     string   `json:"created_at"`
+	UUID          string   `json:"uuid,omitempty"`
+}
+
+// DCFTrustBundleCreateRequest represents the request structure for creating a trust bundle
+type DCFTrustBundleCreateRequest struct {
+	BundleContent string `json:"bundle_content"`
+	DisplayName   string `json:"display_name"`
+}
+
+// DCFTrustBundleCreateResponse represents the response structure for creating a trust bundle
+type DCFTrustBundleCreateResponse struct {
+	BundleID string `json:"bundle_id"`
+}
+
+// DCFTrustbundleErrorResponse represents the error response structure for DCF trust bundle operations
+type DCFTrustbundleErrorResponse struct {
+	Message string `json:"message"`
+}
+
+// CreateDCFTrustBundle creates a new DCF trust bundle
+func (c *Client) CreateDCFTrustBundle(ctx context.Context, bundleContent, displayName string) (string, error) {
+	endpoint := "dcf/trustbundle"
+
+	request := DCFTrustBundleCreateRequest{
+		BundleContent: bundleContent,
+		DisplayName:   displayName,
+	}
+
+	var response DCFTrustBundleCreateResponse
+	err := c.PostAPIContext25(ctx, &response, endpoint, request)
+	if err != nil {
+		return "", err
+	}
+
+	return response.BundleID, nil
+}
+
+// GetDCFTrustBundleByID retrieves a DCF trust bundle by UUID
+func (c *Client) GetDCFTrustBundleByID(ctx context.Context, bundleUUID string) (*DCFTrustBundle, error) {
+	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+
+	var trustBundle DCFTrustBundle
+	err := c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the UUID from the parameter for consistency
+	trustBundle.UUID = bundleUUID
+
+	return &trustBundle, nil
+}
+
+// GetDCFTrustBundleByName retrieves a DCF trust bundle by name
+func (c *Client) GetDCFTrustBundleByName(ctx context.Context, bundleName string) (*DCFTrustBundle, error) {
+	endpoint := fmt.Sprintf("dcf/trustbundle/name/%s", bundleName)
+	var trustBundle DCFTrustBundle
+	err := c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if trustBundle.BundleID == "" {
+		return nil, ErrNotFound
+	}
+	trustBundle.UUID = trustBundle.BundleID
+	return &trustBundle, nil
+}
+
+// DeleteDCFTrustBundle deletes a DCF trust bundle by UUID
+func (c *Client) DeleteDCFTrustBundle(ctx context.Context, bundleUUID string) error {
+	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+	return c.DeleteAPIContext25(ctx, endpoint, nil)
+}

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -1,47 +1,42 @@
 package goaviatrix
 
 import (
+	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 )
 
-// DCFTrustBundle represents a DCF trust bundle structure for GET responses
-type DCFTrustBundle struct {
-	DisplayName   string   `json:"display_name"`
-	BundleID      string   `json:"bundle_id"`
-	BundleContent []string `json:"bundle_content"`
-	CreatedAt     string   `json:"created_at"`
-	UUID          string   `json:"uuid,omitempty"`
-}
-
-// DCFTrustBundleCreateRequest represents the request structure for creating a trust bundle
-type DCFTrustBundleCreateRequest struct {
+// TrustBundleItemRequest represents the request body for creating/updating trust bundles
+type TrustBundleItemRequest struct {
 	BundleContent string `json:"bundle_content"`
 	DisplayName   string `json:"display_name"`
 }
 
-// DCFTrustBundleCreateResponse represents the response structure for creating a trust bundle
-type DCFTrustBundleCreateResponse struct {
+// DCFTrustBundle represents the full trust bundle response from GET operations
+type DCFTrustBundle struct {
+	BundleID      string    `json:"bundle_id"`
+	DisplayName   string    `json:"display_name"`
+	BundleContent []string  `json:"bundle_content"`
+	CreatedAt     time.Time `json:"created_at"`
+	UUID          string   `json:"uuid,omitempty"`
+}
+
+// TrustBundleCreateResponse represents the response from creating/updating trust bundles
+type TrustBundleCreateResponse struct {
 	BundleID string `json:"bundle_id"`
 }
 
-// DCFTrustbundleErrorResponse represents the error response structure for DCF trust bundle operations
-type DCFTrustbundleErrorResponse struct {
-	Message string `json:"message"`
-}
-
 // CreateDCFTrustBundle creates a new DCF trust bundle
-func (c *Client) CreateDCFTrustBundle(ctx context.Context, bundleContent, displayName string) (string, error) {
+func (c *Client) CreateDCFTrustBundle(ctx context.Context, trustBundle *TrustBundleItemRequest) (string, error) {
 	endpoint := "dcf/trustbundle"
 
-	request := DCFTrustBundleCreateRequest{
-		BundleContent: bundleContent,
-		DisplayName:   displayName,
-	}
-
-	var response DCFTrustBundleCreateResponse
-	err := c.PostAPIContext25(ctx, &response, endpoint, request)
+	var response TrustBundleCreateResponse
+	err := c.PostAPIContext25(ctx, &response, endpoint, trustBundle)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +44,7 @@ func (c *Client) CreateDCFTrustBundle(ctx context.Context, bundleContent, displa
 	return response.BundleID, nil
 }
 
-// GetDCFTrustBundleByID retrieves a DCF trust bundle by UUID
+// GetDCFTrustBundle retrieves a DCF trust bundle by UUID
 func (c *Client) GetDCFTrustBundleByID(ctx context.Context, bundleUUID string) (*DCFTrustBundle, error) {
 	endpoint, err := url.JoinPath("dcf/trustbundle", bundleUUID)
 	if err != nil {
@@ -59,6 +54,9 @@ func (c *Client) GetDCFTrustBundleByID(ctx context.Context, bundleUUID string) (
 	var trustBundle DCFTrustBundle
 	err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "not found") {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	// Set the UUID from the parameter for consistency
@@ -68,20 +66,33 @@ func (c *Client) GetDCFTrustBundleByID(ctx context.Context, bundleUUID string) (
 
 // GetDCFTrustBundleByName retrieves a DCF trust bundle by name
 func (c *Client) GetDCFTrustBundleByName(ctx context.Context, bundleName string) (*DCFTrustBundle, error) {
-	endpoint, err := url.JoinPath("dcf/trustbundle/name", bundleName)
+    endpoint, err := url.JoinPath("dcf/trustbundle/name", bundleName)
+    if err != nil {
+        return nil, fmt.Errorf("failed to construct endpoint: %w", err)
+    }
+    var trustBundle DCFTrustBundle
+    err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct endpoint: %w", err)
-	}
-	var trustBundle DCFTrustBundle
-	err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
-	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "not found") {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
-	if trustBundle.BundleID == "" {
-		return nil, ErrNotFound
-	}
-	trustBundle.UUID = trustBundle.BundleID
+    trustBundle.UUID = trustBundle.BundleID
 	return &trustBundle, nil
+}
+
+// UpdateDCFTrustBundle updates an existing DCF trust bundle
+func (c *Client) UpdateDCFTrustBundle(ctx context.Context, bundleUUID string, trustBundle *TrustBundleItemRequest) error {
+	endpoint, err := url.JoinPath("dcf/trustbundle", bundleUUID)
+	if err != nil {
+		return fmt.Errorf("failed to construct endpoint: %w", err)
+	}
+	err = c.PutAPIContext25(ctx, endpoint, trustBundle)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // DeleteDCFTrustBundle deletes a DCF trust bundle by UUID
@@ -91,4 +102,58 @@ func (c *Client) DeleteDCFTrustBundle(ctx context.Context, bundleUUID string) er
 		return fmt.Errorf("failed to construct endpoint: %w", err)
 	}
 	return c.DeleteAPIContext25(ctx, endpoint, nil)
+}
+
+func ValidateTrustbundle(i interface{}, k string) ([]string, []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+	certs, err := ParseCertificates([]byte(v))
+	if err != nil {
+		return nil, []error{err}
+	}
+	if len(certs) == 0 {
+		return nil, []error{fmt.Errorf("no certificates found in bundle")}
+	}
+	for _, cert := range certs {
+		if !cert.IsCA {
+			return nil, []error{fmt.Errorf("certificate %q is not a CA", cert.Subject.CommonName)}
+		}
+	}
+	return nil, nil
+}
+
+func ParseCertificates(remain []byte) ([]*x509.Certificate, error) {
+	// Remove UTF-8 BOM if present using standard library
+	utf8BOM := []byte{0xEF, 0xBB, 0xBF}
+	remain = bytes.TrimPrefix(remain, utf8BOM)
+	return parseCertificatesNoBom(remain)
+}
+
+func parseCertificatesNoBom(remain []byte) ([]*x509.Certificate, error) {
+	var chain []*x509.Certificate
+
+	for {
+		var block *pem.Block
+
+		block, remain = pem.Decode(remain)
+		if block == nil {
+			break
+		}
+
+		// We ignore non-certificate PEM blocks because
+		// that's what (*CertPool).AppendCertsFromPEM()
+		// does.
+		if block.Type == "CERTIFICATE" {
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse %q object: %w", block.Type, err)
+			}
+
+			chain = append(chain, cert)
+		}
+	}
+
+	return chain, nil
 }

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -3,6 +3,7 @@ package goaviatrix
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // DCFTrustBundle represents a DCF trust bundle structure for GET responses
@@ -50,10 +51,13 @@ func (c *Client) CreateDCFTrustBundle(ctx context.Context, bundleContent, displa
 
 // GetDCFTrustBundleByID retrieves a DCF trust bundle by UUID
 func (c *Client) GetDCFTrustBundleByID(ctx context.Context, bundleUUID string) (*DCFTrustBundle, error) {
-	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+	endpoint, err := url.JoinPath("dcf/trustbundle", bundleUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct endpoint: %w", err)
+	}
 
 	var trustBundle DCFTrustBundle
-	err := c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
+	err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -64,9 +68,12 @@ func (c *Client) GetDCFTrustBundleByID(ctx context.Context, bundleUUID string) (
 
 // GetDCFTrustBundleByName retrieves a DCF trust bundle by name
 func (c *Client) GetDCFTrustBundleByName(ctx context.Context, bundleName string) (*DCFTrustBundle, error) {
-	endpoint := fmt.Sprintf("dcf/trustbundle/name/%s", bundleName)
+	endpoint, err := url.JoinPath("dcf/trustbundle/name", bundleName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct endpoint: %w", err)
+	}
 	var trustBundle DCFTrustBundle
-	err := c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
+	err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -79,6 +86,9 @@ func (c *Client) GetDCFTrustBundleByName(ctx context.Context, bundleName string)
 
 // DeleteDCFTrustBundle deletes a DCF trust bundle by UUID
 func (c *Client) DeleteDCFTrustBundle(ctx context.Context, bundleUUID string) error {
-	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+	endpoint, err := url.JoinPath("dcf/trustbundle", bundleUUID)
+	if err != nil {
+		return fmt.Errorf("failed to construct endpoint: %w", err)
+	}
 	return c.DeleteAPIContext25(ctx, endpoint, nil)
 }

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -54,14 +54,11 @@ func (c *Client) GetDCFTrustBundleByID(ctx context.Context, bundleUUID string) (
 
 	var trustBundle DCFTrustBundle
 	err := c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
-
 	if err != nil {
 		return nil, err
 	}
-
 	// Set the UUID from the parameter for consistency
 	trustBundle.UUID = bundleUUID
-
 	return &trustBundle, nil
 }
 


### PR DESCRIPTION
Adding a data source for DCF trust bundle which can be queried by display_name to get the bundle_uuid and other properties that can be used when creating a TLS profile.