### PR TITLE
AVX-70603 IPS Profile VPC update

### DIFF
--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -28,7 +28,7 @@ Last updated: R8.1.10 (8.1.10)
 2.  Added support for managing DCF IPS profiles. This resource enables users to define IPS profiles, associate custom and external rule feeds, and configure intrusion actions for different severity levels.
 **aviatrix_dcf_ips_profile**
 
-3.  Added support for assigning one or more DCF IPS profiles to a specific VPC. This resource allows users to manage the list of IPS profiles applied to a VPC for DCF protection, and supports clearing all profiles from a VPC. **aviatrix_dcf_ips_profile_vpc**
+3.  Added support for assigning one DCF IPS profile to a specific VPC. This resource allows users to assign a IPS profiles to a VPC for DCF intrusion analysis, and supports clearing all profiles from a VPC. **aviatrix_dcf_ips_profile_vpc**
 
 4.  Added **aviatrix_dcf_tls_profile** resource which would allow CRUD operations for DCF TLS Profile.
 

--- a/docs/resources/aviatrix_dcf_ips_profile_vpc.md
+++ b/docs/resources/aviatrix_dcf_ips_profile_vpc.md
@@ -17,8 +17,7 @@ The **aviatrix_dcf_ips_profile_vpc** resource allows you to manage the list of D
 resource "aviatrix_dcf_ips_profile_vpc" "example" {
   vpc_id = "vpc-0a1b2c3d4e5f67890"
   dcf_ips_profiles = [
-    aviatrix_dcf_ips_profile.profile1.uuid,
-    aviatrix_dcf_ips_profile.profile2.uuid
+    aviatrix_dcf_ips_profile.profile1.uuid
   ]
 }
 
@@ -38,7 +37,7 @@ The following arguments are supported:
 - `vpc_id` - (Required) The VPC ID to which DCF IPS Profiles will be assigned.
 The VPC must have a DCF-applied gateway and must be created before the `aviatrix_dcf_ips_profile_vpc` resource is defined. Type: String
 
-- `dcf_ips_profiles` - (Required) List of DCF IPS profile UUIDs to assign to the VPC. Use an empty list to clear all profiles. Type: List(String).
+- `dcf_ips_profiles` – (Required) List of DCF IPS profile UUIDs to assign to the VPC. Set to an empty list (`[]`) to remove all profiles. Only one IPS profile can be assigned per VPC on Controller version 8.2. Type: `list(string)`.
 
 ## Import
 


### PR DESCRIPTION
- Update the release notes for applying IPS profiles to VPC. (only one IPS profile per VPC is supported in controller version 8.2)

- Update the code to handle destroying the IPS-Profile-VPC resource. (If the user manually deletes the Gateway or VPC before disassociating the IPS profile from it, Terraform can still destroy the resource.)

### Test
```
Plan: 0 to add, 0 to change, 2 to destroy.
Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.
  Enter a value: yes
aviatrix_dcf_ips_profile.ips_profile: Destroying... [id=142ca577-fe67-4f42-9bc2-18ee603a23d5]
aviatrix_vpc.vpc_1: Destroying... [id=tf-ips-new-vpc3]
aviatrix_dcf_ips_profile.ips_profile: Destruction complete after 0s
aviatrix_vpc.vpc_1: Destruction complete after 6s
Destroy complete! Resources: 2 destroyed.
```