### PR TITLE
AVX-67564: REVERT fix tag state persistence for gw launch (#2378)

### DIFF
--- a/aviatrix/resource_aviatrix_gateway.go
+++ b/aviatrix/resource_aviatrix_gateway.go
@@ -1473,9 +1473,11 @@ func resourceAviatrixGatewayRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("insane_mode_az", "")
 	}
 
-	err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
-	if err != nil {
-		return fmt.Errorf("failed to set tags for gateway %s: %w", gw.GwName, err)
+	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
+		tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
+		if err := d.Set("tags", tags); err != nil {
+			log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
+		}
 	}
 
 	if gw.VpnStatus == "enabled" && gw.SplitTunnel == "yes" {

--- a/aviatrix/resource_aviatrix_spoke_gateway.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway.go
@@ -1815,9 +1815,11 @@ func resourceAviatrixSpokeGatewayRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("setting 'monitor_exclude_list' to state: %w", err)
 	}
 
-	err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
-	if err != nil {
-		return fmt.Errorf("failed to set tags for spoke gateway %s: %w", gw.GwName, err)
+	if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
+		tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
+		if err := d.Set("tags", tags); err != nil {
+			log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
+		}
 	}
 
 	var spokeBgpManualAdvertiseCidrs []string

--- a/aviatrix/resource_aviatrix_transit_gateway.go
+++ b/aviatrix/resource_aviatrix_transit_gateway.go
@@ -2423,9 +2423,11 @@ func resourceAviatrixTransitGatewayRead(d *schema.ResourceData, meta interface{}
 		}
 		d.Set("lan_interface_cidr", lanCidr)
 
-		err = setGatewayTags(d, client, gw.CloudType, ignoreTagsConfig)
-		if err != nil {
-			return fmt.Errorf("failed to set tags for transit gateway %s: %w", gw.GwName, err)
+		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.AWSRelatedCloudTypes|goaviatrix.AzureArmRelatedCloudTypes) {
+			tags := goaviatrix.KeyValueTags(gw.Tags).IgnoreConfig(ignoreTagsConfig)
+			if err := d.Set("tags", tags); err != nil {
+				log.Printf("[WARN] Error setting tags for (%s): %s", d.Id(), err)
+			}
 		}
 
 		if goaviatrix.IsCloudType(gw.CloudType, goaviatrix.OCIRelatedCloudTypes) {


### PR DESCRIPTION
This reverts commit 6559145e16bf496406304d1c36d144e900fec314.

While the change was fine it turned out the actual issue was on the controller side and this change causes a noticeable performance degradation due to hitting CSP API. Previously when this worked with proper controller behavior it was reading cached values in the DB so the performance was much better. Will be fixing the root issue on controller API side which will make the original code in TF side work properly again.

Validated revert + controller fix manually.