### PR TITLE
AVX-71380 Added backup_remote_lan_ipv6_ip for BGP over LAN

### DIFF
--- a/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_edge_spoke_external_device_conn_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccAviatrixEdgeSpokeExternalDeviceConn_basic(t *testing.T) {
@@ -201,4 +203,53 @@ func testAccCheckEdgeSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func TestEdgeSpokeExternalDeviceConnSchema_RemoteLanIPv6Fields(t *testing.T) {
+	resource := resourceAviatrixEdgeSpokeExternalDeviceConn()
+	schemaMap := resource.Schema
+
+	// Test remote_lan_ipv6_ip field exists and has correct properties
+	remoteLanIPv6Field, ok := schemaMap["remote_lan_ipv6_ip"]
+	assert.True(t, ok, "remote_lan_ipv6_ip field should exist in schema")
+	assert.Equal(t, schema.TypeString, remoteLanIPv6Field.Type)
+	assert.True(t, remoteLanIPv6Field.Optional, "remote_lan_ipv6_ip should be optional")
+	assert.True(t, remoteLanIPv6Field.Computed, "remote_lan_ipv6_ip should be computed")
+	assert.True(t, remoteLanIPv6Field.ForceNew, "remote_lan_ipv6_ip should be ForceNew")
+	assert.Contains(t, remoteLanIPv6Field.Description, "Remote LAN IPv6 address")
+
+	// Test backup_remote_lan_ipv6_ip field exists and has correct properties
+	backupRemoteLanIPv6Field, ok := schemaMap["backup_remote_lan_ipv6_ip"]
+	assert.True(t, ok, "backup_remote_lan_ipv6_ip field should exist in schema")
+	assert.Equal(t, schema.TypeString, backupRemoteLanIPv6Field.Type)
+	assert.True(t, backupRemoteLanIPv6Field.Optional, "backup_remote_lan_ipv6_ip should be optional")
+	assert.True(t, backupRemoteLanIPv6Field.Computed, "backup_remote_lan_ipv6_ip should be computed")
+	assert.True(t, backupRemoteLanIPv6Field.ForceNew, "backup_remote_lan_ipv6_ip should be ForceNew")
+	assert.Contains(t, backupRemoteLanIPv6Field.Description, "Backup Remote LAN IPv6 address")
+}
+
+func TestEdgeSpokeExternalDeviceConnSchema_RemoteLanIPv6FieldsReference(t *testing.T) {
+	// Test that remote_lan_ipv6_ip follows the same pattern as remote_lan_ip
+	resource := resourceAviatrixEdgeSpokeExternalDeviceConn()
+	schemaMap := resource.Schema
+
+	remoteLanIPField, ok := schemaMap["remote_lan_ip"]
+	assert.True(t, ok, "remote_lan_ip field should exist for reference")
+
+	remoteLanIPv6Field, ok := schemaMap["remote_lan_ipv6_ip"]
+	assert.True(t, ok, "remote_lan_ipv6_ip field should exist")
+
+	// Both should be TypeString
+	assert.Equal(t, remoteLanIPField.Type, remoteLanIPv6Field.Type, "remote_lan_ipv6_ip should have same type as remote_lan_ip")
+	assert.Equal(t, remoteLanIPField.ForceNew, remoteLanIPv6Field.ForceNew, "remote_lan_ipv6_ip should have same ForceNew as remote_lan_ip")
+
+	// Test backup fields follow same pattern
+	backupRemoteLanIPField, ok := schemaMap["backup_remote_lan_ip"]
+	assert.True(t, ok, "backup_remote_lan_ip field should exist for reference")
+
+	backupRemoteLanIPv6Field, ok := schemaMap["backup_remote_lan_ipv6_ip"]
+	assert.True(t, ok, "backup_remote_lan_ipv6_ip field should exist")
+
+	assert.Equal(t, backupRemoteLanIPField.Type, backupRemoteLanIPv6Field.Type, "backup_remote_lan_ipv6_ip should have same type as backup_remote_lan_ip")
+	assert.Equal(t, backupRemoteLanIPField.ForceNew, backupRemoteLanIPv6Field.ForceNew, "backup_remote_lan_ipv6_ip should have same ForceNew as backup_remote_lan_ip")
 }

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn.go
@@ -474,6 +474,13 @@ func resourceAviatrixSpokeExternalDeviceConn() *schema.Resource {
 				ForceNew:    true,
 				Description: "Remote LAN IPv6 address.",
 			},
+			"backup_remote_lan_ipv6_ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Backup Remote LAN IPv6 address.",
+			},
 		},
 	}
 }
@@ -516,6 +523,7 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 		ExternalDeviceIPv6:       d.Get("external_device_ipv6").(string),
 		ExternalDeviceBackupIPv6: d.Get("external_device_backup_ipv6").(string),
 		RemoteLanIPv6:            d.Get("remote_lan_ipv6_ip").(string),
+		BackupRemoteLanIPv6:      d.Get("backup_remote_lan_ipv6_ip").(string),
 	}
 
 	sendComm, ok := d.Get("connection_bgp_send_communities").(string)
@@ -649,6 +657,9 @@ func resourceAviatrixSpokeExternalDeviceConnCreate(d *schema.ResourceData, meta 
 		if externalDeviceConn.TunnelProtocol == "LAN" {
 			if externalDeviceConn.BackupRemoteLanIP == "" {
 				return fmt.Errorf("ha is enabled and 'tunnel_protocol' = 'LAN', please specify 'backup_remote_lan_ip'")
+			}
+			if externalDeviceConn.EnableIpv6 && externalDeviceConn.BackupRemoteLanIPv6 == "" {
+				return fmt.Errorf("ha is enabled, 'tunnel_protocol' = 'LAN' and 'enable_ipv6' is true, please specify 'backup_remote_lan_ipv6_ip'")
 			}
 		} else {
 			if externalDeviceConn.BackupRemoteGatewayIP == "" {

--- a/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_spoke_external_device_conn_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccAviatrixSpokeExternalDeviceConn_basic(t *testing.T) {
@@ -160,4 +162,53 @@ func testAccCheckSpokeExternalDeviceConnDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func TestSpokeExternalDeviceConnSchema_RemoteLanIPv6Fields(t *testing.T) {
+	resource := resourceAviatrixSpokeExternalDeviceConn()
+	schemaMap := resource.Schema
+
+	// Test remote_lan_ipv6_ip field exists and has correct properties
+	remoteLanIPv6Field, ok := schemaMap["remote_lan_ipv6_ip"]
+	assert.True(t, ok, "remote_lan_ipv6_ip field should exist in schema")
+	assert.Equal(t, schema.TypeString, remoteLanIPv6Field.Type)
+	assert.True(t, remoteLanIPv6Field.Optional, "remote_lan_ipv6_ip should be optional")
+	assert.True(t, remoteLanIPv6Field.Computed, "remote_lan_ipv6_ip should be computed")
+	assert.True(t, remoteLanIPv6Field.ForceNew, "remote_lan_ipv6_ip should be ForceNew")
+	assert.Contains(t, remoteLanIPv6Field.Description, "Remote LAN IPv6 address")
+
+	// Test backup_remote_lan_ipv6_ip field exists and has correct properties
+	backupRemoteLanIPv6Field, ok := schemaMap["backup_remote_lan_ipv6_ip"]
+	assert.True(t, ok, "backup_remote_lan_ipv6_ip field should exist in schema")
+	assert.Equal(t, schema.TypeString, backupRemoteLanIPv6Field.Type)
+	assert.True(t, backupRemoteLanIPv6Field.Optional, "backup_remote_lan_ipv6_ip should be optional")
+	assert.True(t, backupRemoteLanIPv6Field.Computed, "backup_remote_lan_ipv6_ip should be computed")
+	assert.True(t, backupRemoteLanIPv6Field.ForceNew, "backup_remote_lan_ipv6_ip should be ForceNew")
+	assert.Contains(t, backupRemoteLanIPv6Field.Description, "Backup Remote LAN IPv6 address")
+}
+
+func TestSpokeExternalDeviceConnSchema_RemoteLanIPv6FieldsReference(t *testing.T) {
+	// Test that remote_lan_ipv6_ip follows the same pattern as remote_lan_ip
+	resource := resourceAviatrixSpokeExternalDeviceConn()
+	schemaMap := resource.Schema
+
+	remoteLanIPField, ok := schemaMap["remote_lan_ip"]
+	assert.True(t, ok, "remote_lan_ip field should exist for reference")
+
+	remoteLanIPv6Field, ok := schemaMap["remote_lan_ipv6_ip"]
+	assert.True(t, ok, "remote_lan_ipv6_ip field should exist")
+
+	// Both should be TypeString
+	assert.Equal(t, remoteLanIPField.Type, remoteLanIPv6Field.Type, "remote_lan_ipv6_ip should have same type as remote_lan_ip")
+	assert.Equal(t, remoteLanIPField.ForceNew, remoteLanIPv6Field.ForceNew, "remote_lan_ipv6_ip should have same ForceNew as remote_lan_ip")
+
+	// Test backup fields follow same pattern
+	backupRemoteLanIPField, ok := schemaMap["backup_remote_lan_ip"]
+	assert.True(t, ok, "backup_remote_lan_ip field should exist for reference")
+
+	backupRemoteLanIPv6Field, ok := schemaMap["backup_remote_lan_ipv6_ip"]
+	assert.True(t, ok, "backup_remote_lan_ipv6_ip field should exist")
+
+	assert.Equal(t, backupRemoteLanIPField.Type, backupRemoteLanIPv6Field.Type, "backup_remote_lan_ipv6_ip should have same type as backup_remote_lan_ip")
+	assert.Equal(t, backupRemoteLanIPField.ForceNew, backupRemoteLanIPv6Field.ForceNew, "backup_remote_lan_ipv6_ip should have same ForceNew as backup_remote_lan_ip")
 }

--- a/aviatrix/resource_aviatrix_transit_external_device_conn.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn.go
@@ -514,6 +514,13 @@ func resourceAviatrixTransitExternalDeviceConn() *schema.Resource {
 				ForceNew:    true,
 				Description: "Remote LAN IPv6 address.",
 			},
+			"backup_remote_lan_ipv6_ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Backup Remote LAN IPv6 address.",
+			},
 		},
 	}
 }
@@ -558,6 +565,7 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 		ExternalDeviceIPv6:       d.Get("external_device_ipv6").(string),
 		ExternalDeviceBackupIPv6: d.Get("external_device_backup_ipv6").(string),
 		RemoteLanIPv6:            d.Get("remote_lan_ipv6_ip").(string),
+		BackupRemoteLanIPv6:      d.Get("backup_remote_lan_ipv6_ip").(string),
 	}
 
 	sendComm, ok := d.Get("connection_bgp_send_communities").(string)
@@ -703,6 +711,9 @@ func resourceAviatrixTransitExternalDeviceConnCreate(d *schema.ResourceData, met
 		if externalDeviceConn.TunnelProtocol == "LAN" {
 			if externalDeviceConn.BackupRemoteLanIP == "" {
 				return fmt.Errorf("ha is enabled and 'tunnel_protocol' = 'LAN', please specify 'backup_remote_lan_ip'")
+			}
+			if externalDeviceConn.EnableIpv6 && externalDeviceConn.BackupRemoteLanIPv6 == "" {
+				return fmt.Errorf("ha is enabled, 'tunnel_protocol' = 'LAN' and 'enable_ipv6' is true, please specify 'backup_remote_lan_ipv6_ip'")
 			}
 		} else {
 			if externalDeviceConn.BackupRemoteGatewayIP == "" {

--- a/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
+++ b/aviatrix/resource_aviatrix_transit_external_device_conn_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/AviatrixSystems/terraform-provider-aviatrix/v3/goaviatrix"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccAviatrixTransitExternalDeviceConn_basic(t *testing.T) {
@@ -137,6 +139,55 @@ resource "aviatrix_transit_external_device_conn" "test" {
 }
 	`, rName, os.Getenv("AWS_ACCOUNT_NUMBER"), os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY"),
 		rName, os.Getenv("AWS_VPC_ID"), os.Getenv("AWS_REGION"), os.Getenv("AWS_SUBNET"), rName)
+}
+
+func TestTransitExternalDeviceConnSchema_RemoteLanIPv6Fields(t *testing.T) {
+	resource := resourceAviatrixTransitExternalDeviceConn()
+	schemaMap := resource.Schema
+
+	// Test remote_lan_ipv6_ip field exists and has correct properties
+	remoteLanIPv6Field, ok := schemaMap["remote_lan_ipv6_ip"]
+	assert.True(t, ok, "remote_lan_ipv6_ip field should exist in schema")
+	assert.Equal(t, schema.TypeString, remoteLanIPv6Field.Type)
+	assert.True(t, remoteLanIPv6Field.Optional, "remote_lan_ipv6_ip should be optional")
+	assert.True(t, remoteLanIPv6Field.Computed, "remote_lan_ipv6_ip should be computed")
+	assert.True(t, remoteLanIPv6Field.ForceNew, "remote_lan_ipv6_ip should be ForceNew")
+	assert.Contains(t, remoteLanIPv6Field.Description, "Remote LAN IPv6 address")
+
+	// Test backup_remote_lan_ipv6_ip field exists and has correct properties
+	backupRemoteLanIPv6Field, ok := schemaMap["backup_remote_lan_ipv6_ip"]
+	assert.True(t, ok, "backup_remote_lan_ipv6_ip field should exist in schema")
+	assert.Equal(t, schema.TypeString, backupRemoteLanIPv6Field.Type)
+	assert.True(t, backupRemoteLanIPv6Field.Optional, "backup_remote_lan_ipv6_ip should be optional")
+	assert.True(t, backupRemoteLanIPv6Field.Computed, "backup_remote_lan_ipv6_ip should be computed")
+	assert.True(t, backupRemoteLanIPv6Field.ForceNew, "backup_remote_lan_ipv6_ip should be ForceNew")
+	assert.Contains(t, backupRemoteLanIPv6Field.Description, "Backup Remote LAN IPv6 address")
+}
+
+func TestTransitExternalDeviceConnSchema_RemoteLanIPv6FieldsReference(t *testing.T) {
+	// Test that remote_lan_ipv6_ip follows the same pattern as remote_lan_ip
+	resource := resourceAviatrixTransitExternalDeviceConn()
+	schemaMap := resource.Schema
+
+	remoteLanIPField, ok := schemaMap["remote_lan_ip"]
+	assert.True(t, ok, "remote_lan_ip field should exist for reference")
+
+	remoteLanIPv6Field, ok := schemaMap["remote_lan_ipv6_ip"]
+	assert.True(t, ok, "remote_lan_ipv6_ip field should exist")
+
+	// Both should be TypeString
+	assert.Equal(t, remoteLanIPField.Type, remoteLanIPv6Field.Type, "remote_lan_ipv6_ip should have same type as remote_lan_ip")
+	assert.Equal(t, remoteLanIPField.ForceNew, remoteLanIPv6Field.ForceNew, "remote_lan_ipv6_ip should have same ForceNew as remote_lan_ip")
+
+	// Test backup fields follow same pattern
+	backupRemoteLanIPField, ok := schemaMap["backup_remote_lan_ip"]
+	assert.True(t, ok, "backup_remote_lan_ip field should exist for reference")
+
+	backupRemoteLanIPv6Field, ok := schemaMap["backup_remote_lan_ipv6_ip"]
+	assert.True(t, ok, "backup_remote_lan_ipv6_ip field should exist")
+
+	assert.Equal(t, backupRemoteLanIPField.Type, backupRemoteLanIPv6Field.Type, "backup_remote_lan_ipv6_ip should have same type as backup_remote_lan_ip")
+	assert.Equal(t, backupRemoteLanIPField.ForceNew, backupRemoteLanIPv6Field.ForceNew, "backup_remote_lan_ipv6_ip should have same ForceNew as backup_remote_lan_ip")
 }
 
 func testAccTransitExternalDeviceConnConfigBgpBfd(rName string) string {

--- a/docs/resources/aviatrix_edge_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_edge_spoke_external_device_conn.md
@@ -102,6 +102,7 @@ The following arguments are supported:
 * `enable_jumbo_frame` - (Optional) Enable Jumbo Frame for the external device connection. Requires Edge gateway to be jumbo frame enabled. Valid values: true, false. Default value: false.
 * `enable_ipv6` - (Optional) Enable IPv6 prefix learning for edge gateway.
 * `remote_lan_ipv6_ip` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for BGP over LAN. Only valid if gateway is IPv6 enabled.
+* `backup_remote_lan_ipv6_ip` - (Optional) Backup Remote LAN IPv6 address. Must be set when `enable_ipv6` is true and HA is enabled for BGP over LAN.
 
 ## Import
 

--- a/docs/resources/aviatrix_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_spoke_external_device_conn.md
@@ -238,7 +238,7 @@ The following arguments are supported:
 * `external_device_ipv6` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor. Only valid if gateway is IPv6 enabled.
 * `external_device_backup_ipv6` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for HA gateway. Only valid if gateway is IPv6 enabled.
 * `remote_lan_ipv6_ip` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for BGP over LAN. Only valid if gateway is IPv6 enabled.
-* `backup_remote_lan_ipv6_ip` - (Optional) Backup Remote LAN IPv6 address. Required for IPv6 Enabled HA BGP over LAN connection.
+* `backup_remote_lan_ipv6_ip` - (Optional) Backup Remote LAN IPv6 address. Must be set when `enable_ipv6` is true and HA is enabled for BGP over LAN.
 
 -> **NOTE:** If you are using/upgraded to Aviatrix Terraform Provider R3.1.0+, and a **spoke_external_device_conn** resource was originally created with a provider version <R3.1.0 with "private_ip" for `phase1_local_identifier`, you must paste "phase1_local_identifier = 'private_ip'" into the corresponding **spoke_external_device_conn** resource to avoid ‘terraform plan‘ from showing delta.
 

--- a/docs/resources/aviatrix_spoke_external_device_conn.md
+++ b/docs/resources/aviatrix_spoke_external_device_conn.md
@@ -238,7 +238,7 @@ The following arguments are supported:
 * `external_device_ipv6` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor. Only valid if gateway is IPv6 enabled.
 * `external_device_backup_ipv6` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for HA gateway. Only valid if gateway is IPv6 enabled.
 * `remote_lan_ipv6_ip` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for BGP over LAN. Only valid if gateway is IPv6 enabled.
-
+* `backup_remote_lan_ipv6_ip` - (Optional) Backup Remote LAN IPv6 address. Required for IPv6 Enabled HA BGP over LAN connection.
 
 -> **NOTE:** If you are using/upgraded to Aviatrix Terraform Provider R3.1.0+, and a **spoke_external_device_conn** resource was originally created with a provider version <R3.1.0 with "private_ip" for `phase1_local_identifier`, you must paste "phase1_local_identifier = 'private_ip'" into the corresponding **spoke_external_device_conn** resource to avoid ‘terraform plan‘ from showing delta.
 

--- a/docs/resources/aviatrix_transit_external_device_conn.md
+++ b/docs/resources/aviatrix_transit_external_device_conn.md
@@ -248,6 +248,7 @@ The following arguments are supported:
 * `external_device_ipv6` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor. Only valid if gateway is IPv6 enabled.
 * `external_device_backup_ipv6` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for HA gateway. Only valid if gateway is IPv6 enabled.
 * `remote_lan_ipv6_ip` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for BGP over LAN. Only valid if gateway is IPv6 enabled.
+* `backup_remote_lan_ipv6_ip` - (Optional) Backup Remote LAN IPv6 address. Required for IPv6 Enabled HA BGP over LAN connection.
 
 -> **NOTE:** If you are using/upgraded to Aviatrix Terraform Provider R3.1.0+, and a **transit_external_device_conn** resource was originally created with a provider version <R3.1.0 with "private_ip" for `phase1_local_identifier`, you must paste "phase1_local_identifier = 'private_ip'" into the corresponding **transit_external_device_conn** resource to avoid ‘terraform plan‘ from showing delta.
 

--- a/docs/resources/aviatrix_transit_external_device_conn.md
+++ b/docs/resources/aviatrix_transit_external_device_conn.md
@@ -248,7 +248,7 @@ The following arguments are supported:
 * `external_device_ipv6` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor. Only valid if gateway is IPv6 enabled.
 * `external_device_backup_ipv6` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for HA gateway. Only valid if gateway is IPv6 enabled.
 * `remote_lan_ipv6_ip` - (Optional) Enable IPv6 prefix learning over IPv6 neighbor for BGP over LAN. Only valid if gateway is IPv6 enabled.
-* `backup_remote_lan_ipv6_ip` - (Optional) Backup Remote LAN IPv6 address. Required for IPv6 Enabled HA BGP over LAN connection.
+* `backup_remote_lan_ipv6_ip` - (Optional) Backup Remote LAN IPv6 address. Must be set when `enable_ipv6` is true and HA is enabled for BGP over LAN.
 
 -> **NOTE:** If you are using/upgraded to Aviatrix Terraform Provider R3.1.0+, and a **transit_external_device_conn** resource was originally created with a provider version <R3.1.0 with "private_ip" for `phase1_local_identifier`, you must paste "phase1_local_identifier = 'private_ip'" into the corresponding **transit_external_device_conn** resource to avoid ‘terraform plan‘ from showing delta.
 

--- a/goaviatrix/edge_external_device_conn.go
+++ b/goaviatrix/edge_external_device_conn.go
@@ -69,6 +69,7 @@ type EdgeExternalDeviceConn struct {
 	ExternalDeviceIPv6       string `form:"external_device_ipv6,omitempty"`
 	ExternalDeviceBackupIPv6 string `form:"external_device_backup_ipv6,omitempty"`
 	RemoteLanIPv6            string `form:"remote_lan_ipv6_ip,omitempty"`
+	BackupRemoteLanIPv6      string `form:"backup_remote_lan_ipv6_ip,omitempty"`
 }
 
 func (c *Client) CreateEdgeExternalDeviceConn(edgeExternalDeviceConn *EdgeExternalDeviceConn) (string, error) {

--- a/goaviatrix/transit_external_device_conn.go
+++ b/goaviatrix/transit_external_device_conn.go
@@ -102,6 +102,7 @@ type ExternalDeviceConn struct {
 	ExternalDeviceIPv6       string `form:"external_device_ipv6,omitempty"`
 	ExternalDeviceBackupIPv6 string `form:"external_device_backup_ipv6,omitempty"`
 	RemoteLanIPv6            string `form:"remote_lan_ipv6_ip,omitempty"`
+	BackupRemoteLanIPv6      string `form:"backup_remote_lan_ipv6_ip,omitempty"`
 }
 
 type EditExternalDeviceConnDetail struct {
@@ -158,6 +159,7 @@ type EditExternalDeviceConnDetail struct {
 	ExternalLocalIPv6          string         `json:"bgp_local_ipv6,omitempty"`
 	ExternalBackupLocalIPv6    string         `json:"bgp_backup_local_ipv6,omitempty"`
 	RemoteLanIPv6              string         `json:"remote_lan_ipv6_ip,omitempty"`
+	BackupRemoteLanIPv6        string         `json:"backup_remote_lan_ipv6_ip,omitempty"`
 }
 
 type BgpBfdConfig struct {
@@ -722,6 +724,9 @@ func populateIPv6ConnectionInfo(externalDeviceConn *ExternalDeviceConn, external
 	}
 	if externalDeviceConn.TunnelProtocol == "LAN" {
 		externalDeviceConn.RemoteLanIPv6 = externalDeviceConnDetail.RemoteLanIPv6
+		if externalDeviceConnDetail.HAEnabled == "enabled" {
+			externalDeviceConn.BackupRemoteLanIPv6 = externalDeviceConnDetail.BackupRemoteLanIPv6
+		}
 	} else {
 		// for ipsec and gre tunnels
 		externalDeviceConn.ExternalDeviceIPv6 = externalDeviceConnDetail.ExternalDeviceIPv6


### PR DESCRIPTION
AVX-71380 Added backup_remote_lan_ipv6_ip for BGP over LAN

This pull request adds support for specifying a backup remote LAN IPv6 address in the Aviatrix external device connection resources for Edge, Spoke, and Transit gateways. It introduces the new `backup_remote_lan_ipv6_ip` field, updates resource logic to validate its presence and requirements based on HA and IPv6 settings, and enhances the test coverage and documentation to reflect these changes.

### Schema and Resource Enhancements

* Added a new `backup_remote_lan_ipv6_ip` field to the schemas for `aviatrix_edge_spoke_external_device_conn`, `aviatrix_spoke_external_device_conn`, and `aviatrix_transit_external_device_conn` resources, allowing users to specify a backup IPv6 address for remote LAN in HA configurations. [[1]](diffhunk://#diff-dd9599659ea42319b89e32b30abe0159a3d0d616e7bea1e12ea67606c2ec37bfR247-R253) [[2]](diffhunk://#diff-ef00fda2354446a31b86262d64fa3d5b58c6478499389bc1904613bb596309aeR477-R483) [[3]](diffhunk://#diff-7d52fad139fed8e473e0cc7467a4f5d5157d3f867e2cfa95e528ee6c152511f0R517-R523)
* Updated the resource creation logic to require `backup_remote_lan_ipv6_ip` when both HA and IPv6 are enabled, and to validate that this field is empty when HA or IPv6 is disabled. [[1]](diffhunk://#diff-dd9599659ea42319b89e32b30abe0159a3d0d616e7bea1e12ea67606c2ec37bfR345-R364) [[2]](diffhunk://#diff-ef00fda2354446a31b86262d64fa3d5b58c6478499389bc1904613bb596309aeR661-R663) [[3]](diffhunk://#diff-7d52fad139fed8e473e0cc7467a4f5d5157d3f867e2cfa95e528ee6c152511f0R715-R717)

### Model and Marshalling Updates

* Extended the `EdgeExternalDeviceConn` struct and resource input marshalling to include the new `BackupRemoteLanIPv6` field, ensuring the value is properly handled in API calls and resource state. [[1]](diffhunk://#diff-e9a894e9419af56463de7eb2df8581145b2439f71b6f4bf26529d81a621134f8R72) [[2]](diffhunk://#diff-dd9599659ea42319b89e32b30abe0159a3d0d616e7bea1e12ea67606c2ec37bfR277) [[3]](diffhunk://#diff-ef00fda2354446a31b86262d64fa3d5b58c6478499389bc1904613bb596309aeR526) [[4]](diffhunk://#diff-7d52fad139fed8e473e0cc7467a4f5d5157d3f867e2cfa95e528ee6c152511f0R568)

### State Management

* Modified resource read logic to set the `backup_remote_lan_ipv6_ip` field in state only when IPv6 is enabled, maintaining consistency in state representation. [[1]](diffhunk://#diff-dd9599659ea42319b89e32b30abe0159a3d0d616e7bea1e12ea67606c2ec37bfR537-R539) [[2]](diffhunk://#diff-dd9599659ea42319b89e32b30abe0159a3d0d616e7bea1e12ea67606c2ec37bfR574-R576)

### Testing Improvements

* Added comprehensive schema tests for the new and related IPv6 fields in all three resource types, verifying field existence, properties, and consistency with their IPv4 counterparts. [[1]](diffhunk://#diff-7c708299b46ce81429c25a5616159a6b55b6ac60a683d41d40da87cfee5614faR207-R255) [[2]](diffhunk://#diff-2311e520ab3450232d9d21631c4b57aa88ff9cf703733f2c900e392417cd6123R166-R214) [[3]](diffhunk://#diff-e2db4662dd41b7bfda5799975563183adb3a17ba2e5d827b2899f0808ea5e942R144-R192)

### Documentation Updates

* Updated resource documentation to describe the new `backup_remote_lan_ipv6_ip` argument and its requirements, improving user guidance for HA IPv6 configurations. [[1]](diffhunk://#diff-0e6dc4aa0b698ccea6d2e320e2dc35eef1738fc94ab7738fd2574f2527f33384L241-R241) [[2]](diffhunk://#diff-a5916c38397b8aa0909be715b67e3b6428f90bd0a050b690bd1d44e87cc17511R251)