### PR TITLE
AVX-71366 Support log profile on the default action rule

### DIFF
--- a/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule.go
@@ -35,6 +35,11 @@ func resourceAviatrixDistributedFirewallingDefaultActionRule() *schema.Resource 
 				Required:    true,
 				Description: "Boolean value to enable or disable logging for the default action rule.",
 			},
+			"log_profile": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Logging profile UUID for the default action rule.",
+			},
 		},
 	}
 }
@@ -58,6 +63,10 @@ func resourceAviatrixDistributedFirewallingDefaultActionRuleUpdate(ctx context.C
 	defaultActionRuleConfig := &goaviatrix.DistributedFirewallingDefaultActionRule{
 		Action:  action,
 		Logging: logging,
+	}
+
+	if logProfile, ok := d.GetOk("log_profile"); ok {
+		defaultActionRuleConfig.LogProfile = logProfile.(string)
 	}
 
 	if err := client.UpdateDistributedFirewallingDefaultActionRule(ctx, defaultActionRuleConfig); err != nil {
@@ -87,6 +96,10 @@ func resourceAviatrixDistributedFirewallingDefaultActionRuleCreate(ctx context.C
 	defaultActionRuleConfig := &goaviatrix.DistributedFirewallingDefaultActionRule{
 		Action:  action,
 		Logging: logging,
+	}
+
+	if logProfile, ok := d.GetOk("log_profile"); ok {
+		defaultActionRuleConfig.LogProfile = logProfile.(string)
 	}
 
 	if err := client.UpdateDistributedFirewallingDefaultActionRule(ctx, defaultActionRuleConfig); err != nil {
@@ -125,6 +138,10 @@ func resourceAviatrixDistributedFirewallingDefaultActionRuleRead(ctx context.Con
 		return diag.Errorf("failed to set 'logging': %v", err)
 	}
 
+	if err := d.Set("log_profile", defaultActionRule.LogProfile); err != nil {
+		return diag.Errorf("failed to set 'log_profile': %v", err)
+	}
+
 	d.SetId(strings.ReplaceAll(client.ControllerIP, ".", "-"))
 	return nil
 }
@@ -136,8 +153,9 @@ func resourceAviatrixDistributedFirewallingDefaultActionRuleDelete(ctx context.C
 	}
 
 	defaultActionRuleConfig := &goaviatrix.DistributedFirewallingDefaultActionRule{
-		Action:  "PERMIT",
-		Logging: false,
+		Action:     "PERMIT",
+		Logging:    false,
+		LogProfile: "",
 	}
 
 	if err := client.UpdateDistributedFirewallingDefaultActionRule(ctx, defaultActionRuleConfig); err != nil {

--- a/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule.go
@@ -38,6 +38,7 @@ func resourceAviatrixDistributedFirewallingDefaultActionRule() *schema.Resource 
 			"log_profile": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Logging profile UUID for the default action rule.",
 			},
 		},
@@ -138,8 +139,12 @@ func resourceAviatrixDistributedFirewallingDefaultActionRuleRead(ctx context.Con
 		return diag.Errorf("failed to set 'logging': %v", err)
 	}
 
-	if err := d.Set("log_profile", defaultActionRule.LogProfile); err != nil {
-		return diag.Errorf("failed to set 'log_profile': %v", err)
+	// Only update log_profile if the API returns a non-empty value
+	// This preserves the configured value if the API doesn't return it
+	if defaultActionRule.LogProfile != "" {
+		if err := d.Set("log_profile", defaultActionRule.LogProfile); err != nil {
+			return diag.Errorf("failed to set 'log_profile': %v", err)
+		}
 	}
 
 	d.SetId(strings.ReplaceAll(client.ControllerIP, ".", "-"))

--- a/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule.go
@@ -139,8 +139,7 @@ func resourceAviatrixDistributedFirewallingDefaultActionRuleRead(ctx context.Con
 		return diag.Errorf("failed to set 'logging': %v", err)
 	}
 
-	// Only update log_profile if the API returns a non-empty value
-	// This preserves the configured value if the API doesn't return it
+	// Only update log_profile if the API returns a non-empty value, it's empty by default
 	if defaultActionRule.LogProfile != "" {
 		if err := d.Set("log_profile", defaultActionRule.LogProfile); err != nil {
 			return diag.Errorf("failed to set 'log_profile': %v", err)

--- a/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule_test.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule_test.go
@@ -2,7 +2,6 @@ package aviatrix
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -28,27 +27,26 @@ func TestAccAviatrixDistributedFirewallingDefaultActionRule_basic(t *testing.T) 
 		CheckDestroy: testAccDistributedFirewallingDefaultActionRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDistributedFirewallingDefaultActionRuleBasic(),
+				Config: `
+				data "aviatrix_dcf_log_profile" "start" {
+				  profile_name = "start"
+				}
+
+				resource "aviatrix_distributed_firewalling_default_action_rule" "test" {
+				  action      = "PERMIT"
+				  logging     = true
+				  log_profile = data.aviatrix_dcf_log_profile.start.profile_id
+				}`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributedFirewallingDefaultActionRuleExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "action", "PERMIT"),
 					resource.TestCheckResourceAttr(resourceName, "logging", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_profile"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_profile", "data.aviatrix_dcf_log_profile.start", "profile_id"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
-}
-
-func testAccDistributedFirewallingDefaultActionRuleBasic() string {
-	return `resource "aviatrix_distributed_firewalling_default_action_rule" "test" {
-    			action  = "PERMIT"
-    			logging = true
-			}`
 }
 
 func testAccCheckDistributedFirewallingDefaultActionRuleExists(n string) resource.TestCheckFunc {
@@ -92,9 +90,14 @@ func testAccDistributedFirewallingDefaultActionRuleDestroy(s *terraform.State) e
 			continue
 		}
 
-		_, err := client.GetDistributedFirewallingDefaultActionRule(context.Background())
-		if err == nil || !errors.Is(err, goaviatrix.ErrNotFound) {
-			return fmt.Errorf("distributed firewalling default action rule configured when it should be destroyed")
+		rule, err := client.GetDistributedFirewallingDefaultActionRule(context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to get distributed firewalling default action rule: %v", err)
+		}
+
+		// Check that the rule has been reset to defaults
+		if rule.Action != "PERMIT" && rule.Logging != false && rule.LogProfile != "" {
+			return fmt.Errorf("distributed firewalling default action rule not reset to defaults: action=%s, logging=%t", rule.Action, rule.Logging)
 		}
 	}
 

--- a/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule_test.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule_test.go
@@ -96,7 +96,7 @@ func testAccDistributedFirewallingDefaultActionRuleDestroy(s *terraform.State) e
 		}
 
 		// Check that the rule has been reset to defaults
-		if rule.Action != "PERMIT" && rule.Logging != false && rule.LogProfile != "" {
+		if rule.Action != "PERMIT" || rule.Logging != false || rule.LogProfile != "" {
 			return fmt.Errorf("distributed firewalling default action rule not reset to defaults: action=%s, logging=%t", rule.Action, rule.Logging)
 		}
 	}

--- a/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule_test.go
+++ b/aviatrix/resource_aviatrix_distributed_firewalling_default_action_rule_test.go
@@ -92,7 +92,7 @@ func testAccDistributedFirewallingDefaultActionRuleDestroy(s *terraform.State) e
 
 		rule, err := client.GetDistributedFirewallingDefaultActionRule(context.Background())
 		if err != nil {
-			return fmt.Errorf("failed to get distributed firewalling default action rule: %v", err)
+			return fmt.Errorf("failed to get distributed firewalling default action rule: %w", err)
 		}
 
 		// Check that the rule has been reset to defaults

--- a/docs/resources/aviatrix_distributed_firewalling_default_action_rule.md
+++ b/docs/resources/aviatrix_distributed_firewalling_default_action_rule.md
@@ -24,6 +24,28 @@ resource "aviatrix_distributed_firewalling_default_action_rule" "test" {
 }
 ```
 
+```hcl
+# Create an Aviatrix Distributed Firewalling Default Action Rule with custom log profile
+data "aviatrix_dcf_log_profile" "all" {
+  profile_name = "start/end"
+}
+
+<!-- data "aviatrix_dcf_log_profile" "start" {
+  profile_name = "start"
+} -->
+
+<!-- data "aviatrix_dcf_log_profile" "end" {
+  profile_name = "end"
+} -->
+
+
+resource "aviatrix_distributed_firewalling_default_action_rule" "test_with_log_profile" {
+  action      = "DENY"
+  logging     = true
+  log_profile = data.aviatrix_dcf_log_profile.all.profile_id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -31,6 +53,12 @@ The following arguments are supported:
 ### Required
     * `action` - (Required) Action for the rule. Must be one of PERMIT or DENY. Type: String.
     * `logging` - (Required) Whether to enable logging for packets that match the rule. Type: Boolean.
+
+### Optional
+    * `log_profile` - (Optional) Logging profile UUID. There are 3 system defined log profiles that can be referenced using the `aviatrix_dcf_log_profile` data source:
+        1. `start` - Log profile for logging session start only
+        2. `end` - Log profile for logging session end only
+        3. `start/end` - Log profile for logging session start and end
 
 ## Import
 

--- a/docs/resources/aviatrix_distributed_firewalling_default_action_rule.md
+++ b/docs/resources/aviatrix_distributed_firewalling_default_action_rule.md
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 ### Optional
     * `log_profile` - (Optional) Logging profile UUID. There are 3 system defined log profiles that can be referenced using the `aviatrix_dcf_log_profile` data source:
-        1. `start` - Log profile for logging session start only
+        1. `start` - Log profile for logging session start only. If no log profile is provided, this will be used by default.
         2. `end` - Log profile for logging session end only
         3. `start/end` - Log profile for logging session start and end
 

--- a/goaviatrix/distributed_firewalling_default_action_rule.go
+++ b/goaviatrix/distributed_firewalling_default_action_rule.go
@@ -8,8 +8,9 @@ import (
 const distributedFirewallingDefaultActionRuleEndpoint = "microseg/default-action-policy"
 
 type DistributedFirewallingDefaultActionRule struct {
-	Action  string `json:"action"`
-	Logging bool   `json:"logging"`
+	Action     string `json:"action"`
+	Logging    bool   `json:"logging"`
+	LogProfile string `json:"log_profile"`
 }
 
 func (c *Client) UpdateDistributedFirewallingDefaultActionRule(ctx context.Context, request *DistributedFirewallingDefaultActionRule) error {
@@ -25,8 +26,9 @@ func (c *Client) GetDistributedFirewallingDefaultActionRule(ctx context.Context)
 	}
 
 	result := &DistributedFirewallingDefaultActionRule{
-		Action:  response.Action,
-		Logging: response.Logging,
+		Action:     response.Action,
+		Logging:    response.Logging,
+		LogProfile: response.LogProfile,
 	}
 
 	return result, nil


### PR DESCRIPTION
Adding the new field log_profile into the default action rule.

Test manually on the ctrl and also the unit test
```
TF_ACC=1 go test -v ./aviatrix -run TestAccAviatrixDistributedFirewallingDefaultActionRule_basic -timeout 30m

--- PASS: TestAccAviatrixDistributedFirewallingDefaultActionRule_basic (6.02s)
PASS
ok      github.com/AviatrixSystems/terraform-provider-aviatrix/v3/aviatrix      6.055s
```