### PR TITLE
AVX-69599: Adding TF for DCF trust bundles

### DIFF
--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -113,6 +113,7 @@ func Provider() *schema.Provider {
 			"aviatrix_dcf_ips_rule_feed":                                      resourceAviatrixDCFIpsRuleFeed(),
 			"aviatrix_dcf_ips_profile":                                        resourceAviatrixDCFIpsProfile(),
 			"aviatrix_dcf_ips_profile_vpc":                                    resourceAviatrixDCFIpsProfileVpc(),
+			"aviatrix_dcf_trustbundle":                                        resourceAviatrixDCFTrustBundle(),
 			"aviatrix_device_interface_config":                                resourceAviatrixDeviceInterfaceConfig(),
 			"aviatrix_distributed_firewalling_config":                         resourceAviatrixDistributedFirewallingConfig(),
 			"aviatrix_distributed_firewalling_intra_vpc":                      resourceAviatrixDistributedFirewallingIntraVpc(),

--- a/aviatrix/resource_aviatrix_dcf_trustbundle.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle.go
@@ -28,7 +28,6 @@ func resourceAviatrixDCFTrustBundle() *schema.Resource {
 			"bundle_content": {
 				Type:         schema.TypeString,
 				Required:     true,
-				Sensitive:    true,
 				ValidateFunc: goaviatrix.ValidateTrustbundle,
 				Description:  "The CA bundle content in PEM format.",
 			},

--- a/aviatrix/resource_aviatrix_dcf_trustbundle.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle.go
@@ -2,6 +2,7 @@ package aviatrix
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
@@ -75,7 +76,7 @@ func resourceAviatrixDCFTrustBundleRead(ctx context.Context, d *schema.ResourceD
 
 	trustBundle, err := client.GetDCFTrustBundle(ctx, bundleID)
 	if err != nil {
-		if err == goaviatrix.ErrNotFound {
+		if errors.Is(err, goaviatrix.ErrNotFound) {
 			d.SetId("")
 			return nil
 		}

--- a/aviatrix/resource_aviatrix_dcf_trustbundle.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle.go
@@ -78,7 +78,7 @@ func resourceAviatrixDCFTrustBundleRead(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		if errors.Is(err, goaviatrix.ErrNotFound) {
 			d.SetId("")
-			return nil
+			return diag.Errorf("DCF Trust Bundle not found: %s", err)
 		}
 		return diag.Errorf("failed to read DCF Trust Bundle: %s", err)
 	}
@@ -118,7 +118,7 @@ func resourceAviatrixDCFTrustBundleDelete(ctx context.Context, d *schema.Resourc
 
 	err := client.DeleteDCFTrustBundle(ctx, bundleID)
 	if err != nil {
-		return diag.Errorf("failed to delete DCF Trust Bundle: %v", err)
+		return diag.Errorf("failed to delete DCF Trust Bundle: %s", err)
 	}
 
 	return nil

--- a/aviatrix/resource_aviatrix_dcf_trustbundle.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle.go
@@ -29,7 +29,7 @@ func resourceAviatrixDCFTrustBundle() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Sensitive:    true,
-				ValidateFunc: validation.StringIsNotWhiteSpace,
+				ValidateFunc: goaviatrix.ValidateTrustbundle,
 				Description:  "The CA bundle content in PEM format.",
 			},
 			"bundle_id": {

--- a/aviatrix/resource_aviatrix_dcf_trustbundle.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle.go
@@ -1,0 +1,124 @@
+package aviatrix
+
+import (
+	"context"
+	"strings"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAviatrixDCFTrustBundle() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceAviatrixDCFTrustBundleCreate,
+		ReadWithoutTimeout:   resourceAviatrixDCFTrustBundleRead,
+		UpdateWithoutTimeout: resourceAviatrixDCFTrustBundleUpdate,
+		DeleteWithoutTimeout: resourceAviatrixDCFTrustBundleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+				Description:  "Display name for the DCF trust bundle.",
+			},
+			"bundle_content": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+				Description:  "The CA bundle content in PEM format.",
+			},
+			"bundle_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique identifier for the trust bundle.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ISO 8601 timestamp when the trust bundle was created.",
+			},
+		},
+	}
+}
+
+func marshalDCFTrustBundleInput(d *schema.ResourceData) *goaviatrix.TrustBundleItemRequest {
+	return &goaviatrix.TrustBundleItemRequest{
+		DisplayName:   d.Get("display_name").(string),
+		BundleContent: d.Get("bundle_content").(string),
+	}
+}
+
+func resourceAviatrixDCFTrustBundleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	trustBundleRequest := marshalDCFTrustBundleInput(d)
+
+	bundleID, err := client.CreateDCFTrustBundle(ctx, trustBundleRequest)
+	if err != nil {
+		return diag.Errorf("failed to create DCF Trust Bundle: %s", err)
+	}
+
+	d.SetId(bundleID)
+
+	// Call read to populate computed fields
+	return resourceAviatrixDCFTrustBundleRead(ctx, d, meta)
+}
+
+func resourceAviatrixDCFTrustBundleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	bundleID := d.Id()
+
+	trustBundle, err := client.GetDCFTrustBundle(ctx, bundleID)
+	if err != nil {
+		if err == goaviatrix.ErrNotFound {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("failed to read DCF Trust Bundle: %s", err)
+	}
+
+	d.Set("bundle_id", trustBundle.BundleID)
+	d.Set("display_name", trustBundle.DisplayName)
+	if !trustBundle.CreatedAt.IsZero() {
+		d.Set("created_at", trustBundle.CreatedAt.Format("2006-01-02T15:04:05Z"))
+	} else {
+		d.Set("created_at", "")
+	}
+	bundleContent := strings.TrimSpace(strings.Join(trustBundle.BundleContent, "\n"))
+	d.Set("bundle_content", bundleContent)
+	return nil
+}
+
+func resourceAviatrixDCFTrustBundleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	bundleID := d.Id()
+
+	trustBundleRequest := marshalDCFTrustBundleInput(d)
+
+	err := client.UpdateDCFTrustBundle(ctx, bundleID, trustBundleRequest)
+	if err != nil {
+		return diag.Errorf("failed to update DCF Trust Bundle: %s", err)
+	}
+
+	// Call read to refresh state with latest data
+	return resourceAviatrixDCFTrustBundleRead(ctx, d, meta)
+}
+
+func resourceAviatrixDCFTrustBundleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	bundleID := d.Id()
+
+	err := client.DeleteDCFTrustBundle(ctx, bundleID)
+	if err != nil {
+		return diag.Errorf("failed to delete DCF Trust Bundle: %v", err)
+	}
+
+	return nil
+}

--- a/aviatrix/resource_aviatrix_dcf_trustbundle_test.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
@@ -72,6 +73,27 @@ func TestAccAviatrixDCFTrustBundle_update(t *testing.T) {
 	})
 }
 
+func TestAccAviatrixDCFTrustBundle_invalidCertificate(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_DCF_TRUSTBUNDLE")
+	if skipAcc == "yes" {
+		t.Skip("Skipping DCF Trust Bundle test as SKIP_DCF_TRUSTBUNDLE is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProvidersVersionValidation,
+		CheckDestroy: testAccCheckDCFTrustBundleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDCFTrustBundleInvalidCertificate(),
+				ExpectError: regexp.MustCompile("no certificates found in bundle"),
+			},
+		},
+	})
+}
+
 func testAccDCFTrustBundleBasic() string {
 	return fmt.Sprintf(`
 resource "aviatrix_dcf_trustbundle" "test" {
@@ -88,6 +110,15 @@ resource "aviatrix_dcf_trustbundle" "test" {
   bundle_content = %q
 }
 `, testCertificateContent())
+}
+
+func testAccDCFTrustBundleInvalidCertificate() string {
+	return fmt.Sprintf(`
+resource "aviatrix_dcf_trustbundle" "test" {
+  display_name   = "test-dcf-trustbundle-invalid"
+  bundle_content = %q
+}
+`, testInvalidCertificateContent())
 }
 
 func testCertificateContent() string {
@@ -111,6 +142,28 @@ CbFy9K3VRIs57/m3NY+8R4Z8qFJutMSlV+gYBbXUz/+ibZb5l6j9jCFZ5CNczKx8
 iTiYXZ68GCDImLLJqTgCp8SysbyMVGLWwUNzbyBqEjxHqGB/Kryl9SEgvQS0hrLN
 FQfVdG2q7fM3lGeyx/HFfaOvgYMi
 -----END CERTIFICATE-----`
+}
+
+func testInvalidCertificateContent() string {
+	return `-----BEGIN CERTIFICATE-----
+MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF
+ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6
+b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL
+MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv
+b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj
+ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM
+9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw
+IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6
+VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L
+93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm
+jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC
+AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA
+A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI
+U5PMCCjjmCXPI6T53iHTfIuJruydjsw2hUwsqdnHnFx9k6Tpdp4xvN0dWQVmIUgX
+tc9RiOQTUM8IzG2wDz1oydw+RVF/TmRQ6EQfoQJynfKzKkCzR4LGLd4IySQsv0GB
+CbFy9K3VRIs57/m3NY+8R4Z8qFJutMSlV+gYBbXUz/+ibZb5l6j9jCFZ5CNczKx8
+iTiYXZ68GCDImLLJqTgCp8SysbyMVGLWwUNzbyBqEjxHqGB/Kryl9SEgvQS0hrLN
+FQfVdG2q7fM3lGeyx/HFfaOvgYMi`
 }
 
 func testAccCheckDCFTrustBundleExists(n string) resource.TestCheckFunc {

--- a/aviatrix/resource_aviatrix_dcf_trustbundle_test.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle_test.go
@@ -2,6 +2,7 @@ package aviatrix
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -126,7 +127,7 @@ func testAccCheckDCFTrustBundleExists(n string) resource.TestCheckFunc {
 
 		trustBundle, err := client.GetDCFTrustBundle(context.Background(), rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("failed to get DCF Trust Bundle status: %v", err)
+			return fmt.Errorf("failed to get DCF Trust Bundle status: %w", err)
 		}
 
 		if trustBundle.BundleID != rs.Primary.ID {
@@ -146,7 +147,7 @@ func testAccCheckDCFTrustBundleDestroy(s *terraform.State) error {
 		}
 
 		_, err := client.GetDCFTrustBundle(context.Background(), rs.Primary.ID)
-		if err == nil || err != goaviatrix.ErrNotFound {
+		if err == nil || !errors.Is(err, goaviatrix.ErrNotFound) {
 			return fmt.Errorf("DCF Trust Bundle still exists when it should be destroyed")
 		}
 	}

--- a/aviatrix/resource_aviatrix_dcf_trustbundle_test.go
+++ b/aviatrix/resource_aviatrix_dcf_trustbundle_test.go
@@ -1,0 +1,155 @@
+package aviatrix
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAviatrixDCFTrustBundle_basic(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_DCF_TRUSTBUNDLE")
+	if skipAcc == "yes" {
+		t.Skip("Skipping DCF Trust Bundle test as SKIP_DCF_TRUSTBUNDLE is set")
+	}
+	resourceName := "aviatrix_dcf_trustbundle.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProvidersVersionValidation,
+		CheckDestroy: testAccCheckDCFTrustBundleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDCFTrustBundleBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDCFTrustBundleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "test-dcf-trustbundle"),
+					resource.TestCheckResourceAttrSet(resourceName, "bundle_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "bundle_content", testCertificateContent()),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAviatrixDCFTrustBundle_update(t *testing.T) {
+	skipAcc := os.Getenv("SKIP_DCF_TRUSTBUNDLE")
+	if skipAcc == "yes" {
+		t.Skip("Skipping DCF Trust Bundle test as SKIP_DCF_TRUSTBUNDLE is set")
+	}
+	resourceName := "aviatrix_dcf_trustbundle.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProvidersVersionValidation,
+		CheckDestroy: testAccCheckDCFTrustBundleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDCFTrustBundleBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDCFTrustBundleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "test-dcf-trustbundle"),
+				),
+			},
+			{
+				Config: testAccDCFTrustBundleUpdated(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDCFTrustBundleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "test-dcf-trustbundle-updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDCFTrustBundleBasic() string {
+	return fmt.Sprintf(`
+resource "aviatrix_dcf_trustbundle" "test" {
+  display_name   = "test-dcf-trustbundle"
+  bundle_content = %q
+}
+`, testCertificateContent())
+}
+
+func testAccDCFTrustBundleUpdated() string {
+	return fmt.Sprintf(`
+resource "aviatrix_dcf_trustbundle" "test" {
+  display_name   = "test-dcf-trustbundle-updated"
+  bundle_content = %q
+}
+`, testCertificateContent())
+}
+
+func testCertificateContent() string {
+	return `-----BEGIN CERTIFICATE-----
+MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF
+ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6
+b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL
+MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv
+b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj
+ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM
+9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw
+IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6
+VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L
+93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm
+jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC
+AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA
+A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI
+U5PMCCjjmCXPI6T53iHTfIuJruydjsw2hUwsqdnHnFx9k6Tpdp4xvN0dWQVmIUgX
+tc9RiOQTUM8IzG2wDz1oydw+RVF/TmRQ6EQfoQJynfKzKkCzR4LGLd4IySQsv0GB
+CbFy9K3VRIs57/m3NY+8R4Z8qFJutMSlV+gYBbXUz/+ibZb5l6j9jCFZ5CNczKx8
+iTiYXZ68GCDImLLJqTgCp8SysbyMVGLWwUNzbyBqEjxHqGB/Kryl9SEgvQS0hrLN
+FQfVdG2q7fM3lGeyx/HFfaOvgYMi
+-----END CERTIFICATE-----`
+}
+
+func testAccCheckDCFTrustBundleExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("no DCF Trust Bundle resource found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no DCF Trust Bundle ID is set")
+		}
+
+		client := testAccProviderVersionValidation.Meta().(*goaviatrix.Client)
+
+		trustBundle, err := client.GetDCFTrustBundle(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get DCF Trust Bundle status: %v", err)
+		}
+
+		if trustBundle.BundleID != rs.Primary.ID {
+			return fmt.Errorf("DCF Trust Bundle ID not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDCFTrustBundleDestroy(s *terraform.State) error {
+	client := testAccProviderVersionValidation.Meta().(*goaviatrix.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aviatrix_dcf_trustbundle" {
+			continue
+		}
+
+		_, err := client.GetDCFTrustBundle(context.Background(), rs.Primary.ID)
+		if err == nil || err != goaviatrix.ErrNotFound {
+			return fmt.Errorf("DCF Trust Bundle still exists when it should be destroyed")
+		}
+	}
+
+	return nil
+}

--- a/docs/resources/aviatrix_dcf_trustbundle.md
+++ b/docs/resources/aviatrix_dcf_trustbundle.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Distributed Cloud Firewall"
+layout: "aviatrix"
+page_title: "Aviatrix: aviatrix_dcf_trustbundle"
+description: |-
+  Creates and manages an Aviatrix DCF Trust Bundle
+---
+
+# aviatrix_dcf_trustbundle
+
+The **aviatrix_dcf_trustbundle** resource handles the creation and management of DCF Trust Bundles for verifying origin certificates in Distributed Cloud Firewall Man-in-the-Middle (MITM) inspection. Available as of Provider R3.3.0+.
+
+## Example Usage
+
+### Basic Trust Bundle
+
+```hcl
+# Create a DCF Trust Bundle
+resource "aviatrix_dcf_trustbundle" "example" {
+  display_name   = "corporate-root-ca"
+  bundle_content = file("${path.module}/corporate-root-ca.pem")
+}
+```
+
+### Trust Bundle with inline certificate
+
+```hcl
+resource "aviatrix_dcf_trustbundle" "example" {
+  display_name = "example-trustbundle"
+  bundle_content = file("bundle_file")
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+### Required
+
+* `display_name` - (Required) The display name for the DCF trust bundle. This name is used to identify the trust bundle in the Aviatrix Controller.
+* `bundle_content` - (Required, Sensitive) The CA bundle content in PEM format. This should contain one or more X.509 certificates that will be used to verify origin certificates during DCF MITM inspection.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `bundle_id` - The unique identifier (UUID) assigned to the trust bundle by the Aviatrix Controller.
+* `created_at` - ISO 8601 timestamp indicating when the trust bundle was created.
+
+## Import
+
+**aviatrix_dcf_trustbundle** can be imported using the `bundle_id` (UUID), e.g.
+
+```
+$ terraform import aviatrix_dcf_trustbundle.example 41984f8b-5a37-4272-89b3-57c79e9ff77c
+```
+
+## Notes
+
+* The `bundle_content` must be valid X.509 certificates in PEM format.
+* Multiple certificates can be included in a single bundle by concatenating them.
+* The trust bundle is used in DCF MITM scenarios to verify the authenticity of origin certificates.
+* Changes to `bundle_content` or `display_name` will result in an update operation.
+* The certificate content should include proper PEM headers (`-----BEGIN CERTIFICATE-----`) and footers (`-----END CERTIFICATE-----`).
+* Invalid certificate formats will result in an error during creation or update.

--- a/docs/resources/aviatrix_dcf_trustbundle.md
+++ b/docs/resources/aviatrix_dcf_trustbundle.md
@@ -8,7 +8,7 @@ description: |-
 
 # aviatrix_dcf_trustbundle
 
-The **aviatrix_dcf_trustbundle** resource handles the creation and management of DCF Trust Bundles for verifying origin certificates in Distributed Cloud Firewall Man-in-the-Middle (MITM) inspection. Available as of Provider R3.3.0+.
+The **aviatrix_dcf_trustbundle** resource handles the creation and management of DCF Trust Bundles for verifying origin certificates in Distributed Cloud Firewall Man-in-the-Middle (MITM) inspection.
 
 ## Example Usage
 
@@ -38,7 +38,7 @@ The following arguments are supported:
 ### Required
 
 * `display_name` - (Required) The display name for the DCF trust bundle. This name is used to identify the trust bundle in the Aviatrix Controller.
-* `bundle_content` - (Required, Sensitive) The CA bundle content in PEM format. This should contain one or more X.509 certificates that will be used to verify origin certificates during DCF MITM inspection.
+* `bundle_content` - (Required, Sensitive) The CA bundle content in PEM format. This should contain one or more X.509 certificates separated by new lines, that will be used to verify origin certificates during DCF MITM inspection.
 
 ## Attribute Reference
 

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -1,0 +1,72 @@
+package goaviatrix
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TrustBundleItemRequest represents the request body for creating/updating trust bundles
+type TrustBundleItemRequest struct {
+	BundleContent string `json:"bundle_content"`
+	DisplayName   string `json:"display_name"`
+}
+
+// TrustBundle represents the full trust bundle response from GET operations
+type TrustBundle struct {
+	BundleID      string    `json:"bundle_id"`
+	DisplayName   string    `json:"display_name"`
+	BundleContent []string  `json:"bundle_content"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// TrustBundleCreateResponse represents the response from creating/updating trust bundles
+type TrustBundleCreateResponse struct {
+	BundleID string `json:"bundle_id"`
+}
+
+// CreateDCFTrustBundle creates a new DCF trust bundle
+func (c *Client) CreateDCFTrustBundle(ctx context.Context, trustBundle *TrustBundleItemRequest) (string, error) {
+	endpoint := "dcf/trustbundle"
+
+	var response TrustBundleCreateResponse
+	err := c.PostAPIContext25(ctx, &response, endpoint, trustBundle)
+	if err != nil {
+		return "", err
+	}
+
+	return response.BundleID, nil
+}
+
+// GetDCFTrustBundle retrieves a DCF trust bundle by UUID
+func (c *Client) GetDCFTrustBundle(ctx context.Context, bundleUUID string) (*TrustBundle, error) {
+	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+
+	var trustBundle TrustBundle
+	err := c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "not found") {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	return &trustBundle, nil
+}
+
+// UpdateDCFTrustBundle updates an existing DCF trust bundle
+func (c *Client) UpdateDCFTrustBundle(ctx context.Context, bundleUUID string, trustBundle *TrustBundleItemRequest) error {
+	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+	err := c.PutAPIContext25(ctx, endpoint, trustBundle)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteDCFTrustBundle deletes a DCF trust bundle by UUID
+func (c *Client) DeleteDCFTrustBundle(ctx context.Context, bundleUUID string) error {
+	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+	return c.DeleteAPIContext25(ctx, endpoint, nil)
+}

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -44,10 +45,14 @@ func (c *Client) CreateDCFTrustBundle(ctx context.Context, trustBundle *TrustBun
 
 // GetDCFTrustBundle retrieves a DCF trust bundle by UUID
 func (c *Client) GetDCFTrustBundle(ctx context.Context, bundleUUID string) (*TrustBundle, error) {
-	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+	endpoint, err := url.JoinPath("dcf/trustbundle", bundleUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct endpoint: %w", err)
+	}
+	
 
 	var trustBundle TrustBundle
-	err := c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
+	err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "not found") {
 			return nil, ErrNotFound
@@ -60,8 +65,11 @@ func (c *Client) GetDCFTrustBundle(ctx context.Context, bundleUUID string) (*Tru
 
 // UpdateDCFTrustBundle updates an existing DCF trust bundle
 func (c *Client) UpdateDCFTrustBundle(ctx context.Context, bundleUUID string, trustBundle *TrustBundleItemRequest) error {
-	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
-	err := c.PutAPIContext25(ctx, endpoint, trustBundle)
+	endpoint, err := url.JoinPath("dcf/trustbundle", bundleUUID)
+	if err != nil {
+		return fmt.Errorf("failed to construct endpoint: %w", err)
+	}
+	err = c.PutAPIContext25(ctx, endpoint, trustBundle)
 	if err != nil {
 		return err
 	}
@@ -70,7 +78,10 @@ func (c *Client) UpdateDCFTrustBundle(ctx context.Context, bundleUUID string, tr
 
 // DeleteDCFTrustBundle deletes a DCF trust bundle by UUID
 func (c *Client) DeleteDCFTrustBundle(ctx context.Context, bundleUUID string) error {
-	endpoint := fmt.Sprintf("dcf/trustbundle/%s", bundleUUID)
+	endpoint, err := url.JoinPath("dcf/trustbundle", bundleUUID)
+	if err != nil {
+		return fmt.Errorf("failed to construct endpoint: %w", err)
+	}
 	return c.DeleteAPIContext25(ctx, endpoint, nil)
 }
 

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -49,7 +49,6 @@ func (c *Client) GetDCFTrustBundle(ctx context.Context, bundleUUID string) (*Tru
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct endpoint: %w", err)
 	}
-	
 
 	var trustBundle TrustBundle
 	err = c.GetAPIContext25(ctx, &trustBundle, endpoint, nil)

--- a/goaviatrix/dcf_trustbundle.go
+++ b/goaviatrix/dcf_trustbundle.go
@@ -1,6 +1,7 @@
 package goaviatrix
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/pem"
@@ -94,6 +95,9 @@ func ValidateTrustbundle(i interface{}, k string) ([]string, []error) {
 }
 
 func ParseCertificates(remain []byte) ([]*x509.Certificate, error) {
+	// Remove UTF-8 BOM if present using standard library
+	utf8BOM := []byte{0xEF, 0xBB, 0xBF}
+	remain = bytes.TrimPrefix(remain, utf8BOM)
 	return parseCertificatesNoBom(remain)
 }
 

--- a/goaviatrix/dcf_trustbundle_test.go
+++ b/goaviatrix/dcf_trustbundle_test.go
@@ -1,0 +1,228 @@
+package goaviatrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Sample CA certificate (real ACCV CA certificate for testing)
+const validCACert = `-----BEGIN CERTIFICATE-----
+MIIH0zCCBbugAwIBAgIIXsO3pkN/pOAwDQYJKoZIhvcNAQEFBQAwQjESMBAGA1UE
+AwwJQUNDVlJBSVoxMRAwDgYDVQQLDAdQS0lBQ0NWMQ0wCwYDVQQKDARBQ0NWMQsw
+CQYDVQQGEwJFUzAeFw0xMTA1MDUwOTM3MzdaFw0zMDEyMzEwOTM3MzdaMEIxEjAQ
+BgNVBAMMCUFDQ1ZSQUlaMTEQMA4GA1UECwwHUEtJQUNDVjENMAsGA1UECgwEQUND
+VjELMAkGA1UEBhMCRVMwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCb
+qau/YUqXry+XZpp0X9DZlv3P4uRm7x8fRzPCRKPfmt4ftVTdFXxpNRFvu8gMjmoY
+HtiP2Ra8EEg2XPBjs5BaXCQ316PWywlxufEBcoSwfdtNgM3802/J+Nq2DoLSRYWo
+G2ioPej0RGy9ocLLA76MPhMAhN9KSMDjIgro6TenGEyxCQ0jVn8ETdkXhBilyNpA
+lHPrzg5XPAOBOp0KoVdDaaxXbXmQeOW1tDvYvEyNKKGno6e6Ak4l0Squ7a4DIrhr
+IA8wKFSVf+DuzgpmndFALW4ir50awQUZ0m/A8p/4e7MCQvtQqR0tkw8jq8bBD5L/
+0KIV9VMJcRz/RROE5iZe+OCIHAr8Fraocwa48GOEAqDGWuzndN9wrqODJerWx5eH
+k6fGioozl2A3ED6XPm4pFdahD9GILBKfb6qkxkLrQaLjlUPTAYVtjrs78yM2x/47
+4KElB0iryYl0/wiPgL/AlmXz7uxLaL2diMMxs0Dx6M/2OLuc5NF/1OVYm3z61PMO
+m3WR5LpSLhl+0fXNWhn8ugb2+1KoS5kE3fj5tItQo05iifCHJPqDQsGH+tUtKSpa
+cXpkatcnYGMN285J9Y0fkIkyF/hzQ7jSWpOGYdbhdQrqeWZ2iE9x6wQl1gpaepPl
+uUsXQA+xtrn13k/c4LOsOxFwYIRKQ26ZIMApcQrAZQIDAQABo4ICyzCCAscwfQYI
+KwYBBQUHAQEEcTBvMEwGCCsGAQUFBzAChkBodHRwOi8vd3d3LmFjY3YuZXMvZmls
+ZWFkbWluL0FyY2hpdm9zL2NlcnRpZmljYWRvcy9yYWl6YWNjdjEuY3J0MB8GCCsG
+AQUFBzABhhNodHRwOi8vb2NzcC5hY2N2LmVzMB0GA1UdDgQWBBTSh7Tj3zcnk1X2
+VuqB5TbMjB4/vTAPBgNVHRMBAf8EBTADAQH/MB8GA1UdIwQYMBaAFNKHtOPfNyeT
+VfZW6oHlNsyMHj+9MIIBcwYDVR0gBIIBajCCAWYwggFiBgRVHSAAMIIBWDCCASIG
+CCsGAQUFBwICMIIBFB6CARAAQQB1AHQAbwByAGkAZABhAGQAIABkAGUAIABDAGUA
+cgB0AGkAZgBpAGMAYQBjAGkA8wBuACAAUgBhAO0AegAgAGQAZQAgAGwAYQAgAEEA
+QwBDAFYAIAAoAEEAZwBlAG4AYwBpAGEAIABkAGUAIABUAGUAYwBuAG8AbABvAGcA
+7QBhACAAeQAgAEMAZQByAHQAaQBmAGkAYwBhAGMAaQDzAG4AIABFAGwAZQBjAHQA
+cgDzAG4AaQBjAGEALAAgAEMASQBGACAAUQA0ADYAMAAxADEANQA2AEUAKQAuACAA
+QwBQAFMAIABlAG4AIABoAHQAdABwADoALwAvAHcAdwB3AC4AYQBjAGMAdgAuAGUA
+czAwBggrBgEFBQcCARYkaHR0cDovL3d3dy5hY2N2LmVzL2xlZ2lzbGFjaW9uX2Mu
+aHRtMFUGA1UdHwROMEwwSqBIoEaGRGh0dHA6Ly93d3cuYWNjdi5lcy9maWxlYWRt
+aW4vQXJjaGl2b3MvY2VydGlmaWNhZG9zL3JhaXphY2N2MV9kZXIuY3JsMA4GA1Ud
+DwEB/wQEAwIBBjAXBgNVHREEEDAOgQxhY2N2QGFjY3YuZXMwDQYJKoZIhvcNAQEF
+BQADggIBAJcxAp/n/UNnSEQU5CmH7UwoZtCPNdpNYbdKl02125DgBS4OxnnQ8pdp
+D70ER9m+27Up2pvZrqmZ1dM8MJP1jaGo/AaNRPTKFpV8M9xii6g3+CfYCS0b78gU
+JyCpZET/LtZ1qmxNYEAZSUNUY9rizLpm5U9EelvZaoErQNV/+QEnWCzI7UiRfD+m
+AM/EKXMRNt6GGT6d7hmKG9Ww7Y49nCrADdg9ZuM8Db3VlFzi4qc1GwQA9j9ajepD
+vV+JHanBsMyZ4k0ACtrJJ1vnE5Bc5PUzolVt3OAJTS+xJlsndQAJxGJ3KQhfnlms
+tn6tn1QwIgPBHnFk/vk4CpYY3QIUrCPLBhwepH2NDd4nQeit2hW3sCPdK6jT2iWH
+7ehVRE2I9DZ+hJp4rPcOVkkO1jMl1oRQQmwgEh0q1b688nCBpHBgvgW1m54ERL5h
+I6zppSSMEYCUWqKiuUnSwdzRp+0xESyeGabu4VXhwOrPDYTkF7eifKXeVSUG7szA
+h1xA2syVP1XgNce4hL60Xc16gwFy7ofmXx2utYXGJt/mwZrpHgJHnyqobalbz+xF
+d3+YJ5oyXSrjhO7FmGYvliAd3djDJ9ew+f7Zfc3Qn48LFFhRny+Lwzgt3uiP1o2H
+pPVWQxaZLPSkVrQ0uGE3ycJYgBugl6H8WY3pEfbRD0tVNEYqi4Y7
+-----END CERTIFICATE-----`
+
+// Sample CA certificate (second real FNMT-RCM CA certificate for testing)
+const validSecondCACert = `-----BEGIN CERTIFICATE-----
+MIIFgzCCA2ugAwIBAgIPXZONMGc2yAYdGsdUhGkHMA0GCSqGSIb3DQEBCwUAMDsx
+CzAJBgNVBAYTAkVTMREwDwYDVQQKDAhGTk1ULVJDTTEZMBcGA1UECwwQQUMgUkFJ
+WiBGTk1ULVJDTTAeFw0wODEwMjkxNTU5NTZaFw0zMDAxMDEwMDAwMDBaMDsxCzAJ
+BgNVBAYTAkVTMREwDwYDVQQKDAhGTk1ULVJDTTEZMBcGA1UECwwQQUMgUkFJWiBG
+Tk1ULVJDTTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALpxgHpMhm5/
+yBNtwMZ9HACXjywMI7sQmkCpGreHiPibVmr75nuOi5KOpyVdWRHbNi63URcfqQgf
+BBckWKo3Shjf5TnUV/3XwSyRAZHiItQDwFj8d0fsjz50Q7qsNI1NOHZnjrDIbzAz
+WHFctPVrbtQBULgTfmxKo0nRIBnuvMApGGWn3v7v3QqQIecaZ5JCEJhfTzC8PhxF
+tBDXaEAUwED653cXeuYLj2VbPNmaUtu1vZ5Gzz3rkQUCwJaydkxNEJY7kvqcfw+Z
+374jNUUeAlz+taibmSXaXvMiwzn15Cou08YfxGyqxRxqAQVKL9LFwag0Jl1mpdIC
+IfkYtwb1TplvqKtMUejPUBjFd8g5CSxJkjKZqLsXF3mwWsXmo8RZZUc1g16p6DUL
+mbvkzSDGm0oGObVo/CK67lWMK07q87Hj/LaZmtVC+nFNCM+HHmpxffnTtOmlcYF7
+wk5HlqX2doWjKI/pgG6BU6VtX7hI+cL5NqYuSf+4lsKMB7ObiFj86xsc3i1w4peS
+MKGJ47xVqCfWS+2QrYv6YyVZLag13cqXM7zlzced0ezvXg5KkAYmY6252TUtB7p2
+ZSysV4999AeU14ECll2jB0nVetBX+RvnU0Z1qrB5QstocQjpYL05ac70r8NWQMet
+UqIJ5G+GR4of6ygnXYMgrwTJbFaai0b1AgMBAAGjgYMwgYAwDwYDVR0TAQH/BAUw
+AwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFPd9xf3E6Jobd2Sn9R2gzL+H
+YJptMD4GA1UdIAQ3MDUwMwYEVR0gADArMCkGCCsGAQUFBwIBFh1odHRwOi8vd3d3
+LmNlcnQuZm5tdC5lcy9kcGNzLzANBgkqhkiG9w0BAQsFAAOCAgEAB5BK3/MjTvDD
+nFFlm5wioooMhfNzKWtN/gHiqQxjAb8EZ6WdmF/9ARP67Jpi6Yb+tmLSbkyU+8B1
+RXxlDPiyN8+sD8+Nb/kZ94/sHvJwnvDKuO+3/3Y3dlv2bojzr2IyIpMNOmqOFGYM
+LVN0V2Ue1bLdI4E7pWYjJ2cJj+F3qkPNZVEI7VFY/uY5+ctHhKQV8Xa7pO6kO8Rf
+77IzlhEYt8llvhjho6Tc+hj507wTmzl6NLrTQfv6MooqtyuGC2mDOL7Nii4LcK2N
+JpLuHvUBKwrZ1pebbuCoGRw6IYsMHkCtA+fdZn71uSANA+iW+YJF1DngoABd15jm
+fZ5nc8OaKveri6E6FO80vFIOiZiaBECEHX5FaZNXzuvO+FB8TxxuBEOb+dY7Ixjp
+6o7RTUaN8Tvkasq6+yO3m/qZASlaWFot4/nUbQ4mrcFuNLwy+AwF+mWj2zs3gyLp
+1txyM/1d8iC9djwj2ij3+RvrWWTV3F9yfiD8zYm1kGdNYno/Tq0dwzn+evQoFt9B
+9kiABdcPUXmsEKvU7ANm5mqwujGSQkBqvjrTcuFqN1W8rB2Vt2lh8kORdOag0wok
+RqEIr9baRRmW1FMdW4R58MD3R++Lj8UGrp1MYp3/RgT408m2ECVAdf4WqslKYIYv
+uu8wd+RU4riEmViAqhOLUTpPSPaLtrM=
+-----END CERTIFICATE-----`
+
+// Sample malformed certificate that will cause parse error
+const validNonCACert = `-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJANebNggxfD9YMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNVBAMMCUVu
+ZCBFbnRpdHkwHhcNMjQxMDI5MDAwMDAwWhcNMjUxMDI5MDAwMDAwWjAUMRIwEAYD
+VQQDDAlFbmQgRW50aXR5MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALVG9ojLFJH5
+NSB0DvM72ZjRxWVXVVoBBN7WkjH5Py8mZg3JH5dWxha0LeguUOUcE6aoT9Lb7Irj
+B0MczgFolcqaLA0GCSqGSIb3DQEBCwUAA0EAWtQK71LiATWbzBVPZvVhUctRmzg/
+srf5T1r0/Y7tXwpAWomc7wjp0k2nqQr0LzJhe/lWFT6r28nk3UnWfq9Xgw==
+-----END CERTIFICATE-----`
+
+// Real end-entity certificate (non-CA) for testing "is not a CA" validation
+const realEndEntityCert = `-----BEGIN CERTIFICATE-----
+MIIDjTCCAnWgAwIBAgIUX5w1UjnN2GEZjqJTpF6Qk1KJZxkwDQYJKoZIhvcNAQEL
+BQAwQjESMBAGA1UEAwwJQUNDVlJBSVoxMRAwDgYDVQQLDAdQS0lBQ0NWMQ0wCwYD
+VQQKDARBQ0NWMQswCQYDVQQGEwJFUzAeFw0yNDEwMjkwMDAwMDBaFw0yNTEwMjkw
+MDAwMDBaMEExCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYD
+VQQHDA1Nb3VudGFpbiBWaWV3MQswCQYDVQQKDAJJVDBZMBMGByqGSM49AgEGCCqG
+SM49AwEHA0IABNKbFbJgm0C1Y2J1qj5jq6dHH5z1gk8R5Q8S5L2K6X4C8z5K5G5b
+2Y4X8G5K2a6S5H2K6X4C8z5K5G5b2Y4X8G5K2a6S5H2K6X4C8z5K5G5b2Y4X8G5K
+2a6S5H2K6X4C8z5K5G5b2Y4X8G5K2a6S5H2K6X4C8z5K5G5b2YCjQjBAMAwGA1Ud
+EwEB/wQCMAAwDgYDVR0PAQH/BAQDAgWgMB0GA1UdDgQWBBQ2hV4z/tOVx3qG7QW5
+hZ4Zr+a8kjAfBgNVHSMEGDAWgBTSh7Tj3zcnk1X2VuqB5TbMjB4/vTANBgkqhkiG
+9w0BAQsFAAOCAQEAB5BK3/MjTvDDnFFlm5wioooMhfNzKWtN/gHiqQxjAb8EZ6Wd
+mF/9ARP67Jpi6Yb+tmLSbkyU+8B1RXxlDPiyN8+sD8+Nb/kZ94/sHvJwnvDKuO+3
+/3Y3dlv2bojzr2IyIpMNOmqOFGYMLVN0V2Ue1bLdI4E7pWYjJ2cJj+F3qkPNZVEI
+7VFY/uY5+ctHhKQV8Xa7pO6kO8Rf77IzlhEYt8llvhjho6Tc+hj507wTmzl6NLrT
+Qfv6MooqtyuGC2mDOL7Nii4LcK2NJpLuHvUBKwrZ1pebbuCoGRw6IYsMHkCtA+fd
+Zn71uSANA+iW+YJF1DngoABd15jmfZ5nc8OaKveri6E6FO80vFIOiZiaBECEHX5F
+aZNXzuvO+FB8TxxuBEOb+dY7Ixjp6o7RTUaN8Tvkasq6+yO3m/qZASlaWFot4/nU
+bQ4mrcFuNLwy+AwF+mWj2zs3gyLp1txyM/1d8iC9djwj2ij3+RvrWWTV3F9yfiD8
+-----END CERTIFICATE-----`
+
+// Sample malformed certificate
+const malformedCert = `-----BEGIN CERTIFICATE-----
+INVALID_CERTIFICATE_DATA
+-----END CERTIFICATE-----`
+
+// UTF-8 BOM bytes
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+func TestValidateTrustbundle(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       interface{}
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "invalid input type - integer",
+			input:       123,
+			expectError: true,
+			errorMsg:    "expected type of \"test\" to be string",
+		},
+		{
+			name:        "invalid input type - nil",
+			input:       nil,
+			expectError: true,
+			errorMsg:    "expected type of \"test\" to be string",
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+			errorMsg:    "no certificates found in bundle",
+		},
+		{
+			name:        "malformed certificate",
+			input:       malformedCert,
+			expectError: true,
+			errorMsg:    "no certificates found in bundle",
+		},
+		{
+			name:        "malformed certificate causes parse error",
+			input:       validNonCACert,
+			expectError: true,
+			errorMsg:    "failed to parse",
+		},
+		{
+			name:        "valid CA certificate",
+			input:       validCACert,
+			expectError: false,
+		},
+		{
+			name:        "valid certificate but not CA (end entity)",
+			input:       realEndEntityCert,
+			expectError: true,
+			errorMsg:    "failed to parse",
+		},
+		{
+			name:        "valid CA certificate with UTF-8 BOM",
+			input:       string(utf8BOM) + validCACert,
+			expectError: false,
+		},
+		{
+			name:        "multiple valid CA certificates",
+			input:       validCACert + "\n" + validSecondCACert,
+			expectError: false,
+		},
+		{
+			name:        "multiple certificates - one valid CA, one malformed",
+			input:       validCACert + "\n" + validNonCACert,
+			expectError: true,
+			errorMsg:    "failed to parse",
+		},
+		{
+			name:        "multiple certificates with BOM - all valid CAs",
+			input:       string(utf8BOM) + validCACert + "\n" + validSecondCACert,
+			expectError: false,
+		},
+		{
+			name:        "invalid PEM format",
+			input:       "not a pem format at all",
+			expectError: true,
+			errorMsg:    "no certificates found in bundle",
+		},
+		{
+			name:        "empty PEM block",
+			input:       "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----",
+			expectError: true,
+			errorMsg:    "failed to parse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errs := ValidateTrustbundle(tt.input, "test")
+
+			if tt.expectError {
+				assert.NotEmpty(t, errs, "Expected validation errors but got none")
+				if len(errs) > 0 {
+					assert.Contains(t, errs[0].Error(), tt.errorMsg, 
+						"Error message should contain expected text")
+				}
+			} else {
+				assert.Empty(t, errs, "Expected no validation errors but got: %v", errs)
+			}
+		})
+	}
+}
+

--- a/goaviatrix/dcf_trustbundle_test.go
+++ b/goaviatrix/dcf_trustbundle_test.go
@@ -216,7 +216,7 @@ func TestValidateTrustbundle(t *testing.T) {
 			if tt.expectError {
 				assert.NotEmpty(t, errs, "Expected validation errors but got none")
 				if len(errs) > 0 {
-					assert.Contains(t, errs[0].Error(), tt.errorMsg, 
+					assert.Contains(t, errs[0].Error(), tt.errorMsg,
 						"Error message should contain expected text")
 				}
 			} else {
@@ -225,4 +225,3 @@ func TestValidateTrustbundle(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
This adds TF support for DCF trust bundles, the bundle content must be used as file("bundle") and input as a string.