### PR TITLE
AVX-67564: fix tag state persistence for gw launch (#2378) [backport to rc-8.1]

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1473,11 +1473,9 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("insane_mode_az", "")
 	}
 
-	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-		tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
-		if err := d.Set("tags", tags); err != nil {
-			log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
-		}
+	err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+	if err != nil {
+		return fmt.Errorf("failed to set tags for gateway %s: %w", gw.GwName, err)
 	}
 
 	if gw.VpnStatus == "enabled" && gw.SplitTunnel == "yes" {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1647,11 +1647,9 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("setting 'monitor_exclude_list' to state: %w", err)
 	}
 
-	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-		tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
-		if err := d.Set("tags", tags); err != nil {
-			log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
-		}
+	err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+	if err != nil {
+		return fmt.Errorf("failed to set tags for spoke gateway %s: %w", gw.GwName, err)
 	}
 
 	var spokeBgpManualAdvertiseCidrs []string

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2320,11 +2320,9 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		}
 		d.Set("lan_interface_cidr", lanCidr)
 
-		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
-			tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
-			if err := d.Set("tags", tags); err != nil {
-				log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
-			}
+		err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
+		if err != nil {
+			return fmt.Errorf("failed to set tags for transit gateway %s: %w", gw.GwName, err)
 		}
 
 		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.OCIRelatedCloudTypes) {

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -487,3 +487,34 @@ func ValidateCIDRRule(v interface{}, k string) ([]string, []error) {
 	}
 	return nil, nil
 }
+
+// setGatewayTags fetches and sets gateway tags in the Terraform state for AWS and Azure gateways.
+// It retrieves tags directly from the controller API to ensure state persistence during gateway launch.
+func setGatewayTags(d *schema.ResourceData, client *goaviatrix.Client, cloudType int, ignoreTagsConfig *goaviatrix.IgnoreTagsConfig) error {
+	if !goaviatrix.IsCloudType(cloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
+		return nil
+	}
+
+	gwName := d.Get("gw_name").(string)
+	tags := &goaviatrix.Tags{
+		ResourceType: "gw",
+		ResourceName: gwName,
+		CloudType:    cloudType,
+	}
+
+	// If we encounter errors fetching tags we will just log warnings as it will not cause the gateway launch to fail
+	// only a diff in state.
+	_, err := client.GetTags(tags)
+	if err != nil {
+		log.Printf("[WARN] Failed to get tags for gateway %s: %v", tags.ResourceName, err)
+		return err
+	}
+
+	if len(tags.Tags) > 0 {
+		if err := d.Set("tags", goaviatrix.KeyValueTags(tags.Tags).IgnoreConfig(ignoreTagsConfig)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Tags were not being saved in TF state properly for GWs. Seems to be some issue with the return structure from list_vpcs_summary either not returning them or putting them under a different key but I swapped it to existing client calls used in the data sources instead. Works just fine.

Validated with spoke GW deployment, no diff in state when running terraform plan afterwards.

(cherry picked from commit 6559145e16bf496406304d1c36d144e900fec314)