### PR TITLE
AVX-68721 Add support for ipv6 gateway creation with ipv6 subnet cidr…

### DIFF
--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -26,6 +26,8 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		CustomizeDiff: resourceAviatrixSpokeGatewayCustomizeDiff,
+
 		SchemaVersion: 2,
 		StateUpgraders: []schema.StateUpgrader{
 			{
@@ -85,6 +87,17 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				ValidateFunc: validation.IsCIDR,
 				Description:  "Public Subnet Info.",
 			},
+			"subnet_ipv6_cidr": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIPv6CIDR,
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					// Suppress diff when enable_ipv6 is false (field is not relevant)
+					return !d.Get("enable_ipv6").(bool)
+				},
+				Description: "IPv6 CIDR for the subnet. Only used if enable_ipv6 flag is set. Currently only supported on Azure and AWS Cloud.",
+			},
 			"zone": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -120,6 +133,17 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.IsCIDR,
 				Description:  "HA Subnet. Required if enabling HA for AWS/AWSGov/AWSChina/Azure/AzureChina/OCI/Alibaba Cloud. Optional if enabling HA for GCP.",
+			},
+			"ha_subnet_ipv6_cidr": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIPv6CIDR,
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					// Suppress diff when enable_ipv6 is false (field is not relevant)
+					return !d.Get("enable_ipv6").(bool)
+				},
+				Description: "IPv6 CIDR for the HA subnet. Only used if enable_ipv6 flag is set. Currently only supported on Azure and AWS Cloud.",
 			},
 			"ha_zone": {
 				Type:        schema.TypeString,
@@ -668,6 +692,33 @@ func resourceAviatrixSpokeGateway() *schema.Resource {
 	}
 }
 
+func handleIPv6SubnetForceNew(d *schema.ResourceDiff, fieldName string) error {
+	if !d.HasChange(fieldName) || !d.Get("enable_ipv6").(bool) {
+		return nil
+	}
+
+	oldSubnet, newSubnet := d.GetChange(fieldName)
+	oldSubnetStr, newSubnetStr := oldSubnet.(string), newSubnet.(string)
+
+	if oldSubnetStr != "" && oldSubnetStr != newSubnetStr {
+		return d.ForceNew(fieldName)
+	}
+
+	return nil
+}
+
+func resourceAviatrixSpokeGatewayCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if err := handleIPv6SubnetForceNew(d, "subnet_ipv6_cidr"); err != nil {
+		return err
+	}
+
+	if err := handleIPv6SubnetForceNew(d, "ha_subnet_ipv6_cidr"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 
@@ -1053,14 +1104,6 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("'enable_global_vpc' is only valid for GCP")
 	}
 
-	enableIpv6 := d.Get("enable_ipv6").(bool)
-	if enableIpv6 {
-		if !goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes|goaviatrix.AWSRelatedCloudTypes) {
-			return fmt.Errorf("error creating gateway: enable_ipv6 is only supported for AWS (1), Azure (8)")
-		}
-		gateway.EnableIPv6 = true
-	}
-
 	insertionGateway := d.Get("insertion_gateway").(bool)
 	insertionGatewayAz := d.Get("insertion_gateway_az").(string)
 
@@ -1083,6 +1126,25 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 		strs = append(strs, gateway.Subnet, insertionGatewayAz)
 		gateway.Subnet = strings.Join(strs, subnetSeparator)
 		gateway.InsertionGateway = true
+	}
+
+	enableIpv6 := d.Get("enable_ipv6").(bool)
+	if enableIpv6 {
+		if !goaviatrix.IsCloudType(gateway.CloudType, goaviatrix.AzureArmRelatedCloudTypes|goaviatrix.AWSRelatedCloudTypes) {
+			return fmt.Errorf("error creating gateway: enable_ipv6 is only supported for AWS (1), Azure (8)")
+		}
+		gateway.EnableIPv6 = true
+
+		subnetIPv6Cidr := d.Get("subnet_ipv6_cidr").(string)
+		if subnetIPv6Cidr == "" {
+			return fmt.Errorf("error creating gateway: subnet_ipv6_cidr must be set when enable_ipv6 is true")
+		}
+		gatewaySubnet := gateway.Subnet
+		// Trim any trailing '~' to normalize it first
+		gatewaySubnet = strings.TrimRight(gatewaySubnet, "~")
+
+		// Append IPv6 subnet CIDR
+		gateway.Subnet = gatewaySubnet + subnetSeparator + subnetIPv6Cidr
 	}
 
 	log.Printf("[INFO] Creating Aviatrix Spoke Gateway: %#v", gateway)
@@ -1189,6 +1251,18 @@ func resourceAviatrixSpokeGatewayCreate(d *schema.ResourceData, meta interface{}
 				spokeHaGw.Subnet = haSubnet
 			}
 			spokeHaGw.InsertionGateway = true
+		}
+
+		enableIpv6 := d.Get("enable_ipv6").(bool)
+		if enableIpv6 {
+			haSubnetIPv6Cidr := d.Get("ha_subnet_ipv6_cidr").(string)
+			if haSubnetIPv6Cidr == "" {
+				return fmt.Errorf("error creating HA gateway: ha_subnet_ipv6_cidr must be set when enable_ipv6 is true")
+			}
+
+			haSubnet := spokeHaGw.Subnet
+			haSubnetTrimmed := strings.TrimRight(haSubnet, "~")
+			spokeHaGw.Subnet = haSubnetTrimmed + subnetSeparator + haSubnetIPv6Cidr
 		}
 
 		_, err := client.CreateSpokeHaGw(spokeHaGw)
@@ -1556,6 +1630,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("enable_ipv6", gw.EnableIPv6)
 
 	d.Set("insertion_gateway", gw.InsertionGateway)
+	d.Set("subnet_ipv6_cidr", gw.SubnetIPv6Cidr)
 
 	if gw.InsertionGateway && goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes) {
 		d.Set("insertion_gateway_az", gw.GatewayZone)
@@ -1824,6 +1899,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 			d.Set("ha_security_group_id", "")
 			d.Set("ha_software_version", "")
 			d.Set("ha_subnet", "")
+			d.Set("ha_subnet_ipv6_cidr", "")
 			d.Set("ha_zone", "")
 			d.Set("ha_public_ip", "")
 			d.Set("ha_private_mode_subnet_zone", "")
@@ -1851,6 +1927,7 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 				d.Set("ha_subnet", "")
 			}
 		}
+		d.Set("ha_subnet_ipv6_cidr", gw.HaGw.SubnetIPv6Cidr)
 
 		if goaviatrix.IsCloudType(gw.HaGw.CloudType, goaviatrix.OCIRelatedCloudTypes) {
 			if gw.HaGw.GatewayZone != "" {
@@ -2259,6 +2336,18 @@ func resourceAviatrixSpokeGatewayUpdate(d *schema.ResourceData, meta interface{}
 				spokeHaGw.Subnet = strings.Join(haStrs, subnetSeparator)
 			}
 			spokeHaGw.InsertionGateway = true
+		}
+
+		enableIpv6 := d.Get("enable_ipv6").(bool)
+		if enableIpv6 {
+			haSubnetIPv6Cidr := d.Get("ha_subnet_ipv6_cidr").(string)
+			if haSubnetIPv6Cidr == "" {
+				return fmt.Errorf("error creating HA gateway: ha_subnet_ipv6_cidr must be set when enable_ipv6 is true")
+			}
+
+			haSubnet := spokeHaGw.Subnet
+			haSubnetTrimmed := strings.TrimRight(haSubnet, "~")
+			spokeHaGw.Subnet = haSubnetTrimmed + subnetSeparator + haSubnetIPv6Cidr
 		}
 
 		if newHaGwEnabled {

--- a/aviatrix/resource_aviatrix_spoke_gateway_test.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway_test.go
@@ -459,3 +459,400 @@ func testAccCheckSpokeGatewayDestroy(s *terraform.State) error {
 
 	return nil
 }
+
+// TestAccAviatrixSpokeGateway_ipv6AWS tests IPv6 CIDR fields for AWS spoke gateway
+func TestAccAviatrixSpokeGateway_ipv6AWS(t *testing.T) {
+	var gateway goaviatrix.Gateway
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_spoke_gateway.test_spoke_gateway_ipv6"
+
+	msgCommon := ". Set SKIP_SPOKE_GATEWAY_IPV6 to yes to skip Spoke Gateway IPv6 tests"
+
+	skipGwIPv6 := os.Getenv("SKIP_SPOKE_GATEWAY_IPV6")
+	if skipGwIPv6 == "yes" {
+		t.Skip("Skipping Spoke Gateway IPv6 test as SKIP_SPOKE_GATEWAY_IPV6 is set")
+	}
+
+	awsGwSize := os.Getenv("AWS_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "t2.micro"
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAwsSpokeGatewayIPv6Check(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSpokeGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpokeGatewayConfigAWSIPv6(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpokeGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", fmt.Sprintf("tfg-aws-ipv6-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "gw_size", awsGwSize),
+					resource.TestCheckResourceAttr(resourceName, "account_name", fmt.Sprintf("tfa-aws-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", os.Getenv("AWS_VPC_ID4")),
+					resource.TestCheckResourceAttr(resourceName, "subnet", os.Getenv("AWS_SUBNET4")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AWS_REGION")),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ipv6_cidr", os.Getenv("AWS_SUBNET_IPV6_CIDR")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"gcloud_project_credentials_filepath",
+					"vnet_and_resource_group_names",
+				},
+			},
+		},
+	})
+}
+
+// TestAccAviatrixSpokeGateway_ipv6WithHA tests IPv6 CIDR fields with HA enabled
+func TestAccAviatrixSpokeGateway_ipv6WithHA(t *testing.T) {
+	var gateway goaviatrix.Gateway
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_spoke_gateway.test_spoke_gateway_ipv6_ha"
+
+	msgCommon := ". Set SKIP_SPOKE_GATEWAY_IPV6 to yes to skip Spoke Gateway IPv6 tests"
+
+	skipGwIPv6 := os.Getenv("SKIP_SPOKE_GATEWAY_IPV6")
+	if skipGwIPv6 == "yes" {
+		t.Skip("Skipping Spoke Gateway IPv6 HA test as SKIP_SPOKE_GATEWAY_IPV6 is set")
+	}
+
+	awsGwSize := os.Getenv("AWS_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "t2.micro"
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAwsSpokeGatewayIPv6HACheck(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSpokeGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpokeGatewayConfigAWSIPv6WithHA(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpokeGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", fmt.Sprintf("tfg-aws-ipv6-ha-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "gw_size", awsGwSize),
+					resource.TestCheckResourceAttr(resourceName, "account_name", fmt.Sprintf("tfa-aws-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", os.Getenv("AWS_VPC_ID4")),
+					resource.TestCheckResourceAttr(resourceName, "subnet", os.Getenv("AWS_SUBNET4")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AWS_REGION")),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ipv6_cidr", os.Getenv("AWS_SUBNET_IPV6_CIDR")),
+					resource.TestCheckResourceAttr(resourceName, "ha_subnet", os.Getenv("AWS_HA_SUBNET")),
+					resource.TestCheckResourceAttr(resourceName, "ha_subnet_ipv6_cidr", os.Getenv("AWS_HA_SUBNET_IPV6_CIDR")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"gcloud_project_credentials_filepath",
+					"vnet_and_resource_group_names",
+				},
+			},
+		},
+	})
+}
+
+// TestAccAviatrixSpokeGateway_ipv6Azure tests IPv6 CIDR fields for Azure spoke gateway
+func TestAccAviatrixSpokeGateway_ipv6Azure(t *testing.T) {
+	var gateway goaviatrix.Gateway
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_spoke_gateway.test_spoke_gateway_ipv6_azure"
+
+	msgCommon := ". Set SKIP_SPOKE_GATEWAY_IPV6_AZURE to yes to skip Azure Spoke Gateway IPv6 tests"
+
+	skipGwIPv6Azure := os.Getenv("SKIP_SPOKE_GATEWAY_IPV6_AZURE")
+	if skipGwIPv6Azure == "yes" {
+		t.Skip("Skipping Azure Spoke Gateway IPv6 test as SKIP_SPOKE_GATEWAY_IPV6_AZURE is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAzureSpokeGatewayIPv6Check(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSpokeGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpokeGatewayConfigAzureIPv6(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpokeGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", fmt.Sprintf("tfg-azure-ipv6-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "gw_size", os.Getenv("AZURE_GW_SIZE")),
+					resource.TestCheckResourceAttr(resourceName, "account_name", fmt.Sprintf("tfa-azure-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", os.Getenv("AZURE_VNET_ID")),
+					resource.TestCheckResourceAttr(resourceName, "subnet", os.Getenv("AZURE_SUBNET")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AZURE_REGION")),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ipv6_cidr", os.Getenv("AZURE_SUBNET_IPV6_CIDR")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"gcloud_project_credentials_filepath",
+					"vnet_and_resource_group_names",
+					"vpc_id",
+				},
+			},
+		},
+	})
+}
+
+func preAwsSpokeGatewayIPv6Check(t *testing.T, msgCommon string) {
+	requiredEnvVars := []string{
+		"AWS_VPC_ID4",
+		"AWS_SUBNET4",
+		"AWS_REGION",
+		"AWS_SUBNET_IPV6_CIDR",
+	}
+	for _, v := range requiredEnvVars {
+		if os.Getenv(v) == "" {
+			t.Fatalf("Env Var %s required %s", v, msgCommon)
+		}
+	}
+}
+
+func preAwsSpokeGatewayIPv6HACheck(t *testing.T, msgCommon string) {
+	requiredEnvVars := []string{
+		"AWS_VPC_ID4",
+		"AWS_SUBNET4",
+		"AWS_REGION",
+		"AWS_SUBNET_IPV6_CIDR",
+		"AWS_HA_SUBNET",
+		"AWS_HA_SUBNET_IPV6_CIDR",
+	}
+	for _, v := range requiredEnvVars {
+		if os.Getenv(v) == "" {
+			t.Fatalf("Env Var %s required %s", v, msgCommon)
+		}
+	}
+}
+
+func preAzureSpokeGatewayIPv6Check(t *testing.T, msgCommon string) {
+	requiredEnvVars := []string{
+		"AZURE_VNET_ID",
+		"AZURE_SUBNET",
+		"AZURE_REGION",
+		"AZURE_GW_SIZE",
+		"AZURE_SUBNET_IPV6_CIDR",
+	}
+	for _, v := range requiredEnvVars {
+		if os.Getenv(v) == "" {
+			t.Fatalf("Env Var %s required %s", v, msgCommon)
+		}
+	}
+}
+
+func testAccSpokeGatewayConfigAWSIPv6(rName string) string {
+	awsGwSize := os.Getenv("AWS_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "t2.micro"
+	}
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_aws" {
+	account_name       = "tfa-aws-%s"
+	cloud_type         = 1
+	aws_account_number = "%s"
+	aws_iam            = false
+	aws_access_key     = "%s"
+	aws_secret_key     = "%s"
+}
+resource "aviatrix_spoke_gateway" "test_spoke_gateway_ipv6" {
+	cloud_type        = 1
+	account_name      = aviatrix_account.test_acc_aws.account_name
+	gw_name           = "tfg-aws-ipv6-%[1]s"
+	vpc_id            = "%[5]s"
+	vpc_reg           = "%[6]s"
+	gw_size           = "%[7]s"
+	subnet            = "%[8]s"
+	enable_ipv6       = true
+	subnet_ipv6_cidr  = "%[9]s"
+}
+	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
+		os.Getenv("AWS_VPC_ID4"), os.Getenv("AWS_REGION"), awsGwSize, os.Getenv("AWS_SUBNET4"),
+		os.Getenv("AWS_SUBNET_IPV6_CIDR"))
+}
+
+func testAccSpokeGatewayConfigAWSIPv6WithHA(rName string) string {
+	awsGwSize := os.Getenv("AWS_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "t2.micro"
+	}
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_aws" {
+	account_name       = "tfa-aws-%s"
+	cloud_type         = 1
+	aws_account_number = "%s"
+	aws_iam            = false
+	aws_access_key     = "%s"
+	aws_secret_key     = "%s"
+}
+resource "aviatrix_spoke_gateway" "test_spoke_gateway_ipv6_ha" {
+	cloud_type           = 1
+	account_name         = aviatrix_account.test_acc_aws.account_name
+	gw_name              = "tfg-aws-ipv6-ha-%[1]s"
+	vpc_id               = "%[5]s"
+	vpc_reg              = "%[6]s"
+	gw_size              = "%[7]s"
+	subnet               = "%[8]s"
+	enable_ipv6          = true
+	subnet_ipv6_cidr     = "%[9]s"
+	ha_subnet            = "%[10]s"
+	ha_subnet_ipv6_cidr  = "%[11]s"
+	ha_gw_size           = "%[7]s"
+}
+	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
+		os.Getenv("AWS_VPC_ID4"), os.Getenv("AWS_REGION"), awsGwSize, os.Getenv("AWS_SUBNET4"),
+		os.Getenv("AWS_SUBNET_IPV6_CIDR"), os.Getenv("AWS_HA_SUBNET"), os.Getenv("AWS_HA_SUBNET_IPV6_CIDR"))
+}
+
+func testAccSpokeGatewayConfigAzureIPv6(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_azure" {
+	account_name        = "tfa-azure-%s"
+	cloud_type          = 8
+	arm_subscription_id = "%s"
+	arm_directory_id    = "%s"
+	arm_application_id  = "%s"
+	arm_application_key = "%s"
+}
+resource "aviatrix_spoke_gateway" "test_spoke_gateway_ipv6_azure" {
+	cloud_type       = 8
+	account_name     = aviatrix_account.test_acc_azure.account_name
+	gw_name          = "tfg-azure-ipv6-%[1]s"
+	vpc_id           = "%[6]s"
+	vpc_reg          = "%[7]s"
+	gw_size          = "%[8]s"
+	subnet           = "%[9]s"
+	enable_ipv6      = true
+	subnet_ipv6_cidr = "%[10]s"
+}
+	`, rName, os.Getenv("ARM_SUBSCRIPTION_ID"), os.Getenv("ARM_DIRECTORY_ID"),
+		os.Getenv("ARM_APPLICATION_ID"), os.Getenv("ARM_APPLICATION_KEY"),
+		os.Getenv("AZURE_VNET_ID"), os.Getenv("AZURE_REGION"),
+		os.Getenv("AZURE_GW_SIZE"), os.Getenv("AZURE_SUBNET"), os.Getenv("AZURE_SUBNET_IPV6_CIDR"))
+}
+
+// TestAccAviatrixSpokeGateway_ipv6WithInsaneMode tests IPv6 with Insane Mode enabled
+func TestAccAviatrixSpokeGateway_ipv6WithInsaneMode(t *testing.T) {
+	var gateway goaviatrix.Gateway
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_spoke_gateway.test_spoke_gateway_ipv6_insane"
+
+	msgCommon := ". Set SKIP_SPOKE_GATEWAY_IPV6_INSANE_MODE to yes to skip Spoke Gateway IPv6 Insane Mode tests"
+
+	skipGwIPv6InsaneMode := os.Getenv("SKIP_SPOKE_GATEWAY_IPV6_INSANE_MODE")
+	if skipGwIPv6InsaneMode == "yes" {
+		t.Skip("Skipping Spoke Gateway IPv6 Insane Mode test as SKIP_SPOKE_GATEWAY_IPV6_INSANE_MODE is set")
+	}
+
+	awsGwSize := os.Getenv("AWS_INSANE_MODE_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "c5.xlarge"
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAwsSpokeGatewayIPv6InsaneModeCheck(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSpokeGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpokeGatewayConfigAWSIPv6WithInsaneMode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpokeGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", fmt.Sprintf("tfg-aws-ipv6-insane-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "gw_size", awsGwSize),
+					resource.TestCheckResourceAttr(resourceName, "account_name", fmt.Sprintf("tfa-aws-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", os.Getenv("AWS_VPC_ID4")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AWS_REGION")),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ipv6_cidr", os.Getenv("AWS_SUBNET_IPV6_CIDR")),
+					resource.TestCheckResourceAttr(resourceName, "insane_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "insane_mode_az", os.Getenv("AWS_AVAILABILITY_ZONE")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"gcloud_project_credentials_filepath",
+					"vnet_and_resource_group_names",
+				},
+			},
+		},
+	})
+}
+
+func preAwsSpokeGatewayIPv6InsaneModeCheck(t *testing.T, msgCommon string) {
+	requiredEnvVars := []string{
+		"AWS_VPC_ID4",
+		"AWS_REGION",
+		"AWS_SUBNET_IPV6_CIDR",
+		"AWS_AVAILABILITY_ZONE",
+		"AWS_INSANE_MODE_SUBNET",
+	}
+	for _, v := range requiredEnvVars {
+		if os.Getenv(v) == "" {
+			t.Fatalf("Env Var %s required %s", v, msgCommon)
+		}
+	}
+}
+
+func testAccSpokeGatewayConfigAWSIPv6WithInsaneMode(rName string) string {
+	awsGwSize := os.Getenv("AWS_INSANE_MODE_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "c5.xlarge"
+	}
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_aws" {
+	account_name       = "tfa-aws-%s"
+	cloud_type         = 1
+	aws_account_number = "%s"
+	aws_iam            = false
+	aws_access_key     = "%s"
+	aws_secret_key     = "%s"
+}
+resource "aviatrix_spoke_gateway" "test_spoke_gateway_ipv6_insane" {
+	cloud_type        = 1
+	account_name      = aviatrix_account.test_acc_aws.account_name
+	gw_name           = "tfg-aws-ipv6-insane-%[1]s"
+	vpc_id            = "%[5]s"
+	vpc_reg           = "%[6]s"
+	gw_size           = "%[7]s"
+	subnet            = "%[8]s"
+	enable_ipv6       = true
+	subnet_ipv6_cidr  = "%[9]s"
+	insane_mode       = true
+	insane_mode_az    = "%[10]s"
+}
+	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
+		os.Getenv("AWS_VPC_ID4"), os.Getenv("AWS_REGION"), awsGwSize, os.Getenv("AWS_INSANE_MODE_SUBNET"),
+		os.Getenv("AWS_SUBNET_IPV6_CIDR"), os.Getenv("AWS_AVAILABILITY_ZONE"))
+}

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -42,6 +42,8 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		CustomizeDiff: resourceAviatrixTransitGatewayCustomizeDiff,
+
 		SchemaVersion: 1,
 		MigrateState:  resourceAviatrixTransitGatewayMigrateState,
 
@@ -104,6 +106,17 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				ValidateFunc: validateAzureAZ,
 				Description:  "Availability Zone. Only available for Azure (8), Azure GOV (32) and Azure CHINA (2048). Must be in the form 'az-n', for example, 'az-2'.",
 			},
+			"subnet_ipv6_cidr": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIPv6CIDR,
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					// Suppress diff when enable_ipv6 is false (field is not relevant)
+					return !d.Get("enable_ipv6").(bool)
+				},
+				Description: "IPv6 CIDR for the subnet. Only used if enable_ipv6 flag is set.Currently only supported on Azure and AWS Cloud.",
+			},
 			"insane_mode_az": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -140,6 +153,17 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 				ValidateFunc: validation.IsCIDR,
 				Description: "HA Subnet. Required for enabling HA for AWS/AWSGov/AWSChina/Azure/OCI/Alibaba Cloud. " +
 					"Optional for enabling HA for GCP gateway.",
+			},
+			"ha_subnet_ipv6_cidr": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIPv6CIDR,
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					// Suppress diff when enable_ipv6 is false (field is not relevant)
+					return !d.Get("enable_ipv6").(bool)
+				},
+				Description: "IPv6 CIDR for the HA subnet. Only used if enable_ipv6 flag is set. Currently only supported on Azure and AWS Cloud.",
 			},
 			"ha_zone": {
 				Type:        schema.TypeString,
@@ -966,6 +990,18 @@ func resourceAviatrixTransitGateway() *schema.Resource {
 	}
 }
 
+func resourceAviatrixTransitGatewayCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if err := handleIPv6SubnetForceNew(d, "subnet_ipv6_cidr"); err != nil {
+		return err
+	}
+
+	if err := handleIPv6SubnetForceNew(d, "ha_subnet_ipv6_cidr"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*goaviatrix.Client)
 
@@ -1437,6 +1473,17 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 				return fmt.Errorf("error creating gateway: enable_ipv6 is only supported for AWS (1), Azure (8)")
 			}
 			gateway.EnableIPv6 = true
+			subnetIPv6Cidr := d.Get("subnet_ipv6_cidr").(string)
+			if subnetIPv6Cidr == "" {
+				return fmt.Errorf("error creating gateway: subnet_ipv6_cidr must be set when enable_ipv6 is true")
+			}
+			gatewaySubnet := gateway.Subnet
+			// Trim any trailing '~' to normalize it first
+			gatewaySubnet = strings.TrimRight(gatewaySubnet, "~")
+
+			// Append IPv6 subnet CIDR
+			gateway.Subnet = gatewaySubnet + subnetSeparator + subnetIPv6Cidr
+
 		}
 
 		log.Printf("[INFO] Creating Aviatrix Transit Gateway: %#v", gateway)
@@ -1523,6 +1570,18 @@ func resourceAviatrixTransitGatewayCreate(d *schema.ResourceData, meta interface
 					return fmt.Errorf("%q must be set when creating a Transit HA Gateway in AWS with Private Mode enabled on the Controller", "ha_private_mode_subnet_zone")
 				}
 				transitHaGw.Subnet = haSubnet + "~~" + haPrivateModeSubnetZone
+			}
+
+			enableIpv6 := d.Get("enable_ipv6").(bool)
+			if enableIpv6 {
+				haSubnetIPv6Cidr := d.Get("ha_subnet_ipv6_cidr").(string)
+				if haSubnetIPv6Cidr == "" {
+					return fmt.Errorf("error creating HA gateway: ha_subnet_ipv6_cidr must be set when enable_ipv6 is true")
+				}
+
+				haSubnet = transitHaGw.Subnet
+				haSubnetTrimmed := strings.TrimRight(haSubnet, "~")
+				transitHaGw.Subnet = haSubnetTrimmed + subnetSeparator + haSubnetIPv6Cidr
 			}
 
 			haAzureEipName, haAzureEipNameOk := d.GetOk("ha_azure_eip_name_resource_group")
@@ -2041,6 +2100,7 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 			d.Set("ha_security_group_id", "")
 			d.Set("ha_software_version", "")
 			d.Set("ha_subnet", "")
+			d.Set("ha_subnet_ipv6_cidr", "")
 			d.Set("ha_zone", "")
 			d.Set("ha_public_ip", "")
 			d.Set("ha_private_mode_subnet_zone", "")
@@ -2126,6 +2186,8 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		if err != nil {
 			return fmt.Errorf("could not set prepend_as_path: %w", err)
 		}
+
+		d.Set("subnet_ipv6_cidr", gw.SubnetIPv6Cidr)
 		d.Set("local_as_number", gw.LocalASNumber)
 		d.Set("bgp_ecmp", gw.BgpEcmp)
 		d.Set("enable_active_standby", gw.EnableActiveStandby)
@@ -2420,11 +2482,14 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 			d.Set("ha_security_group_id", "")
 			d.Set("ha_software_version", "")
 			d.Set("ha_subnet", "")
+			d.Set("ha_subnet_ipv6_cidr", "")
 			d.Set("ha_zone", "")
 			d.Set("ha_public_ip", "")
 			d.Set("ha_private_mode_subnet_zone", "")
 			return nil
 		}
+
+		d.Set("ha_subnet_ipv6_cidr", gw.HaGw.SubnetIPv6Cidr)
 		if goaviatrix.IsCloudType(gw.HaGw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes|goaviatrix.OCIRelatedCloudTypes|goaviatrix.AliCloudRelatedCloudTypes) {
 			d.Set("ha_subnet", gw.HaGw.VpcNet)
 			if zone := d.Get("ha_zone"); goaviatrix.IsCloudType(gw.HaGw.CloudType, goaviatrix.AzureArmRelatedCloudTypes) && (isImport || zone.(string) != "") {
@@ -2770,6 +2835,18 @@ func resourceAviatrixTransitGatewayUpdate(d *schema.ResourceData, meta interface
 				transitHaGw.Subnet = strings.Join(haStrs, "~~")
 			}
 			transitHaGw.InsaneMode = "yes"
+		}
+
+		enableIpv6 := d.Get("enable_ipv6").(bool)
+		if enableIpv6 {
+			haSubnetIPv6Cidr := d.Get("ha_subnet_ipv6_cidr").(string)
+			if haSubnetIPv6Cidr == "" {
+				return fmt.Errorf("error creating HA gateway: ha_subnet_ipv6_cidr must be set when enable_ipv6 is true")
+			}
+
+			haSubnet := transitHaGw.Subnet
+			haSubnetTrimmed := strings.TrimRight(haSubnet, "~")
+			transitHaGw.Subnet = haSubnetTrimmed + subnetSeparator + haSubnetIPv6Cidr
 		}
 
 		if (newHaGwEnabled || changeHaGw) && haGwSize == "" {

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -779,6 +779,403 @@ func testAccCheckTransitGatewayDestroy(s *terraform.State) error {
 	return nil
 }
 
+// TestAccAviatrixTransitGateway_ipv6AWS tests IPv6 CIDR fields for AWS transit gateway
+func TestAccAviatrixTransitGateway_ipv6AWS(t *testing.T) {
+	var gateway goaviatrix.Gateway
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_transit_gateway.test_transit_gateway_ipv6"
+
+	msgCommon := ". Set SKIP_TRANSIT_GATEWAY_IPV6 to yes to skip Transit Gateway IPv6 tests"
+
+	skipGwIPv6 := os.Getenv("SKIP_TRANSIT_GATEWAY_IPV6")
+	if skipGwIPv6 == "yes" {
+		t.Skip("Skipping Transit Gateway IPv6 test as SKIP_TRANSIT_GATEWAY_IPV6 is set")
+	}
+
+	awsGwSize := os.Getenv("AWS_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "t2.micro"
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAwsTransitGatewayIPv6Check(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitGatewayConfigAWSIPv6(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", fmt.Sprintf("tfg-aws-transit-ipv6-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "gw_size", awsGwSize),
+					resource.TestCheckResourceAttr(resourceName, "account_name", fmt.Sprintf("tfa-aws-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", os.Getenv("AWS_VPC_ID4")),
+					resource.TestCheckResourceAttr(resourceName, "subnet", os.Getenv("AWS_SUBNET4")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AWS_REGION")),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ipv6_cidr", os.Getenv("AWS_SUBNET_IPV6_CIDR")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"gcloud_project_credentials_filepath",
+					"vnet_and_resource_group_names",
+				},
+			},
+		},
+	})
+}
+
+// TestAccAviatrixTransitGateway_ipv6WithHA tests IPv6 CIDR fields with HA enabled
+func TestAccAviatrixTransitGateway_ipv6WithHA(t *testing.T) {
+	var gateway goaviatrix.Gateway
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_transit_gateway.test_transit_gateway_ipv6_ha"
+
+	msgCommon := ". Set SKIP_TRANSIT_GATEWAY_IPV6 to yes to skip Transit Gateway IPv6 tests"
+
+	skipGwIPv6 := os.Getenv("SKIP_TRANSIT_GATEWAY_IPV6")
+	if skipGwIPv6 == "yes" {
+		t.Skip("Skipping Transit Gateway IPv6 HA test as SKIP_TRANSIT_GATEWAY_IPV6 is set")
+	}
+
+	awsGwSize := os.Getenv("AWS_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "t2.micro"
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAwsTransitGatewayIPv6HACheck(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitGatewayConfigAWSIPv6WithHA(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", fmt.Sprintf("tfg-aws-transit-ipv6-ha-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "gw_size", awsGwSize),
+					resource.TestCheckResourceAttr(resourceName, "account_name", fmt.Sprintf("tfa-aws-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", os.Getenv("AWS_VPC_ID4")),
+					resource.TestCheckResourceAttr(resourceName, "subnet", os.Getenv("AWS_SUBNET4")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AWS_REGION")),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ipv6_cidr", os.Getenv("AWS_SUBNET_IPV6_CIDR")),
+					resource.TestCheckResourceAttr(resourceName, "ha_subnet", os.Getenv("AWS_HA_SUBNET")),
+					resource.TestCheckResourceAttr(resourceName, "ha_subnet_ipv6_cidr", os.Getenv("AWS_HA_SUBNET_IPV6_CIDR")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"gcloud_project_credentials_filepath",
+					"vnet_and_resource_group_names",
+				},
+			},
+		},
+	})
+}
+
+// TestAccAviatrixTransitGateway_ipv6Azure tests IPv6 CIDR fields for Azure transit gateway
+func TestAccAviatrixTransitGateway_ipv6Azure(t *testing.T) {
+	var gateway goaviatrix.Gateway
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_transit_gateway.test_transit_gateway_ipv6_azure"
+
+	msgCommon := ". Set SKIP_TRANSIT_GATEWAY_IPV6_AZURE to yes to skip Azure Transit Gateway IPv6 tests"
+
+	skipGwIPv6Azure := os.Getenv("SKIP_TRANSIT_GATEWAY_IPV6_AZURE")
+	if skipGwIPv6Azure == "yes" {
+		t.Skip("Skipping Azure Transit Gateway IPv6 test as SKIP_TRANSIT_GATEWAY_IPV6_AZURE is set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAzureTransitGatewayIPv6Check(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitGatewayConfigAzureIPv6(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", fmt.Sprintf("tfg-azure-transit-ipv6-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "gw_size", os.Getenv("AZURE_GW_SIZE")),
+					resource.TestCheckResourceAttr(resourceName, "account_name", fmt.Sprintf("tfa-azure-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", os.Getenv("AZURE_VNET_ID")),
+					resource.TestCheckResourceAttr(resourceName, "subnet", os.Getenv("AZURE_SUBNET")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AZURE_REGION")),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ipv6_cidr", os.Getenv("AZURE_SUBNET_IPV6_CIDR")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"gcloud_project_credentials_filepath",
+					"vnet_and_resource_group_names",
+					"vpc_id",
+				},
+			},
+		},
+	})
+}
+
+func preAwsTransitGatewayIPv6Check(t *testing.T, msgCommon string) {
+	requiredEnvVars := []string{
+		"AWS_VPC_ID4",
+		"AWS_SUBNET4",
+		"AWS_REGION",
+		"AWS_SUBNET_IPV6_CIDR",
+	}
+	for _, v := range requiredEnvVars {
+		if os.Getenv(v) == "" {
+			t.Fatalf("Env Var %s required %s", v, msgCommon)
+		}
+	}
+}
+
+func preAwsTransitGatewayIPv6HACheck(t *testing.T, msgCommon string) {
+	requiredEnvVars := []string{
+		"AWS_VPC_ID4",
+		"AWS_SUBNET4",
+		"AWS_REGION",
+		"AWS_SUBNET_IPV6_CIDR",
+		"AWS_HA_SUBNET",
+		"AWS_HA_SUBNET_IPV6_CIDR",
+	}
+	for _, v := range requiredEnvVars {
+		if os.Getenv(v) == "" {
+			t.Fatalf("Env Var %s required %s", v, msgCommon)
+		}
+	}
+}
+
+func preAzureTransitGatewayIPv6Check(t *testing.T, msgCommon string) {
+	requiredEnvVars := []string{
+		"AZURE_VNET_ID",
+		"AZURE_SUBNET",
+		"AZURE_REGION",
+		"AZURE_GW_SIZE",
+		"AZURE_SUBNET_IPV6_CIDR",
+	}
+	for _, v := range requiredEnvVars {
+		if os.Getenv(v) == "" {
+			t.Fatalf("Env Var %s required %s", v, msgCommon)
+		}
+	}
+}
+
+func testAccTransitGatewayConfigAWSIPv6(rName string) string {
+	awsGwSize := os.Getenv("AWS_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "t2.micro"
+	}
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_aws" {
+	account_name       = "tfa-aws-%s"
+	cloud_type         = 1
+	aws_account_number = "%s"
+	aws_iam            = false
+	aws_access_key     = "%s"
+	aws_secret_key     = "%s"
+}
+resource "aviatrix_transit_gateway" "test_transit_gateway_ipv6" {
+	cloud_type        = 1
+	account_name      = aviatrix_account.test_acc_aws.account_name
+	gw_name           = "tfg-aws-transit-ipv6-%[1]s"
+	vpc_id            = "%[5]s"
+	vpc_reg           = "%[6]s"
+	gw_size           = "%[7]s"
+	subnet            = "%[8]s"
+	enable_ipv6       = true
+	subnet_ipv6_cidr  = "%[9]s"
+}
+	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
+		os.Getenv("AWS_VPC_ID4"), os.Getenv("AWS_REGION"), awsGwSize, os.Getenv("AWS_SUBNET4"),
+		os.Getenv("AWS_SUBNET_IPV6_CIDR"))
+}
+
+func testAccTransitGatewayConfigAWSIPv6WithHA(rName string) string {
+	awsGwSize := os.Getenv("AWS_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "t2.micro"
+	}
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_aws" {
+	account_name       = "tfa-aws-%s"
+	cloud_type         = 1
+	aws_account_number = "%s"
+	aws_iam            = false
+	aws_access_key     = "%s"
+	aws_secret_key     = "%s"
+}
+resource "aviatrix_transit_gateway" "test_transit_gateway_ipv6_ha" {
+	cloud_type           = 1
+	account_name         = aviatrix_account.test_acc_aws.account_name
+	gw_name              = "tfg-aws-transit-ipv6-ha-%[1]s"
+	vpc_id               = "%[5]s"
+	vpc_reg              = "%[6]s"
+	gw_size              = "%[7]s"
+	subnet               = "%[8]s"
+	enable_ipv6          = true
+	subnet_ipv6_cidr     = "%[9]s"
+	ha_subnet            = "%[10]s"
+	ha_subnet_ipv6_cidr  = "%[11]s"
+	ha_gw_size           = "%[7]s"
+}
+	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
+		os.Getenv("AWS_VPC_ID4"), os.Getenv("AWS_REGION"), awsGwSize, os.Getenv("AWS_SUBNET4"),
+		os.Getenv("AWS_SUBNET_IPV6_CIDR"), os.Getenv("AWS_HA_SUBNET"), os.Getenv("AWS_HA_SUBNET_IPV6_CIDR"))
+}
+
+func testAccTransitGatewayConfigAzureIPv6(rName string) string {
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_azure" {
+	account_name        = "tfa-azure-%s"
+	cloud_type          = 8
+	arm_subscription_id = "%s"
+	arm_directory_id    = "%s"
+	arm_application_id  = "%s"
+	arm_application_key = "%s"
+}
+resource "aviatrix_transit_gateway" "test_transit_gateway_ipv6_azure" {
+	cloud_type       = 8
+	account_name     = aviatrix_account.test_acc_azure.account_name
+	gw_name          = "tfg-azure-transit-ipv6-%[1]s"
+	vpc_id           = "%[6]s"
+	vpc_reg          = "%[7]s"
+	gw_size          = "%[8]s"
+	subnet           = "%[9]s"
+	enable_ipv6      = true
+	subnet_ipv6_cidr = "%[10]s"
+}
+	`, rName, os.Getenv("ARM_SUBSCRIPTION_ID"), os.Getenv("ARM_DIRECTORY_ID"),
+		os.Getenv("ARM_APPLICATION_ID"), os.Getenv("ARM_APPLICATION_KEY"),
+		os.Getenv("AZURE_VNET_ID"), os.Getenv("AZURE_REGION"),
+		os.Getenv("AZURE_GW_SIZE"), os.Getenv("AZURE_SUBNET"), os.Getenv("AZURE_SUBNET_IPV6_CIDR"))
+}
+
+// TestAccAviatrixTransitGateway_ipv6WithInsaneMode tests IPv6 with Insane Mode enabled
+func TestAccAviatrixTransitGateway_ipv6WithInsaneMode(t *testing.T) {
+	var gateway goaviatrix.Gateway
+
+	rName := acctest.RandString(5)
+	resourceName := "aviatrix_transit_gateway.test_transit_gateway_ipv6_insane"
+
+	msgCommon := ". Set SKIP_TRANSIT_GATEWAY_IPV6_INSANE_MODE to yes to skip Transit Gateway IPv6 Insane Mode tests"
+
+	skipGwIPv6InsaneMode := os.Getenv("SKIP_TRANSIT_GATEWAY_IPV6_INSANE_MODE")
+	if skipGwIPv6InsaneMode == "yes" {
+		t.Skip("Skipping Transit Gateway IPv6 Insane Mode test as SKIP_TRANSIT_GATEWAY_IPV6_INSANE_MODE is set")
+	}
+
+	awsGwSize := os.Getenv("AWS_INSANE_MODE_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "c5.xlarge"
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAwsTransitGatewayIPv6InsaneModeCheck(t, msgCommon)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitGatewayConfigAWSIPv6WithInsaneMode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "gw_name", fmt.Sprintf("tfg-aws-transit-ipv6-insane-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "gw_size", awsGwSize),
+					resource.TestCheckResourceAttr(resourceName, "account_name", fmt.Sprintf("tfa-aws-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", os.Getenv("AWS_VPC_ID4")),
+					resource.TestCheckResourceAttr(resourceName, "vpc_reg", os.Getenv("AWS_REGION")),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ipv6_cidr", os.Getenv("AWS_SUBNET_IPV6_CIDR")),
+					resource.TestCheckResourceAttr(resourceName, "insane_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "insane_mode_az", os.Getenv("AWS_AVAILABILITY_ZONE")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"gcloud_project_credentials_filepath",
+					"vnet_and_resource_group_names",
+				},
+			},
+		},
+	})
+}
+
+func preAwsTransitGatewayIPv6InsaneModeCheck(t *testing.T, msgCommon string) {
+	requiredEnvVars := []string{
+		"AWS_VPC_ID4",
+		"AWS_REGION",
+		"AWS_SUBNET_IPV6_CIDR",
+		"AWS_AVAILABILITY_ZONE",
+		"AWS_INSANE_MODE_SUBNET",
+	}
+	for _, v := range requiredEnvVars {
+		if os.Getenv(v) == "" {
+			t.Fatalf("Env Var %s required %s", v, msgCommon)
+		}
+	}
+}
+
+func testAccTransitGatewayConfigAWSIPv6WithInsaneMode(rName string) string {
+	awsGwSize := os.Getenv("AWS_INSANE_MODE_GW_SIZE")
+	if awsGwSize == "" {
+		awsGwSize = "c5.xlarge"
+	}
+	return fmt.Sprintf(`
+resource "aviatrix_account" "test_acc_aws" {
+	account_name       = "tfa-aws-%s"
+	cloud_type         = 1
+	aws_account_number = "%s"
+	aws_iam            = false
+	aws_access_key     = "%s"
+	aws_secret_key     = "%s"
+}
+resource "aviatrix_transit_gateway" "test_transit_gateway_ipv6_insane" {
+	cloud_type        = 1
+	account_name      = aviatrix_account.test_acc_aws.account_name
+	gw_name           = "tfg-aws-transit-ipv6-insane-%[1]s"
+	vpc_id            = "%[5]s"
+	vpc_reg           = "%[6]s"
+	gw_size           = "%[7]s"
+	subnet            = "%[8]s"
+	enable_ipv6       = true
+	subnet_ipv6_cidr  = "%[9]s"
+	insane_mode       = true
+	insane_mode_az    = "%[10]s"
+}
+	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
+		os.Getenv("AWS_VPC_ID4"), os.Getenv("AWS_REGION"), awsGwSize, os.Getenv("AWS_INSANE_MODE_SUBNET"),
+		os.Getenv("AWS_SUBNET_IPV6_CIDR"), os.Getenv("AWS_AVAILABILITY_ZONE"))
+}
+
 func TestGetInterfaceMappingDetails(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/aviatrix/utils.go
+++ b/aviatrix/utils.go
@@ -20,6 +20,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func validateIPv6CIDR(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	ip, _, err := net.ParseCIDR(v)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("expected %s to contain a valid IPv6 CIDR, got: %s (%w)", k, v, err))
+		return warnings, errors
+	}
+
+	// Reject IPv4 CIDRs
+	if ip.To4() != nil {
+		errors = append(errors, fmt.Errorf("expected %s to contain an IPv6 CIDR, got IPv4: %s", k, v))
+		return warnings, errors
+	}
+
+	return warnings, errors
+}
+
 // validateAzureAZ is a SchemaValidateFunc for Azure Availability Zone
 // parameters.
 func validateAzureAZ(i interface{}, k string) (warnings []string, errors []error) {

--- a/docs/resources/aviatrix_spoke_gateway.md
+++ b/docs/resources/aviatrix_spoke_gateway.md
@@ -264,6 +264,7 @@ resource "aviatrix_spoke_gateway" "test_spoke_gateway_aws" {
   vpc_reg           = "us-west-1"
   gw_size           = "t2.micro"
   subnet            = "10.11.0.0/24"
+  subnet_ipv6_cidr  = "2600:1f16:11b3:4900::/64"
   enable_ipv6       = true
 }
 ```
@@ -292,6 +293,7 @@ The following arguments are supported:
 ### HA
 * `single_az_ha` (Optional) Set to true if this [feature](https://docs.aviatrix.com/Solutions/gateway_ha.html#single-az-gateway) is desired. Valid values: true, false.
 * `ha_subnet` - (Optional) HA Subnet. Required if enabling HA for AWS, AWSGov, AWSChina, Azure, AzureGov, AzureChina, OCI, Alibaba Cloud, AWS Top Secret or AWS Secret gateways. Optional for GCP. Setting to empty/unsetting will disable HA. Setting to a valid subnet CIDR will create an HA gateway on the subnet. Example: "10.12.0.0/24"
+* `ha_subnet_ipv6_cidr` - (Optional/Computed) The IPv6 CIDR block of the subnet used to create the HA Spoke Gateway. This argument is supported only on AWS, Azure, AzureGov, and AWSGov. Required when creating a gateway with `enable_ipv6` set to true and HA is enabled. When enabling IPv6 on an existing gateway with HA, this value will be computed from the controller. Changing this value while IPv6 is enabled will force recreation of the gateway.
 * `ha_zone` - (Optional) HA Zone. Required if enabling HA for GCP gateway. Optional for Azure. For GCP, setting to empty/unsetting will disable HA and setting to a valid zone will create an HA gateway in the zone. Example: "us-west1-c". For Azure, this is an optional parameter to place the HA gateway in a specific availability zone. Valid values for Azure gateways are in the form "az-n". Example: "az-2". Available for Azure as of provider version R2.17+.
 * `ha_insane_mode_az` (Optional) AZ of subnet being created for Insane Mode Spoke HA Gateway. Required for AWS, AzureGov, AWSGov, AWS Top Secret and AWS Secret if `insane_mode` is enabled and `ha_subnet` is set. Example: AWS: "us-west-1a".
 * `ha_eip` - (Optional) Public IP address that you want to assign to the HA peering instance. If no value is given, a new EIP will automatically be allocated. Only available for AWS, GCP, Azure, OCI, AzureGov, AWSGov, AWSChina, AzureChina, AWS Top Secret and AWS Secret.
@@ -399,6 +401,7 @@ The following arguments are supported:
 * `private_mode_subnet_zone` - (Optional) Availability Zone of the subnet. Required when Private Mode is enabled on the Controller and `cloud_type` is AWS or AWSGov. Available in Provider version R2.23+.
 * `ha_private_mode_subnet_zone` - (Optional) Availability Zone of the HA subnet. Required when Private Mode is enabled on the Controller and `cloud_type` is AWS or AWSGov with HA. Available in Provider version R2.23+.
 * `enable_ipv6` - (Optional) To enable IPv6 CIDR in Spoke Gateway. Only AWS, Azure, AzureGov and AWSGov are supported.
+* `subnet_ipv6_cidr` - (Optional/Computed) The IPv6 CIDR block of the subnet used to create the Spoke Gateway. This argument is supported only on AWS, Azure, AzureGov, and AWSGov. Required when creating a gateway with `enable_ipv6` set to true. When enabling IPv6 on an existing gateway, this value will be computed from the controller. Changing this value while IPv6 is enabled will force recreation of the gateway.
 * `tunnel_encryption_cipher` - (Optional) Encryption ciphers for gateway peering tunnels. Config options are default (AES-126-GCM-96) or strong (AES-256-GCM-96).
 * `tunnel_forward_secrecy` - (Optional) Perfect Forward Secrecy (PFS) for gateway peering tunnels. Config Options are enable/disable.
 

--- a/docs/resources/aviatrix_transit_gateway.md
+++ b/docs/resources/aviatrix_transit_gateway.md
@@ -414,7 +414,8 @@ resource "aviatrix_transit_gateway" "test_transit_gateway_aws" {
   gw_size                  = "t2.micro"
   subnet                   = "10.1.0.0/24"
   connected_transit        = true
-  enable_ipv6 = true
+  enable_ipv6              = true
+  subnet_ipv6_cidr         = "2600:1f16:11b3:4800::/64"
 }
 ```
 
@@ -462,6 +463,7 @@ The following arguments are supported:
 ### HA
 * `single_az_ha` (Optional) Set to true if this [feature](https://docs.aviatrix.com/Solutions/gateway_ha.html#single-az-gateway) is desired. Valid values: true, false.
 * `ha_subnet` - (Optional) HA Subnet CIDR. Required only if enabling HA for AWS, Azure, AzureGov, AWSGov, AWSChina, AzureChina, OCI, Alibaba Cloud, AWS Top Secret or AWS Secret gateways. Optional for GCP. Setting to empty/unsetting will disable HA. Setting to a valid subnet CIDR will create an HA gateway on the subnet. Example: "10.12.0.0/24".
+* `ha_subnet_ipv6_cidr` - (Optional/Computed) The IPv6 CIDR block of the subnet used to create the HA Transit Gateway. This argument is supported only on AWS, Azure, AzureGov, and AWSGov. Required when creating a gateway with `enable_ipv6` set to true and HA is enabled. When enabling IPv6 on an existing gateway with HA, this value will be computed from the controller. Changing this value while IPv6 is enabled will force recreation of the gateway.
 * `ha_zone` - (Optional) HA Zone. Required if enabling HA for GCP gateway. Optional if enabling HA for Azure gateway. For GCP, setting to empty/unsetting will disable HA and setting to a valid zone will create an HA gateway in the zone. Example: "us-west1-c". For Azure, this is an optional parameter to place the HA gateway in a specific availability zone. Valid values for Azure gateways are in the form "az-n". Example: "az-2". Available for Azure as of provider version R2.17+.
 * `ha_insane_mode_az` - (Optional) AZ of subnet being created for Insane Mode Transit HA Gateway. Required for AWS, AWSGov, AWSChina, AWS Top Secret and AWS Secret if `insane_mode` is enabled and `ha_subnet` is set. Example: AWS: "us-west-1a".
 * `ha_eip` - (Optional) Public IP address that you want to assign to the HA peering instance. If no value is given, a new EIP will automatically be allocated. Only available for AWS, GCP, Azure, OCI, AzureGov, AWSGov, AWSChina, AzureChina, AWS Top Secret and AWS Secret.
@@ -510,6 +512,7 @@ The following arguments are supported:
 * `enable_s2c_rx_balancing` - (Optional) Enable S2C receive packet CPU re-balancing on transit gateway. Valid values: true, false. Default value: false. Available in provider version R2.21.2+.
 * `enable_preserve_as_path` - (Optional) Enable preserve as_path when advertising manual summary cidrs on transit gateway. Valid values: true, false. Default value: false. Available as of provider version R.2.22.1+.
 * `enable_ipv6` - (Optional) To enable IPv6 CIDR in Transit Gateway. Only AWS, Azure, AzureGov and AWSGov are supported.
+* `subnet_ipv6_cidr` - (Optional/Computed) The IPv6 CIDR block of the subnet used to create the Transit Gateway. This argument is supported only on AWS, Azure, AzureGov, and AWSGov. Required when creating a gateway with `enable_ipv6` set to true. When enabling IPv6 on an existing gateway, this value will be computed from the controller. Changing this value while IPv6 is enabled will force recreation of the gateway.
 * `tunnel_encryption_cipher` - (Optional) Encryption ciphers for gateway peering tunnels. Config options are default (AES-126-GCM-96) or strong (AES-256-GCM-96).
 * `tunnel_forward_secrecy` - (Optional) Perfect Forward Secrecy (PFS) for gateway peering tunnels. Config Options are enable/disable.
 

--- a/goaviatrix/gateway.go
+++ b/goaviatrix/gateway.go
@@ -235,6 +235,7 @@ type Gateway struct {
 	EdgeGateway                     bool                                `json:"edge_gateway,omitempty"`
 	EnableIPv6                      bool                                `json:"enable_ipv6,omitempty"`
 	InsertionGateway                bool                                `json:"insertion_gateway,omitempty"`
+	SubnetIPv6Cidr                  string                              `json:"gw_subnet_ipv6_cidr,omitempty"`
 	TunnelEncryptionCipher          string                              `json:"ph2_encryption_policy,omitempty"`
 	TunnelForwardSecrecy            string                              `json:"ph2_pfs_policy,omitempty"`
 }
@@ -260,6 +261,7 @@ type HaGateway struct {
 	DeviceID                 string                 `json:"edge_csp_device_id,omitempty"`
 	Interfaces               []EdgeTransitInterface `json:"interfaces,omitempty"`
 	ManagementEgressIPPrefix string                 `json:"mgmt_egress_ip,omitempty"`
+	SubnetIPv6Cidr           string                 `json:"gw_subnet_ipv6_cidr,omitempty"`
 }
 
 type BackupLinkInfo struct {


### PR DESCRIPTION
… (#2423)

* AVX-68721 Add support foripv6 gateway creation with ipv6 subnet cidr with HA/HPE support

* Add support for IPv6 CIDR in spoke and transit gateways with customization for state changes

* Addressed comments

* Fixed linting error

* Refactor subnet concatenation for IPv6 CIDR in transit gateway to use a configurable separator

* Fixed errors

* Refactor IPv6 subnet handling in spoke and transit gateway customization to use a shared function for ForceNew logic

* Fix error message formatting in IPv6 CIDR validation and clean up whitespace in transit gateway customization function

* Added UT

---------



(cherry picked from commit 7324467bc15e8edb62c49ae8f4312f9e55edacf6)