### PR TITLE
AVX-69941: support for bump in the wire insertion gateway launch flag [backport to rc-8.2]

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const subnetSeparator = "~~"
+
 func resourceAviatrixSpokeGateway() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAviatrixSpokeGatewayCreate,
@@ -626,6 +628,22 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Description: "BGP communities gateway accept configuration.",
 				Default:     false,
 			},
+			"insertion_gateway": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Default:       false,
+				ForceNew:      true,
+				Description:   "Enable insertion gateway mode.",
+				ConflictsWith: []string{"insane_mode"},
+			},
+			"insertion_gateway_az": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "",
+				ForceNew:     true,
+				Description:  "AZ of subnet being created for Insertion Gateway. Required if insertion_gateway is enabled.",
+				RequiredWith: []string{"insertion_gateway"},
+			},
 		},
 	}
 }
@@ -776,7 +794,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			// Append availability zone to subnet
 			var strs []string
 			strs = append(strs, gateway.Subnet, insaneModeAz)
-			gateway.Subnet = strings.Join(strs, "~~")
+			gateway.Subnet = strings.Join(strs, subnetSeparator)
 		}
 		gateway.InsaneMode = "yes"
 	} else {
@@ -881,8 +899,8 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 		}
 
 		gateway.EnablePrivateOob = "on"
-		gateway.Subnet = gateway.Subnet + "~~" + oobAvailabilityZone
-		gateway.OobManagementSubnet = oobManagementSubnet + "~~" + oobAvailabilityZone
+		gateway.Subnet = gateway.Subnet + subnetSeparator + oobAvailabilityZone
+		gateway.OobManagementSubnet = oobManagementSubnet + subnetSeparator + oobAvailabilityZone
 	} else {
 		if oobAvailabilityZone != "" {
 			return fmt.Errorf("\"oob_availability_zone\" must be empty if \"enable_private_oob\" is false")
@@ -1013,6 +1031,30 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("'enable_global_vpc' is only valid for GCP")
 	}
 
+	insertionGateway := d.Get("insertion_gateway").(bool)
+	insertionGatewayAz := d.Get("insertion_gateway_az").(string)
+
+	// Validation: insertion_gateway and insane_mode cannot both be true
+	if insertionGateway && insaneMode {
+		return fmt.Errorf("insertion_gateway and insane_mode cannot both be enabled")
+	}
+
+	// Validation: insertion_gateway is only supported on AWS
+	if insertionGateway && !goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
+		return fmt.Errorf("insertion_gateway is only supported for AWS")
+	}
+
+	if insertionGateway {
+		if insertionGatewayAz == "" {
+			return fmt.Errorf("insertion_gateway_az needed if insertion_gateway is enabled")
+		}
+		// Append availability zone to subnet
+		var strs []string
+		strs = append(strs, gateway.Subnet, insertionGatewayAz)
+		gateway.Subnet = strings.Join(strs, subnetSeparator)
+		gateway.InsertionGateway = true
+	}
+
 	log.Printf("[INFO] Creating Aviatrix Spoke Gateway: %#v", gateway)
 
 	d.SetId(gateway.GwName)
@@ -1070,7 +1112,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 				var haStrs []string
 				haStrs = append(haStrs, haSubnet, haInsaneModeAz)
-				haSubnet = strings.Join(haStrs, "~~")
+				haSubnet = strings.Join(haStrs, subnetSeparator)
 				spokeHaGw.Subnet = haSubnet
 			}
 			spokeHaGw.InsaneMode = "yes"
@@ -1091,7 +1133,7 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			if haPrivateModeSubnetZone == "" && goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 				return fmt.Errorf("%q must be set when creating a Spoke HA Gateway in AWS with Private Mode enabled on the Controller", "ha_private_mode_subnet_zone")
 			}
-			spokeHaGw.Subnet = haSubnet + "~~" + haPrivateModeSubnetZone
+			spokeHaGw.Subnet = haSubnet + subnetSeparator + haPrivateModeSubnetZone
 		}
 
 		haAzureEipName, haAzureEipNameOk := d.GetOk("ha_azure_eip_name_resource_group")
@@ -1107,6 +1149,16 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 			}
 		} else if haAzureEipNameOk {
 			return fmt.Errorf("failed to create HA Spoke Gateway: 'ha_azure_eip_name_resource_group' must be empty when cloud_type is not one of Azure (8), AzureGov (32) or AzureChina (2048)")
+		}
+
+		if insertionGateway {
+			if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
+				var haStrs []string
+				haStrs = append(haStrs, haSubnet, insertionGatewayAz)
+				haSubnet = strings.Join(haStrs, subnetSeparator)
+				spokeHaGw.Subnet = haSubnet
+			}
+			spokeHaGw.InsertionGateway = true
 		}
 
 		_, err := client.CreateSpokeHaGw(spokeHaGw)
@@ -1471,6 +1523,14 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("enable_jumbo_frame", gw.JumboFrame)
 	d.Set("enable_bgp", gw.EnableBgp)
 	d.Set("enable_bgp_over_lan", goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) && gw.EnableBgpOverLan)
+	d.Set("insertion_gateway", gw.InsertionGateway)
+
+	if gw.InsertionGateway && goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes) {
+		d.Set("insertion_gateway_az", gw.GatewayZone)
+	} else {
+		d.Set("insertion_gateway_az", "")
+	}
+
 	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) && gw.EnableBgpOverLan {
 		bgpLanIpInfo, err := client.GetBgpLanIPList(&goaviatrix.TransitVpc{GwName: gateway.GwName})
 		if err != nil {
@@ -1554,8 +1614,8 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes) {
-		d.Set("vpc_id", strings.Split(gw.VpcID, "~~")[0]) // AWS vpc_id returns as <vpc_id>~~<other vpc info> in rest api
-		d.Set("vpc_reg", gw.VpcRegion)                    // AWS vpc_reg returns as vpc_region in rest api
+		d.Set("vpc_id", strings.Split(gw.VpcID, subnetSeparator)[0]) // AWS vpc_id returns as <vpc_id>~~<other vpc info> in rest api
+		d.Set("vpc_reg", gw.VpcRegion)                               // AWS vpc_reg returns as vpc_region in rest api
 
 		if gw.AllocateNewEipRead && !gw.EnablePrivateOob {
 			d.Set("allocate_new_eip", true)
@@ -1573,11 +1633,11 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("vpc_reg", gw.VpcRegion)
 		d.Set("allocate_new_eip", gw.AllocateNewEipRead)
 	} else if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.OCIRelatedCloudTypes) {
-		d.Set("vpc_id", strings.Split(gw.VpcID, "~~")[0]) // oci vpc_id returns as <vpc_id>~~<vpc_name> in rest api
+		d.Set("vpc_id", strings.Split(gw.VpcID, subnetSeparator)[0]) // oci vpc_id returns as <vpc_id>~~<vpc_name> in rest api
 		d.Set("vpc_reg", gw.VpcRegion)
 		d.Set("allocate_new_eip", gw.AllocateNewEipRead)
 	} else if gw.CloudType == goaviatrix.AliCloud {
-		d.Set("vpc_id", strings.Split(gw.VpcID, "~~")[0])
+		d.Set("vpc_id", strings.Split(gw.VpcID, subnetSeparator)[0])
 		d.Set("vpc_reg", gw.VpcRegion)
 		d.Set("allocate_new_eip", true)
 	}
@@ -1668,7 +1728,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("enable_private_oob", gw.EnablePrivateOob)
 	if gw.EnablePrivateOob {
-		d.Set("oob_management_subnet", strings.Split(gw.OobManagementSubnet, "~~")[0])
+		d.Set("oob_management_subnet", strings.Split(gw.OobManagementSubnet, subnetSeparator)[0])
 		d.Set("oob_availability_zone", gw.GatewayZone)
 	}
 
@@ -1782,7 +1842,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 			d.Set("ha_insane_mode_az", "")
 		}
 		if gw.HaGw.EnablePrivateOob {
-			d.Set("ha_oob_management_subnet", strings.Split(gw.HaGw.OobManagementSubnet, "~~")[0])
+			d.Set("ha_oob_management_subnet", strings.Split(gw.HaGw.OobManagementSubnet, subnetSeparator)[0])
 			d.Set("ha_oob_availability_zone", gw.HaGw.GatewayZone)
 		}
 		if gw.LbVpcId != "" && gw.GatewayZone != "AvailabilitySet" {
@@ -2109,7 +2169,7 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 				}
 
 				haStrs = append(haStrs, spokeHaGw.Subnet, insaneModeHaAz)
-				spokeHaGw.Subnet = strings.Join(haStrs, "~~")
+				spokeHaGw.Subnet = strings.Join(haStrs, subnetSeparator)
 			}
 			spokeHaGw.InsaneMode = "yes"
 		}
@@ -2151,8 +2211,20 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 				}
 
 				privateModeSubnetZone := d.Get("ha_private_mode_subnet_zone").(string)
-				spokeHaGw.Subnet += "~~" + privateModeSubnetZone
+				spokeHaGw.Subnet += subnetSeparator + privateModeSubnetZone
 			}
+		}
+
+		insertionGateway := d.Get("insertion_gateway").(bool)
+		insertionGatewayAz := d.Get("insertion_gateway_az").(string)
+
+		if insertionGateway {
+			if goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AWSRelatedCloudTypes) {
+				var haStrs []string
+				haStrs = append(haStrs, spokeHaGw.Subnet, insertionGatewayAz)
+				spokeHaGw.Subnet = strings.Join(haStrs, subnetSeparator)
+			}
+			spokeHaGw.InsertionGateway = true
 		}
 
 		if newHaGwEnabled {

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -294,6 +294,10 @@ The following arguments are supported:
 * `insane_mode` - (Optional) Enable [Insane Mode](https://docs.aviatrix.com/HowTos/insane_mode.html) for Spoke Gateway. Insane Mode gateway size must be at least c5 size (AWS, AWSGov, AWS China, AWS Top Secret and AWS Secret) or Standard_D3_v2 (Azure and AzureGov); for GCP only four size are supported: "n1-highcpu-4", "n1-highcpu-8", "n1-highcpu-16" and "n1-highcpu-32". If enabled, you must specify a valid /26 CIDR segment of the VPC to create a new subnet for AWS, Azure, AzureGov, AWSGov, AWS Top Secret and AWS Secret. Only available for AWS, GCP/OCI, Azure, AzureGov, AzureChina, AWSGov, AWS Top Secret and AWS Secret. Valid values: true, false. Default value: false.
 * `insane_mode_az` - (Optional) AZ of subnet being created for Insane Mode Spoke Gateway. Required for AWS, AWSGov, AWS China, AWS Top Secret or AWS Secret if `insane_mode` is enabled. Example: AWS: "us-west-1a".
 
+### Insertion Gateway
+* `insertion_gateway` - (Optional) Enable Insertion Gateway mode. When enabled, the gateway will be created in a new subnet that will be automatically created. Changing this value requires Gateway replacement. Only available for AWS, AWSGov, AWSChina, AWS Top Secret and AWS Secret. Cannot be enabled if `insane_mode` is enabled. Valid values: true, false. Default value: false.
+* `insertion_gateway_az` - (Optional) AZ of subnet being created for Insertion Gateway. Must be in the same region as the Gateway. Changing this value requires Gateway replacement. Required if `insertion_gateway` is enabled. Example: "us-west-1a".
+
 ### SNAT/DNAT
 * `single_ip_snat` - (Optional) Specify whether to enable Source NAT feature in "single_ip" mode on the gateway or not. Please disable AWS NAT instance before enabling this feature. Currently, only supports AWS(1) and Azure(8). Valid values: true, false.
 
@@ -451,6 +455,9 @@ $ terraform import aviatrix_spoke_gateway.test gw_name
 ## Notes
 ### insane_mode
 If `insane_mode` is enabled, you must specify a valid /26 CIDR segment of the VPC specified for the `subnet`. This will then create a new subnet to be used for the corresponding gateway. You cannot specify an existing /26 subnet.
+
+### insertion_gateway
+If `insertion_gateway` is enabled, you must specify a valid CIDR segment of the VPC for the `subnet` parameter. This will create a new subnet to be used for the gateway. The subnet will be created in the availability zone specified by `insertion_gateway_az`. This feature is only supported on AWS cloud types and cannot be used together with `insane_mode`.
 
 ### enable_snat
 If you are using/upgraded to Aviatrix Terraform Provider R2.10+, and a spoke gateway with `enable_snat` set to true was originally created with a provider version <R2.10, you must do a ‘terraform refresh’ to update and apply the attribute’s value into the state. In addition, you must also change this attribute to `single_ip_snat` in your `.tf` file.

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -229,6 +229,7 @@ type Gateway struct {
 	IfNamesTranslation              map[string]string                   `json:"ifnames_translation,omitempty"`
 	ManagementEgressIPPrefix        string                              `json:"mgmt_egress_ip,omitempty"`
 	EdgeGateway                     bool                                `json:"edge_gateway,omitempty"`
+	InsertionGateway                bool                                `json:"insertion_gateway,omitempty"`
 }
 
 type HaGateway struct {

--- a/goaviatrix/spoke_ha_gateway.go
+++ b/goaviatrix/spoke_ha_gateway.go
@@ -23,6 +23,7 @@ type SpokeHaGateway struct {
 	TagJson               string `json:"tag_json"`
 	AutoGenHaGwName       string `json:"autogen_hagw_name"`
 	Async                 bool   `json:"async"`
+	InsertionGateway      bool   `json:"insertion_gateway,omitempty"`
 }
 
 type APIRespHaGw struct {

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -51,6 +51,7 @@ type SpokeVpc struct {
 	BgpLanInterfacesCount        int      `form:"bgp_lan_intf_count,omitempty"`
 	LbVpcId                      string   `form:"lb_vpc_id,omitempty"`
 	EnableGlobalVpc              bool     `form:"global_vpc"`
+	InsertionGateway             bool     `form:"insertion_gateway,omitempty"`
 }
 
 type SpokeGatewayAdvancedConfig struct {


### PR DESCRIPTION
This adds basic initial support to launch bump in the wire "insertion gateway". These are only ever spokes so support is only added to the spoke resource and related places. Minimal initial support to facilitate E2E, bump in the wire is a PaaS only feature so we will not be advertising this support to users.

Validated with manual deployment on dev provider build on 8.2.0 controller.

(cherry picked from commit c51e8e5badf9efc8cd2ee0f7361c71788215c773)