### PR TITLE
AVX-54809: Adding a data source for webgroups to search by name [Backport 2350 to rc-8.0]

### DIFF
--- a/aviatrix/data_source_aviatrix_dcf_webgroups.go
+++ b/aviatrix/data_source_aviatrix_dcf_webgroups.go
@@ -1,0 +1,103 @@
+package aviatrix
+
+import (
+	"context"
+
+	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAviatrixDcfWebgroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAviatrixDcfWebgroupsRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the Web Group.",
+			},
+			"selector": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"match_expressions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"snifilter": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Server name indicator this expression matches.",
+									},
+									"urlfilter": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "URL address this expression matches.",
+									},
+								},
+							},
+						},
+					},
+				},
+				Description: "List of match expressions for the Web Group.",
+			},
+			"uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of the Web Group.",
+			},
+		},
+	}
+}
+
+func dataSourceAviatrixDcfWebgroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*goaviatrix.Client)
+
+	name, ok := d.Get("name").(string)
+	if !ok {
+		return diag.Errorf("name must be of type string")
+	}
+	if name == "" {
+		return diag.Errorf("name must be specified")
+	}
+
+	webGroup, err := client.GetWebGroupByName(ctx, name)
+	if err != nil {
+		return diag.Errorf("could not get DCF webgroups: %s", err)
+	}
+
+	err = d.Set("name", webGroup.Name)
+	if err != nil {
+		return diag.Errorf("could not set name: %s", err)
+	}
+	err = d.Set("uuid", webGroup.UUID)
+	if err != nil {
+		return diag.Errorf("could not set uuid: %s", err)
+	}
+	var expressions []interface{}
+
+	for _, filter := range webGroup.Selector.Expressions {
+		filterMap := map[string]interface{}{
+			"snifilter": filter.SniFilter,
+			"urlfilter": filter.UrlFilter,
+		}
+
+		expressions = append(expressions, filterMap)
+	}
+
+	selector := []interface{}{
+		map[string]interface{}{
+			"match_expressions": expressions,
+		},
+	}
+	if err := d.Set("selector", selector); err != nil {
+		return diag.Errorf("failed to set selector during Web Group read: %s", err)
+	}
+
+	d.SetId(webGroup.UUID)
+
+	return nil
+}

--- a/aviatrix/data_source_aviatrix_dcf_webgroups_test.go
+++ b/aviatrix/data_source_aviatrix_dcf_webgroups_test.go
@@ -1,0 +1,67 @@
+package aviatrix
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSourceAviatrixDcfWebgroups_basic(t *testing.T) {
+	resourceName := "data.aviatrix_web_group.test"
+
+	skipAcc := os.Getenv("SKIP_DATA_DCF_WEBGROUPS")
+	if skipAcc == "yes" {
+		t.Skip("Skipping Data Source DCF Webgroups test as SKIP_DATA_DCF_WEBGROUPS is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, ". Set SKIP_DATA_DCF_WEBGROUPS to yes to skip Data Source DCF Webgroups tests")
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAviatrixDcfWebgroupsConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAviatrixDcfWebgroups(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
+					resource.TestCheckResourceAttr(resourceName, "selector.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAviatrixDcfWebgroupsConfigBasic() string {
+	return `
+resource aviatrix_web_group "test_webgroup" {
+	name = "test-webgroup"
+	selector {
+		match_expressions {
+			snifilter = "example.com"
+		}
+	}
+}
+
+data "aviatrix_web_group" "test" {
+	depends_on = [aviatrix_web_group.test_webgroup]
+	name = "test-webgroup"
+}
+	`
+}
+
+func testAccDataSourceAviatrixDcfWebgroups(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no data source called %s", name)
+		}
+
+		return nil
+	}
+}

--- a/aviatrix/provider.go
+++ b/aviatrix/provider.go
@@ -201,6 +201,7 @@ func Provider() *schema.Provider {
 			"aviatrix_account":                              dataSourceAviatrixAccount(),
 			"aviatrix_caller_identity":                      dataSourceAviatrixCallerIdentity(),
 			"aviatrix_controller_metadata":                  dataSourceAviatrixControllerMetadata(),
+			"aviatrix_web_group":                            dataSourceAviatrixDcfWebgroups(),
 			"aviatrix_device_interfaces":                    dataSourceAviatrixDeviceInterfaces(),
 			"aviatrix_edge_gateway_wan_interface_discovery": dataSourceAviatrixEdgeGatewayWanInterfaceDiscovery(),
 			"aviatrix_firenet":                              dataSourceAviatrixFireNet(),

--- a/docs/data-sources/aviatrix_web_group.md
+++ b/docs/data-sources/aviatrix_web_group.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Secured Networking"
+layout: "aviatrix"
+page_title: "Aviatrix: aviatrix_web_group"
+description: |-
+    Gets details about a DCF Web Group.
+---
+
+# aviatrix_web_group
+
+The **aviatrix_web_group** data source provides details about a specific DCF Web Group created by the Aviatrix Controller.
+
+## Example Usage
+
+```hcl
+# Aviatrix Web Group Data Source
+data "aviatrix_web_group" "example" {
+    name = "my-web-group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the Web Group.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `name` - Name of the Web Group.
+* `uuid` - UUID of the Web Group.
+* `selector` - Block containing match expressions to filter the Web Group.
+        * `match_expressions` - List of match expressions for the Web Group.
+                * `snifilter` - Server name indication this expression matches.
+                * `urlfilter` - URL address this expression matches.

--- a/goaviatrix/web_group.go
+++ b/goaviatrix/web_group.go
@@ -3,6 +3,7 @@ package goaviatrix
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 )
 
@@ -19,6 +20,18 @@ type WebGroup struct {
 	Name     string
 	UUID     string
 	Selector WebGroupSelector
+}
+
+type WebGroupMatchExpressionResult struct {
+	All map[string]string `json:"all"`
+}
+type WebGroupAnyResult struct {
+	Any []WebGroupMatchExpressionResult `json:"any"`
+}
+type WebGroupResult struct {
+	UUID     string            `json:"uuid"`
+	Name     string            `json:"name"`
+	Selector WebGroupAnyResult `json:"selector"`
 }
 
 func webGroupFilterToMap(filter *WebGroupMatchExpression) map[string]string {
@@ -61,15 +74,74 @@ func (c *Client) CreateWebGroup(ctx context.Context, webGroup *WebGroup) (string
 	return c.appdomainCache.Create(ctx, c, form)
 }
 
+func (c *Client) GetWebGroupByName(ctx context.Context, name string) (*WebGroup, error) {
+	endpoint := fmt.Sprintf("app-domains/name/%s", name)
+
+	var data WebGroupResult
+	err := c.GetAPIContext25(ctx, &data, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if data.Name == name {
+		webGroup := &WebGroup{
+			Name: data.Name,
+			UUID: data.UUID,
+		}
+
+		for _, filterResult := range data.Selector.Any {
+			filterMap := filterResult.All
+
+			filter := &WebGroupMatchExpression{
+				SniFilter: filterMap["snifilter"],
+				UrlFilter: filterMap["urlfilter"],
+			}
+
+			webGroup.Selector.Expressions = append(webGroup.Selector.Expressions, filter)
+		}
+		return webGroup, nil
+	}
+	return nil, ErrNotFound
+}
+
 func (c *Client) GetWebGroup(ctx context.Context, uuid string) (*WebGroup, error) {
+	endpoint := fmt.Sprintf("app-domains/%s", uuid)
+
+	var data WebGroupResult
+	err := c.GetAPIContext25(ctx, &data, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if data.UUID == uuid {
+		webGroup := &WebGroup{
+			Name: data.Name,
+			UUID: data.UUID,
+		}
+
+		for _, filterResult := range data.Selector.Any {
+			filterMap := filterResult.All
+
+			filter := &WebGroupMatchExpression{
+				SniFilter: filterMap["snifilter"],
+				UrlFilter: filterMap["urlfilter"],
+			}
+
+			webGroup.Selector.Expressions = append(webGroup.Selector.Expressions, filter)
+		}
+		return webGroup, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (c *Client) GetWebGroup(ctx context.Context, uuid string) (*WebGroup, error) {
+	endpoint := fmt.Sprintf("app-domains/%s", uuid)
+
 	type WebGroupMatchExpressionResult struct {
 		All map[string]string `json:"all"`
 	}
-
 	type WebGroupAnyResult struct {
 		Any []WebGroupMatchExpressionResult `json:"any"`
 	}
-
 	type WebGroupResult struct {
 		UUID     string            `json:"uuid"`
 		Name     string            `json:"name"`

--- a/goaviatrix/web_group.go
+++ b/goaviatrix/web_group.go
@@ -2,7 +2,6 @@ package goaviatrix
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 )
@@ -131,54 +130,6 @@ func (c *Client) GetWebGroup(ctx context.Context, uuid string) (*WebGroup, error
 		return webGroup, nil
 	}
 	return nil, ErrNotFound
-}
-
-func (c *Client) GetWebGroup(ctx context.Context, uuid string) (*WebGroup, error) {
-	endpoint := fmt.Sprintf("app-domains/%s", uuid)
-
-	type WebGroupMatchExpressionResult struct {
-		All map[string]string `json:"all"`
-	}
-	type WebGroupAnyResult struct {
-		Any []WebGroupMatchExpressionResult `json:"any"`
-	}
-	type WebGroupResult struct {
-		UUID     string            `json:"uuid"`
-		Name     string            `json:"name"`
-		Selector WebGroupAnyResult `json:"selector"`
-	}
-
-	type WebGroupResp struct {
-		WebGroups []WebGroupResult `json:"app_domains"`
-	}
-
-	g, err := c.appdomainCache.Get(ctx, c, uuid)
-	if err != nil {
-		return nil, err
-	}
-
-	selector := WebGroupAnyResult{}
-	if err := json.Unmarshal(g.Selector, &selector); err != nil {
-		return nil, err
-	}
-
-	webGroup := &WebGroup{
-		Name: g.Name,
-		UUID: g.UUID,
-	}
-
-	for _, filterResult := range selector.Any {
-		filterMap := filterResult.All
-
-		filter := &WebGroupMatchExpression{
-			SniFilter: filterMap["snifilter"],
-			UrlFilter: filterMap["urlfilter"],
-		}
-
-		webGroup.Selector.Expressions = append(webGroup.Selector.Expressions, filter)
-	}
-
-	return webGroup, nil
 }
 
 func (c *Client) UpdateWebGroup(ctx context.Context, webGroup *WebGroup, uuid string) error {


### PR DESCRIPTION
The previous backport led to a build failure, so fixed that issue and creating a new backport PR. The original PR was backported by @jpeach in https://github.com/AviatrixSystems/terraform-provider-aviatrix/pull/2401 , thank you for finding the error and fixing the main branch, now the build should work fine.

It was tested with the unit test.