### PR TITLE
AVX-69941: support for bump in the wire insertion gateway launch flag

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1056,7 +1056,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 
 	if insertionGateway {
 		if insertionGatewayAz == "" {
-			return fmt.Errorf("insertion_gateway_az needed if insertion_gateway is enabled.")
+			return fmt.Errorf("insertion_gateway_az needed if insertion_gateway is enabled")
 		}
 		// Append availability zone to subnet
 		var strs []string

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const subnetSeparator = "~~"
+
 func resourceAviatrixSpokeGateway() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAviatrixSpokeGatewayCreate,
@@ -633,18 +635,20 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description: "Enable IPv6 for the gateway. Only supported for AWS (1), Azure (8).",
 			},
 			"insertion_gateway": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				ForceNew:    true,
-				Description: "Enable insertion gateway mode.",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Default:       false,
+				ForceNew:      true,
+				Description:   "Enable insertion gateway mode.",
+				ConflictsWith: []string{"insane_mode"},
 			},
 			"insertion_gateway_az": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "",
-				ForceNew:    true,
-				Description: "AZ of subnet being created for Insertion Gateway. Required if insertion_gateway is enabled.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "",
+				ForceNew:     true,
+				Description:  "AZ of subnet being created for Insertion Gateway. Required if insertion_gateway is enabled.",
+				RequiredWith: []string{"insertion_gateway"},
 			},
 		},
 	}
@@ -796,7 +800,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			// Append availability zone to subnet
 			var strs []string
 			strs = append(strs, gateway.Subnet, insaneModeAz)
-			gateway.Subnet = strings.Join(strs, "~~")
+			gateway.Subnet = strings.Join(strs, subnetSeparator)
 		}
 		gateway.InsaneMode = "yes"
 	} else {
@@ -901,8 +905,8 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 		}
 
 		gateway.EnablePrivateOob = "on"
-		gateway.Subnet = gateway.Subnet + "~~" + oobAvailabilityZone
-		gateway.OobManagementSubnet = oobManagementSubnet + "~~" + oobAvailabilityZone
+		gateway.Subnet = gateway.Subnet + subnetSeparator + oobAvailabilityZone
+		gateway.OobManagementSubnet = oobManagementSubnet + subnetSeparator + oobAvailabilityZone
 	} else {
 		if oobAvailabilityZone != "" {
 			return fmt.Errorf("\"oob_availability_zone\" must be empty if \"enable_private_oob\" is false")
@@ -1061,7 +1065,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 		// Append availability zone to subnet
 		var strs []string
 		strs = append(strs, gateway.Subnet, insertionGatewayAz)
-		gateway.Subnet = strings.Join(strs, "~~")
+		gateway.Subnet = strings.Join(strs, subnetSeparator)
 		gateway.InsertionGateway = true
 	}
 
@@ -1122,7 +1126,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 				var haStrs []string
 				haStrs = append(haStrs, haSubnet, haInsaneModeAz)
-				haSubnet = strings.Join(haStrs, "~~")
+				haSubnet = strings.Join(haStrs, subnetSeparator)
 				spokeHaGw.Subnet = haSubnet
 			}
 			spokeHaGw.InsaneMode = "yes"
@@ -1143,7 +1147,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			if haPrivateModeSubnetZone == "" && goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 				return fmt.Errorf("%q must be set when creating a Spoke HA Gateway in AWS with Private Mode enabled on the Controller", "ha_private_mode_subnet_zone")
 			}
-			spokeHaGw.Subnet = haSubnet + "~~" + haPrivateModeSubnetZone
+			spokeHaGw.Subnet = haSubnet + subnetSeparator + haPrivateModeSubnetZone
 		}
 
 		haAzureEipName, haAzureEipNameOk := d.GetOk("ha_azure_eip_name_resource_group")
@@ -1165,7 +1169,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 				var haStrs []string
 				haStrs = append(haStrs, haSubnet, insertionGatewayAz)
-				haSubnet = strings.Join(haStrs, "~~")
+				haSubnet = strings.Join(haStrs, subnetSeparator)
 				spokeHaGw.Subnet = haSubnet
 			}
 			spokeHaGw.InsertionGateway = true
@@ -1625,8 +1629,8 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes) {
-		d.Set("vpc_id", strings.Split(gw.VpcID, "~~")[0]) // AWS vpc_id returns as <vpc_id>~~<other vpc info> in rest api
-		d.Set("vpc_reg", gw.VpcRegion)                    // AWS vpc_reg returns as vpc_region in rest api
+		d.Set("vpc_id", strings.Split(gw.VpcID, subnetSeparator)[0]) // AWS vpc_id returns as <vpc_id>~~<other vpc info> in rest api
+		d.Set("vpc_reg", gw.VpcRegion)                               // AWS vpc_reg returns as vpc_region in rest api
 
 		if gw.AllocateNewEipRead && !gw.EnablePrivateOob {
 			d.Set("allocate_new_eip", true)
@@ -1644,11 +1648,11 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("vpc_reg", gw.VpcRegion)
 		d.Set("allocate_new_eip", gw.AllocateNewEipRead)
 	} else if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.OCIRelatedCloudTypes) {
-		d.Set("vpc_id", strings.Split(gw.VpcID, "~~")[0]) // oci vpc_id returns as <vpc_id>~~<vpc_name> in rest api
+		d.Set("vpc_id", strings.Split(gw.VpcID, subnetSeparator)[0]) // oci vpc_id returns as <vpc_id>~~<vpc_name> in rest api
 		d.Set("vpc_reg", gw.VpcRegion)
 		d.Set("allocate_new_eip", gw.AllocateNewEipRead)
 	} else if gw.CloudType == goaviatrix.AliCloud {
-		d.Set("vpc_id", strings.Split(gw.VpcID, "~~")[0])
+		d.Set("vpc_id", strings.Split(gw.VpcID, subnetSeparator)[0])
 		d.Set("vpc_reg", gw.VpcRegion)
 		d.Set("allocate_new_eip", true)
 	}
@@ -1739,7 +1743,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("enable_private_oob", gw.EnablePrivateOob)
 	if gw.EnablePrivateOob {
-		d.Set("oob_management_subnet", strings.Split(gw.OobManagementSubnet, "~~")[0])
+		d.Set("oob_management_subnet", strings.Split(gw.OobManagementSubnet, subnetSeparator)[0])
 		d.Set("oob_availability_zone", gw.GatewayZone)
 	}
 
@@ -1853,7 +1857,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 			d.Set("ha_insane_mode_az", "")
 		}
 		if gw.HaGw.EnablePrivateOob {
-			d.Set("ha_oob_management_subnet", strings.Split(gw.HaGw.OobManagementSubnet, "~~")[0])
+			d.Set("ha_oob_management_subnet", strings.Split(gw.HaGw.OobManagementSubnet, subnetSeparator)[0])
 			d.Set("ha_oob_availability_zone", gw.HaGw.GatewayZone)
 		}
 		if gw.LbVpcId != "" && gw.GatewayZone != "AvailabilitySet" {
@@ -2180,7 +2184,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 				}
 
 				haStrs = append(haStrs, spokeHaGw.Subnet, insaneModeHaAz)
-				spokeHaGw.Subnet = strings.Join(haStrs, "~~")
+				spokeHaGw.Subnet = strings.Join(haStrs, subnetSeparator)
 			}
 			spokeHaGw.InsaneMode = "yes"
 		}
@@ -2222,7 +2226,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 				}
 
 				privateModeSubnetZone := d.Get("ha_private_mode_subnet_zone").(string)
-				spokeHaGw.Subnet += "~~" + privateModeSubnetZone
+				spokeHaGw.Subnet += subnetSeparator + privateModeSubnetZone
 			}
 		}
 
@@ -2233,7 +2237,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 			if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 				var haStrs []string
 				haStrs = append(haStrs, spokeHaGw.Subnet, insertionGatewayAz)
-				spokeHaGw.Subnet = strings.Join(haStrs, "~~")
+				spokeHaGw.Subnet = strings.Join(haStrs, subnetSeparator)
 			}
 			spokeHaGw.InsertionGateway = true
 		}

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -307,6 +307,10 @@ The following arguments are supported:
 * `insane_mode` - (Optional) Enable [Insane Mode](https://docs.aviatrix.com/HowTos/insane_mode.html) for Spoke Gateway. Insane Mode gateway size must be at least c5 size (AWS, AWSGov, AWS China, AWS Top Secret and AWS Secret) or Standard_D3_v2 (Azure and AzureGov); for GCP only four size are supported: "n1-highcpu-4", "n1-highcpu-8", "n1-highcpu-16" and "n1-highcpu-32". If enabled, you must specify a valid /26 CIDR segment of the VPC to create a new subnet for AWS, Azure, AzureGov, AWSGov, AWS Top Secret and AWS Secret. Only available for AWS, GCP/OCI, Azure, AzureGov, AzureChina, AWSGov, AWS Top Secret and AWS Secret. Valid values: true, false. Default value: false.
 * `insane_mode_az` - (Optional) AZ of subnet being created for Insane Mode Spoke Gateway. Required for AWS, AWSGov, AWS China, AWS Top Secret or AWS Secret if `insane_mode` is enabled. Example: AWS: "us-west-1a".
 
+### Insertion Gateway
+* `insertion_gateway` - (Optional) Enable Insertion Gateway mode. When enabled, the gateway will be created in a new subnet that will be automatically created. Only available for AWS, AWSGov, AWSChina, AWS Top Secret and AWS Secret. Cannot be enabled if `insane_mode` is enabled. Valid values: true, false. Default value: false.
+* `insertion_gateway_az` - (Optional) AZ of subnet being created for Insertion Gateway. Required if `insertion_gateway` is enabled. Example: "us-west-1a".
+
 ### SNAT/DNAT
 * `single_ip_snat` - (Optional) Specify whether to enable Source NAT feature in "single_ip" mode on the gateway or not. Please disable AWS NAT instance before enabling this feature. Currently, only supports AWS(1) and Azure(8). Valid values: true, false.
 
@@ -465,6 +469,9 @@ $ terraform import aviatrix_spoke_gateway.test gw_name
 ## Notes
 ### insane_mode
 If `insane_mode` is enabled, you must specify a valid /26 CIDR segment of the VPC specified for the `subnet`. This will then create a new subnet to be used for the corresponding gateway. You cannot specify an existing /26 subnet.
+
+### insertion_gateway
+If `insertion_gateway` is enabled, you must specify a valid CIDR segment of the VPC for the `subnet` parameter. This will create a new subnet to be used for the gateway. The subnet will be created in the availability zone specified by `insertion_gateway_az`. This feature is only supported on AWS cloud types and cannot be used together with `insane_mode`.
 
 ### enable_snat
 If you are using/upgraded to Aviatrix Terraform Provider R2.10+, and a spoke gateway with `enable_snat` set to true was originally created with a provider version <R2.10, you must do a ‘terraform refresh’ to update and apply the attribute’s value into the state. In addition, you must also change this attribute to `single_ip_snat` in your `.tf` file.

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -308,8 +308,8 @@ The following arguments are supported:
 * `insane_mode_az` - (Optional) AZ of subnet being created for Insane Mode Spoke Gateway. Required for AWS, AWSGov, AWS China, AWS Top Secret or AWS Secret if `insane_mode` is enabled. Example: AWS: "us-west-1a".
 
 ### Insertion Gateway
-* `insertion_gateway` - (Optional) Enable Insertion Gateway mode. When enabled, the gateway will be created in a new subnet that will be automatically created. Only available for AWS, AWSGov, AWSChina, AWS Top Secret and AWS Secret. Cannot be enabled if `insane_mode` is enabled. Valid values: true, false. Default value: false.
-* `insertion_gateway_az` - (Optional) AZ of subnet being created for Insertion Gateway. Required if `insertion_gateway` is enabled. Example: "us-west-1a".
+* `insertion_gateway` - (Optional) Enable Insertion Gateway mode. When enabled, the gateway will be created in a new subnet that will be automatically created. Changing this value requires Gateway replacement. Only available for AWS, AWSGov, AWSChina, AWS Top Secret and AWS Secret. Cannot be enabled if `insane_mode` is enabled. Valid values: true, false. Default value: false.
+* `insertion_gateway_az` - (Optional) AZ of subnet being created for Insertion Gateway. Must be in the same region as the Gateway. Changing this value requries Gateway replacement. Required if `insertion_gateway` is enabled. Example: "us-west-1a".
 
 ### SNAT/DNAT
 * `single_ip_snat` - (Optional) Specify whether to enable Source NAT feature in "single_ip" mode on the gateway or not. Please disable AWS NAT instance before enabling this feature. Currently, only supports AWS(1) and Azure(8). Valid values: true, false.

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -309,7 +309,7 @@ The following arguments are supported:
 
 ### Insertion Gateway
 * `insertion_gateway` - (Optional) Enable Insertion Gateway mode. When enabled, the gateway will be created in a new subnet that will be automatically created. Changing this value requires Gateway replacement. Only available for AWS, AWSGov, AWSChina, AWS Top Secret and AWS Secret. Cannot be enabled if `insane_mode` is enabled. Valid values: true, false. Default value: false.
-* `insertion_gateway_az` - (Optional) AZ of subnet being created for Insertion Gateway. Must be in the same region as the Gateway. Changing this value requries Gateway replacement. Required if `insertion_gateway` is enabled. Example: "us-west-1a".
+* `insertion_gateway_az` - (Optional) AZ of subnet being created for Insertion Gateway. Must be in the same region as the Gateway. Changing this value requires Gateway replacement. Required if `insertion_gateway` is enabled. Example: "us-west-1a".
 
 ### SNAT/DNAT
 * `single_ip_snat` - (Optional) Specify whether to enable Source NAT feature in "single_ip" mode on the gateway or not. Please disable AWS NAT instance before enabling this feature. Currently, only supports AWS(1) and Azure(8). Valid values: true, false.

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -230,6 +230,7 @@ type Gateway struct {
 	ManagementEgressIPPrefix        string                              `json:"mgmt_egress_ip,omitempty"`
 	EdgeGateway                     bool                                `json:"edge_gateway,omitempty"`
 	EnableIPv6                      bool                                `json:"enable_ipv6,omitempty"`
+	InsertionGateway                bool                                `json:"insertion_gateway,omitempty"`
 }
 
 type HaGateway struct {

--- a/goaviatrix/spoke_ha_gateway.go
+++ b/goaviatrix/spoke_ha_gateway.go
@@ -23,6 +23,7 @@ type SpokeHaGateway struct {
 	TagJson               string `json:"tag_json"`
 	AutoGenHaGwName       string `json:"autogen_hagw_name"`
 	Async                 bool   `json:"async"`
+	InsertionGateway      bool   `json:"insertion_gateway,omitempty"`
 }
 
 type APIRespHaGw struct {

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -52,6 +52,7 @@ type SpokeVpc struct {
 	LbVpcId                      string   `form:"lb_vpc_id,omitempty"`
 	EnableGlobalVpc              bool     `form:"global_vpc"`
 	EnableIPv6                   bool     `json:"enable_ipv6,omitempty"`
+	InsertionGateway             bool     `form:"insertion_gateway,omitempty"`
 }
 
 type SpokeGatewayAdvancedConfig struct {


### PR DESCRIPTION
This adds basic initial support to launch bump in the wire "insertion gateway". These are only ever spokes so support is only added to the spoke resource and related places. Minimal initial support to facilitate E2E, bump in the wire is a PaaS only feature so we will not be advertising this support to users.

Validated with manual deployment on dev provider build on 8.2.0 controller.