### PR TITLE
AVX-70078 Terraform is mandating to specify external_device_backup_ipv6

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -665,7 +665,7 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 			if externalDeviceConn.BackupRemoteGatewayIP == externalDeviceConn.RemoteGatewayIP {
 				return fmt.Errorf("expected 'backup_remote_gateway_ip' to contain a different valid IPv4 address than 'remote_gateway_ip'")
 			}
-			if externalDeviceConn.EnableIpv6 && externalDeviceConn.ExternalDeviceBackupIPv6 == "" {
+			if externalDeviceConn.EnableIpv6 && externalDeviceConn.ExternalDeviceIPv6 != "" && externalDeviceConn.ExternalDeviceBackupIPv6 == "" {
 				return fmt.Errorf("ha is enabled and 'enable_ipv6' is true, please specify 'external_device_backup_ipv6'")
 			}
 		}

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -719,7 +719,7 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 			if externalDeviceConn.BackupRemoteGatewayIP == externalDeviceConn.RemoteGatewayIP {
 				return fmt.Errorf("expected 'backup_remote_gateway_ip' to contain a different valid IPv4 address than 'remote_gateway_ip'")
 			}
-			if externalDeviceConn.EnableIpv6 && externalDeviceConn.ExternalDeviceBackupIPv6 == "" {
+			if externalDeviceConn.EnableIpv6 && externalDeviceConn.ExternalDeviceIPv6 != "" && externalDeviceConn.ExternalDeviceBackupIPv6 == "" {
 				return fmt.Errorf("ha is enabled and 'enable_ipv6' is true, please specify 'external_device_backup_ipv6'")
 			}
 		}


### PR DESCRIPTION
Handled HA case with IPv6 S2C.
IPv6 S2C can be enabled over IPv4 neighbor which was broken due to bad check.

Added fix to make sure if primary IPv6 neighbor is configured then check for backup IPv6 neighbor.