### PR TITLE
AVX-68863 Terraform changes to support gateway level cipher settings.…

### DIFF
--- a/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
+++ b/aviatrix/resource_aviatrix_edge_gateway_selfmanaged_test.go
@@ -20,7 +20,7 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 
 	resourceName := "aviatrix_edge_gateway_selfmanaged.test"
 	gwName := "edge-" + acctest.RandString(5)
-	siteId := "site-" + acctest.RandString(5)
+	siteID := "site-" + acctest.RandString(5)
 	path, _ := os.Getwd()
 
 	resource.Test(t, resource.TestCase{
@@ -31,11 +31,11 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 		CheckDestroy: testAccCheckEdgeGatewaySelfmanagedDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEdgeGatewaySelfmanagedBasic(gwName, siteId, path),
+				Config: testAccEdgeGatewaySelfmanagedBasic(gwName, siteID, path),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEdgeGatewaySelfmanagedExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "gw_name", gwName),
-					resource.TestCheckResourceAttr(resourceName, "site_id", siteId),
+					resource.TestCheckResourceAttr(resourceName, "site_id", siteID),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.0.ip_address", "172.16.15.162/20"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.1.ip_address", "10.230.3.32/24"),
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.ip_address", "10.230.5.32/24"),
@@ -43,8 +43,20 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interfaces.2.secondary_dns_server_ip", "9.9.9.9"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_polling_time", "50"),
 					resource.TestCheckResourceAttr(resourceName, "bgp_neighbor_status_polling_time", "5"),
-					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.0", "10.230.3.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.1", "10.230.5.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.0", "10.231.3.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "included_advertised_spoke_routes.1", "10.232.5.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_encryption_cipher", "strong"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_forward_secrecy", "enable"),
+				),
+			},
+			{
+				Config: testAccEdgeGatewaySelfmanagedUpdate(gwName, siteID, path),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeGatewaySelfmanagedExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", gwName),
+					resource.TestCheckResourceAttr(resourceName, "site_id", siteID),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_encryption_cipher", "default"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_forward_secrecy", "disable"),
 				),
 			},
 			{
@@ -57,7 +69,7 @@ func TestAccAviatrixEdgeGatewaySelfmanaged_basic(t *testing.T) {
 	})
 }
 
-func testAccEdgeGatewaySelfmanagedBasic(gwName, siteId, path string) string {
+func testAccEdgeGatewaySelfmanagedBasic(gwName, siteID, path string) string {
 	return fmt.Sprintf(`
 resource "aviatrix_edge_gateway_selfmanaged" "test" {
 	gw_name                            = "%s"
@@ -66,6 +78,52 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 	ztp_file_download_path             = "%s"
 	bgp_polling_time                   = 50
 	bgp_neighbor_status_polling_time   = 5
+	tunnel_encryption_cipher           = "strong"
+	tunnel_forward_secrecy             = "enable"
+
+	interfaces {
+		name          = "eth0"
+		type          = "WAN"
+		ip_address    = "10.230.5.32/24"
+		gateway_ip    = "10.230.5.100"
+		wan_public_ip = "64.71.24.221"
+		dns_server_ip = "8.8.8.8"
+		secondary_dns_server_ip = "9.9.9.9"
+	}
+
+	interfaces {
+		name       = "eth1"
+		type       = "LAN"
+		ip_address = "10.230.3.32/24"
+	}
+
+	interfaces {
+		name        = "eth2"
+		type        = "MANAGEMENT"
+		enable_dhcp = false
+		ip_address  = "172.16.15.162/20"
+		gateway_ip  = "172.16.0.1"
+	}
+
+	included_advertised_spoke_routes = [
+		"10.231.3.0/24",
+		"10.232.5.0/24"
+	]
+}
+  `, gwName, siteID, path)
+}
+
+func testAccEdgeGatewaySelfmanagedUpdate(gwName, siteID, path string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_edge_gateway_selfmanaged" "test" {
+	gw_name                            = "%s"
+	site_id                            = "%s"
+	ztp_file_type                      = "iso"
+	ztp_file_download_path             = "%s"
+	bgp_polling_time                   = 50
+	bgp_neighbor_status_polling_time   = 5
+	tunnel_encryption_cipher           = "default"
+	tunnel_forward_secrecy             = "disable"
 
 	interfaces {
 		name          = "eth0"
@@ -96,7 +154,7 @@ resource "aviatrix_edge_gateway_selfmanaged" "test" {
 		"10.230.5.0/24"
 	]
 }
-  `, gwName, siteId, path)
+  `, gwName, siteID, path)
 }
 
 func testAccCheckEdgeGatewaySelfmanagedExists(resourceName string) resource.TestCheckFunc {
@@ -137,4 +195,90 @@ func testAccCheckEdgeGatewaySelfmanagedDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func TestAccAviatrixEdgeGatewaySelfmanaged_tunnelPolicies(t *testing.T) {
+	if os.Getenv("SKIP_EDGE_GATEWAY_SELFMANAGED") == "yes" {
+		t.Skip("Skipping Edge Gateway Selfmanaged test as SKIP_EDGE_GATEWAY_SELFMANAGED is set")
+	}
+
+	resourceName := "aviatrix_edge_gateway_selfmanaged.test_tunnel"
+	gwName := "edge-tunnel-" + acctest.RandString(5)
+	siteID := "site-tunnel-" + acctest.RandString(5)
+	path, _ := os.Getwd()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEdgeGatewaySelfmanagedDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEdgeGatewaySelfmanagedTunnelPoliciesConfig(gwName, siteID, path, "default", "disable"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeGatewaySelfmanagedExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", gwName),
+					resource.TestCheckResourceAttr(resourceName, "site_id", siteID),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_encryption_cipher", "default"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_forward_secrecy", "disable"),
+				),
+			},
+			{
+				Config: testAccEdgeGatewaySelfmanagedTunnelPoliciesConfig(gwName, siteID, path, "strong", "enable"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeGatewaySelfmanagedExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", gwName),
+					resource.TestCheckResourceAttr(resourceName, "site_id", siteID),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_encryption_cipher", "strong"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_forward_secrecy", "enable"),
+				),
+			},
+			{
+				Config: testAccEdgeGatewaySelfmanagedTunnelPoliciesConfig(gwName, siteID, path, "default", "disable"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEdgeGatewaySelfmanagedExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", gwName),
+					resource.TestCheckResourceAttr(resourceName, "site_id", siteID),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_encryption_cipher", "default"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_forward_secrecy", "disable"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEdgeGatewaySelfmanagedTunnelPoliciesConfig(gwName, siteID, path, encCipher, forwardSecrecy string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_edge_gateway_selfmanaged" "test_tunnel" {
+	gw_name                            = "%s"
+	site_id                            = "%s"
+	ztp_file_type                      = "iso"
+	ztp_file_download_path             = "%s"
+	tunnel_encryption_cipher           = "%s"
+	tunnel_forward_secrecy             = "%s"
+
+	interfaces {
+		name          = "eth0"
+		type          = "WAN"
+		ip_address    = "10.230.5.32/24"
+		gateway_ip    = "10.230.5.100"
+		wan_public_ip = "64.71.24.221"
+	}
+
+	interfaces {
+		name       = "eth1"
+		type       = "LAN"
+		ip_address = "10.230.3.32/24"
+	}
+
+	interfaces {
+		name        = "eth2"
+		type        = "MANAGEMENT"
+		enable_dhcp = false
+		ip_address  = "172.16.15.162/20"
+		gateway_ip  = "172.16.0.1"
+	}
+}
+  `, gwName, siteID, path, encCipher, forwardSecrecy)
 }

--- a/docs/resources/aviatrix_edge_gateway_selfmanaged.md
+++ b/docs/resources/aviatrix_edge_gateway_selfmanaged.md
@@ -114,6 +114,8 @@ The following arguments are supported:
   * `vrrp_virtual_ip` - (Optional) LAN sub-interface virtual IP.
   * `tag` - (Optional) Tag.
 * `included_advertised_spoke_routes` - (Optional) A list of CIDRs to be advertised to on-prem gateways as Included CIDR List. When configured, it will replace all advertised routes from this VPC.
+* `tunnel_encryption_cipher` - (Optional) Encryption ciphers for gateway peering tunnels. Config options are default (AES-126-GCM-96) or strong (AES-256-GCM-96).
+* `tunnel_forward_secrecy` - (Optional) PPerfect Forward Secrecy (PFS) for gateway peering tunnels. Config Options are enable/disable.
 
 ## Attribute Reference
 

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -385,6 +385,10 @@ The following arguments are supported:
 * `private_mode_lb_vpc_id` - (Optional) VPC ID of Private Mode load balancer. Required when Private Mode is enabled on the Controller. Available in provider version R2.23+.
 * `private_mode_subnet_zone` - (Optional) Availability Zone of the subnet. Required when Private Mode is enabled on the Controller and `cloud_type` is AWS or AWSGov. Available in Provider version R2.23+.
 * `ha_private_mode_subnet_zone` - (Optional) Availability Zone of the HA subnet. Required when Private Mode is enabled on the Controller and `cloud_type` is AWS or AWSGov with HA. Available in Provider version R2.23+.
+* `enable_ipv6` - (Optional) To enable IPv6 CIDR in Spoke Gateway. Only AWS, Azure, AzureGov and AWSGov are supported.
+* `tunnel_encryption_cipher` - (Optional) Encryption ciphers for gateway peering tunnels. Config options are default (AES-126-GCM-96) or strong (AES-256-GCM-96).
+* `tunnel_forward_secrecy` - (Optional) PPerfect Forward Secrecy (PFS) for gateway peering tunnels. Config Options are enable/disable.
+
 
 !> **WARNING:** Aviatrix released the Global VPC feature in Preview mode. Preview features are not safe for deployment in production environments.
 * `enable_global_vpc` - (Optional) Enable global VPC. Only supported for GCP spoke gateways. Valid values: true, false. Default value: false.

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -495,6 +495,9 @@ The following arguments are supported:
 * `enable_multi_tier_transit` - (Optional) Enable Multi-tier Transit mode on transit gateway. When enabled, transit gateway will propagate routes it receives from its transit peering peer to other transit peering peers. `local_as_number` is required. Default value: false. Available as of provider version R2.19+.
 * `enable_s2c_rx_balancing` - (Optional) Enable S2C receive packet CPU re-balancing on transit gateway. Valid values: true, false. Default value: false. Available in provider version R2.21.2+.
 * `enable_preserve_as_path` - (Optional) Enable preserve as_path when advertising manual summary cidrs on transit gateway. Valid values: true, false. Default value: false. Available as of provider version R.2.22.1+.
+* `enable_ipv6` - (Optional) To enable IPv6 CIDR in Transit Gateway. Only AWS, Azure, AzureGov and AWSGov are supported.
+* `tunnel_encryption_cipher` - (Optional) Encryption ciphers for gateway peering tunnels. Config options are default (AES-126-GCM-96) or strong (AES-256-GCM-96).
+* `tunnel_forward_secrecy` - (Optional) PPerfect Forward Secrecy (PFS) for gateway peering tunnels. Config Options are enable/disable.
 
 -> **NOTE:** Enabling FireNet will automatically enable hybrid connection. If `enable_firenet` is set to true, please set `enable_hybrid_connection` to true in the respective **aviatrix_transit_gateway** as well.
 

--- a/goaviatrix/edge_spoke.go
+++ b/goaviatrix/edge_spoke.go
@@ -57,6 +57,8 @@ type EdgeSpoke struct {
 	Vlan                               string                        `json:"vlan,omitempty"`
 	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
 	AdvertisedCidrList                 []string                      `json:"advertise_cidr_list,omitempty"`
+	TunnelEncryptionCipher             string                        `json:"ph2_encryption_policy,omitempty"`
+	TunnelForwardSecrecy               string                        `json:"ph2_pfs_policy,omitempty"`
 }
 
 type EdgeSpokeInterface struct {
@@ -123,6 +125,8 @@ type EdgeSpokeResp struct {
 	InterfaceList                      []*EdgeSpokeInterface         `json:"interfaces"`
 	CustomInterfaceMapping             map[string]CustomInterfaceMap `json:"custom_interface_mapping,omitempty"`
 	AdvertisedCidrList                 []string                      `json:"advertise_cidr_list,omitempty"`
+	TunnelEncryptionCipher             string                        `form:"ph2_encryption_policy,omitempty"`
+	TunnelForwardSecrecy               string                        `form:"ph2_pfs_policy,omitempty"`
 }
 
 type EdgeSpokeListResp struct {

--- a/goaviatrix/spoke_vpc.go
+++ b/goaviatrix/spoke_vpc.go
@@ -52,6 +52,8 @@ type SpokeVpc struct {
 	LbVpcId                      string   `form:"lb_vpc_id,omitempty"`
 	EnableGlobalVpc              bool     `form:"global_vpc"`
 	InsertionGateway             bool     `form:"insertion_gateway,omitempty"`
+	TunnelEncryptionCipher       string   `form:"ph2_encryption_policy,omitempty"`
+	TunnelForwardSecrecy         string   `form:"ph2_pfs_policy,omitempty"`
 }
 
 type SpokeGatewayAdvancedConfig struct {

--- a/goaviatrix/transit_vpc.go
+++ b/goaviatrix/transit_vpc.go
@@ -77,6 +77,9 @@ type TransitVpc struct {
 	GatewayRegistrationMethod    string              `json:"gw_registration_method,omitempty"`
 	ManagementEgressIPPrefix     string              `json:"mgmt_egress_ip,omitempty"`
 	JumboFrame                   bool                `json:"jumbo_frame,omitempty"`
+	EnableIPv6                   bool                `json:"enable_ipv6,omitempty"`
+	TunnelEncryptionCipher       string              `form:"ph2_encryption_policy,omitempty"`
+	TunnelForwardSecrecy         string              `form:"ph2_pfs_policy,omitempty"`
 }
 
 type TransitGatewayAdvancedConfig struct {


### PR DESCRIPTION
… (#2397)

* AVX-68863 Terraform changes to support gateway level cipher settings.

Added changes to support cipher on gateway creation.

* AVX-68863 Terraform changes to support gateway level cipher settings.

Updated default value for pfs to disabled.

* Added edge support.

* Fix lint issue

* AVX-68863 Terraform changes to support gateway level

Added support for edit flow with v2.5 api.
Added support for edge.
Aligned terraform name with UI.

* Added test case.

* Fix lint issue.

* Fixed unit test failing for edge.

* Updated the config helper messages.

* Changed tunnel cipher policy to two different structure for better readability.

---------


(cherry picked from commit 2f037334655d2f6a52f956705185a8316e533af8)